### PR TITLE
typo fixing (neue Rechtschreibung)

### DIFF
--- a/Lecture-Notes/antlr.tex
+++ b/Lecture-Notes/antlr.tex
@@ -81,13 +81,13 @@ Diese Grammatik lässt sich nun mit Hilfe von \textsc{Antlr} wie in Abbildung
       \textsl{expr}.  Zu beachten ist hier, dass die Terminale ``\texttt{+}'' und
       ``\texttt{-}'' bei \textsc{Antlr} in einfache Anführungszeichen gesetzt werden
       müssen.  Zusätzlich sehen wir, dass die
-      verschiedenen Grammatikregeln, welche die selbe syntaktische
+      verschiedenen Grammatikregeln, welche dieselbe syntaktische
       Variable definieren, durch das Zeichen ``\texttt{|}'' von einander getrennt werden.
 \item Entsprechend enthalten die Zeilen 10 und 14 die Grammatik-Regeln für die syntaktischen
       Variablen \textsl{product} und \textsl{factor}.  
 
 \item Bei \textsc{Antlr} werden die grammatikalische Struktur und die lexikalische
-      Struktur der Eingabe in der selben Datei definiert.  Um syntaktische Variablen und
+      Struktur der Eingabe in derselben Datei definiert.  Um syntaktische Variablen und
       Terminale von einander unterscheiden zu können, wird vereinbart, dass Terminale mit
       einem Großbuchstaben beginnen,\footnote
       {Es ist Konvention, aber nicht vorgeschrieben, dass die 
@@ -396,7 +396,7 @@ Interpreters mit \textsc{Antlr}.
       der Parser die entsprechende Grammatik-Regel anwendet.  Die Aktionen werden von der
       eigentlichen Grammatik-Regel, für die sie angewendet werden sollen, dadurch
       abgesetzt, dass sie in den geschweiften Klammern ``\texttt{\{}'' und ``\texttt{\}}''
-      eingefaßt werden.
+      eingefasst werden.
 \item Wird vom Parser in Zeile 13 eine Zuweisung der Form $\textsl{var} \;\mathtt{:=}\; \textsl{expr}$
       erkannt,  
       so soll der Wert des Ausdrucks \textsl{expr} berechnet und das Ergebnis in der
@@ -627,7 +627,7 @@ aus Abbildung \ref{fig:Expr-exp-ln}.
 \item Die weiteren Grammatik-Regeln erzeugen in analoger Weise \textsl{Java}-Objekte.
 \end{enumerate}
 
-Zum Abschluß zeigt Abbildung \ref{fig:Differentiate.java} noch die Einbindung des Parsers.
+Zum Abschluss zeigt Abbildung \ref{fig:Differentiate.java} noch die Einbindung des Parsers.
 Gegenüber dem in Abbildung \ref{fig:ParseExpr.java} gezeigten Treiber gibt es nur einen
 wesentlichen Unterschied: In Zeile 20 wird nun ein Objekt der Klasse \texttt{Expr} erzeugt.
 Beachten Sie, dass der Aufruf

--- a/Lecture-Notes/compiler-2.tex
+++ b/Lecture-Notes/compiler-2.tex
@@ -845,7 +845,7 @@ Die Idee wird in der in Abbildung \ref{fig:Statement:Assign.java} gezeigten Klas
 
 \subsubsection{Übersetzung von Ausdrücken als Befehlen}
 Die Übersetzung eines Ausdrucks, der als Befehl verwendet wird, birgt eine Tücke:
-Die Übersetzung des Ausdrucks selber hinterläßt auf dem Stack einen Wert.  Dieser muss aber bei
+Die Übersetzung des Ausdrucks selber hinterlässt auf dem Stack einen Wert.  Dieser muss aber bei
 Beendigung des Befehls vom Stack entfernt werden!  Daher müssen wir den Befehl \texttt{pop} an das
 Ende der Liste der Assembler-Befehle anfügen, die bei der Übersetzung des Ausdrucks erzeugt werden.
 Die Übersetzung eines  Befehls vom Typ \texttt{ExprStatement} wird also

--- a/Lecture-Notes/cup.tex
+++ b/Lecture-Notes/cup.tex
@@ -124,7 +124,7 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
             übergeben wird.
       \end{enumerate}
 \item In den Zeilen 7 und 8 werden die syntaktischen Variablen, die wir auch als Nicht-Terminale
-      bezeichnen, deklariert.  Die Syntax ist die selbe wie bei der Deklaration der Terminale, nur
+      bezeichnen, deklariert.  Die Syntax ist dieselbe wie bei der Deklaration der Terminale, nur
       dass wir jetzt das Schlüsselwort ``\texttt{nonterminal}'' an Stelle von ``\texttt{terminal}''
       verwenden.  Auch hier gibt es wieder zwei Fälle:  Den in Zeile 7 deklarierten Nicht-Terminalen
       \texttt{expr\_list} und \texttt{expr\_part} wird kein Wert zugeordnet, während wir dem
@@ -184,7 +184,7 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
             nicht ganz so gut lesbar wie \textsc{Antlr}-Grammatiken.
             Der Grund dafür ist, dass bei  \textsc{Cup} zum Scannen ein separates
             Werkzeug, nämlich \textsl{JFlex}, zum Scannen verwendet wird.  Demgegenüber
-            wird bei \textsc{Antlr} der Scanner zusammen mit dem Parser in der selben
+            wird bei \textsc{Antlr} der Scanner zusammen mit dem Parser in derselben
             Datei spezifiziert und das Werkzeug \textsc{Antlr} erzeugt aus dieser Datei
             sowohl einen Parser als auch einen Scanner.
       \end{enumerate}
@@ -888,7 +888,7 @@ der Datei, die für die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Gramm
       $E \rightarrow E \quoted{*} E \bullet$, 
       \\[0.2cm]
       denn die erste Regel verlangt nach einem Shift, während die zweite Regel eine Reduktion fordert.
-      Da die Regel $E \rightarrow E \quoted{*} E$ die selbe Präzedenz wie der Operator ``\texttt{*}''
+      Da die Regel $E \rightarrow E \quoted{*} E$ dieselbe Präzedenz wie der Operator ``\texttt{*}''
       und dieser eine höhere Präzedenz als $\quoted{+}$ hat, wird beispielsweise beim Lesen des Zeichens
       ``\texttt{+}'' mit der Regel $E \rightarrow E \quoted{*} E$ reduziert.
       Wird hingegen das Zeichen ``\texttt{\^}'' gelesen, so wird dieses geshiftet, denn
@@ -943,7 +943,7 @@ der Datei, die für die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Gramm
       $E \rightarrow E \quoted{\symbol{94}} E  \bullet$,
       \\[0.2cm]
       wenn das nächste Token der Operator ``\texttt{\symbol{94}}'' ist.  Da der Operator 
-      die selbe Präzedenz 
+      dieselbe Präzedenz 
       hat wie die Regel, entscheidet die Assoziativität.  Nun ist der Operator
       ``\texttt{\symbol{94}}'' rechts-assoziativ, daher wird in diesem Fall geshiftet.
 
@@ -979,7 +979,7 @@ der Datei, die für die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Gramm
     \label{fig:state18}
   \end{figure}
 
-      Hier gibt es noch viele andere Shift/Reduce-Konflikte, die aber alle die selbe Struktur haben.
+      Hier gibt es noch viele andere Shift/Reduce-Konflikte, die aber alle dieselbe Struktur haben.
       Exemplarisch betrachten wir den Shift/Reduce-Konflikt zwischen den Regeln
       \\[0.2cm]
       \hspace*{1.3cm}

--- a/Lecture-Notes/earley-parser.tex
+++ b/Lecture-Notes/earley-parser.tex
@@ -27,7 +27,7 @@ Dieses Kapitel gliedert sich in die folgenden Abschnitte.
 \item Zunächst skizzieren wir die Theorie, die Earley's Algorithmus zu Grunde liegt.
 \item Danach geben wir eine einfache Implementierung des Algorithmus in \textsc{SetlX} an.
 \item Anschließend beweisen wir die Korrektheit und Vollständigkeit des Algorithmus.
-\item Zum Abschluß des Kapitels untersuchen wir die Komplexität.
+\item Zum Abschluss des Kapitels untersuchen wir die Komplexität.
 \end{enumerate}
 
 \section{Der Algorithmus von Earley}
@@ -178,7 +178,7 @@ Grammatik ist also durch
 \\[0.2cm]
 gegeben.
 Wie zeigen, wie sich der String
-``\texttt{1+2*3}'' mit dieser Grammatik und dem Algorithmus von Earley parsen läßt.
+``\texttt{1+2*3}'' mit dieser Grammatik und dem Algorithmus von Earley parsen lässt.
 In der folgenden Darstellung werden wir die syntaktische Variable \texttt{expr} mit
 dem Buchstaben $E$ abkürzen, für \texttt{prod} schreiben wir $P$ und für \texttt{fact} verwenden wir die
 Abkürzung $F$.
@@ -988,7 +988,7 @@ In diesem Kapitel beweisen wir zwei Eigenschaften des von Earley angegebenen Alg
 Zunächst zeigen wir, dass immer dann, wenn wir den Algorithmus auf einen String $s = x_1 x_2 \cdots x_n$
 anwenden und nach Beendigung des Algorithmus das Earley-Objekt 
 $\pair(\widehat{S} \rightarrow S \,\bullet, 0)$ in der Menge $Q_n$ enthalten ist, wir
-schließen können, dass der String $s$ sich von dem Start-Symbol $S$ ableiten läßt.
+schließen können, dass der String $s$ sich von dem Start-Symbol $S$ ableiten lässt.
 Diese Eigenschaft
 bezeichnen wir als die Korrektheit des Algorithmus.  Außerdem beweisen wir, dass auch die
 Umkehrung gilt:  Falls der String $s$ in der von der Variablen $S$ erzeugten Sprache
@@ -1268,7 +1268,7 @@ $k:= 0$ und $l:= n$ setzen.
 
 \section{Analyse der Komplexität}
 Wir zeigen, dass sich die Anzahl der Schritte, die der Algorithmus von Earley bei einem String der
-Länge $n$ durch $\mathcal{O}(n^3)$ nach oben abschätzen läßt.  Falls die Grammatik eindeutig ist,
+Länge $n$ durch $\mathcal{O}(n^3)$ nach oben abschätzen lässt.  Falls die Grammatik eindeutig ist,
 wenn es also zu jedem String nur einen Parse-Baum gibt, kann dies zu $\mathcal{O}(n^2)$ verbessert
 werden.  
 Zusätzlich hat Jay Earley in seiner Doktorarbeit \cite{earley:68} gezeigt, dass der
@@ -1334,7 +1334,7 @@ die bei den einzelnen Operationen durchgeführt werden.
 \end{enumerate}
 Da die einzelnen Operationen für alle Mengen $Q_i$ für $i = 0, \cdots, n$ durchgeführt
 werden müssen, hat der Algorithmus insgesamt die Komplexität $\mathcal{O}(n^3)$.  Damit
-diese Komplexität auch tatsächlich erreicht wird, müßten wir die Implementierung der Methoden so umändern,
+diese Komplexität auch tatsächlich erreicht wird, müssten wir die Implementierung der Methoden so umändern,
 dass kein Element der Menge $Q_i$ mehrfach betrachtet wird.  Da eine solche
 Implementierung schwerer zu verstehen wäre, haben wir uns aus didaktischen Gründen
 mit einer ineffizienteren Implementierung begnügt.
@@ -1358,7 +1358,7 @@ eindeutig ist.  Bei der Verwendung eines Earley-Parser-Generators können solche 
 erst zur Laufzeit des erzeugten Parsers bemerkt werden.  Bei Systemen wie \textsl{Antlr}
 oder \textsl{Bison}, die mit einer eingeschränkteren Klasse von Grammatiken arbeiten,
 tritt dieses Problem nicht auf, denn die Grammatiken, für die sich mit einem solchen
-System ein Parser erzeugen läßt, sind nach Konstruktion eindeutig.  Ist also eine
+System ein Parser erzeugen lässt, sind nach Konstruktion eindeutig.  Ist also eine
 Grammatik aufgrund eines Design-Fehlers nicht eindeutig, so liegt Sie erst recht nicht in
 der eingeschränkten Klasse von LR(1)-Grammatiken, die sich beispielsweise mit
 \textsl{Bison} bearbeiten lassen und der Fehler wird bereits bei der Erstellung des

--- a/Lecture-Notes/entscheidbarkeit-kontextfrei.tex
+++ b/Lecture-Notes/entscheidbarkeit-kontextfrei.tex
@@ -6,7 +6,7 @@ und ein Wort $w$ die Frage, ob
 $S \Rightarrow_G^* w$
 \\[0.2cm]
 gilt, entscheidbar ist.   Wir werden einen konkreten Algorithmus angeben, mit dem sich
-diese Frage für ein gegebenes Wort $w$ beantworten läßt. 
+diese Frage für ein gegebenes Wort $w$ beantworten lässt. 
 
 %%% Local Variables: 
 %%% mode: latex

--- a/Lecture-Notes/finite-state-machines.tex
+++ b/Lecture-Notes/finite-state-machines.tex
@@ -189,7 +189,7 @@ $\delta: Q \times \Sigma \rightarrow Q$.
 
 \begin{Satz}
   Zu jedem endlichen deterministischen Automaten $A$ gibt es einen vollständigen deterministischen 
-  Automaten $\hat{A}$, der die selbe Sprache akzeptiert wie der Automat $A$, es gilt also:
+  Automaten $\hat{A}$, der dieselbe Sprache akzeptiert wie der Automat $A$, es gilt also:
   \\[0.2cm]
   \hspace*{1.3cm}
   $L(\hat{A}) = L(A)$.
@@ -245,7 +245,7 @@ Damit können wir den Automaten $\hat{A}$ angeben:
 $\hat{A} = \langle \hat{Q}, \Sigma, \hat{\delta}, q_0, F \rangle$.
 \\[0.2cm]
 Falls nun der Automat $A$  einen String $s$ einliest und dabei nicht stirbt, so ist das 
-Verhalten von $A$ und $\hat{A}$ identisch, es werden in beiden Automaten die selben Zustände
+Verhalten von $A$ und $\hat{A}$ identisch, es werden in beiden Automaten dieselben Zustände
 durchlaufen.   Falls der Automat $A$ stirbt, dann geht der Automat $\hat{A}$ ersatzweise in den
 Zustand $\dag$ und bleibt bei allen folgenden Eingaben in diesem Zustand.  Damit ist klar,
 dass die von $A$ und $\hat{A}$ akzeptierten Sprachen identisch sind. \qed
@@ -409,7 +409,7 @@ hellseherische Fähigkeiten haben, um den richtigen Übergang raten zu können.  Wi
 allerdings im nächsten Abschnitt sehen, dass die beiden Konzepte bei der Erkennung von
 Sprachen die gleiche Mächtigkeit haben.  Dazu formalisieren wir den Begriff des
 nicht-deterministischen endlichen Automaten.  Die Definition,
-die nun folgt, ist noch etwas weiter gefaßt als in der informalen Erklärung, die wir
+die nun folgt, ist noch etwas weiter gefasst als in der informalen Erklärung, die wir
 bisher gegeben haben, denn wir erlauben dem Automaten zusätzlich \emph{spontane
 Übergänge}, sogenannte \emph{$\varepsilon$-Transitionen}:  Darunter verstehen wir einen
 Zustands-Übergang, bei dem kein Zeichen der Eingabe gelesen wird.  Wir schreiben einen
@@ -515,7 +515,7 @@ Weiter haben wir
 \hspace*{1.3cm}
 $\langle q_1, s \rangle \leadsto \langle q_2, s \rangle$ \quad falls \quad $q_1 \stackrel{\varepsilon}{\mapsto} q_2$.
 \\[0.2cm]
-Hier werden die $\varepsilon$-Transitionen erfaßt.
+Hier werden die $\varepsilon$-Transitionen erfasst.
 
 Wir beichnen den transitiven Abschluss der Relation $\leadsto$ mit $\leadsto^*$.
 Die von einem nicht-deterministischen endlichem Automaten $A$ akzeptierte Sprache $L(A)$
@@ -559,7 +559,7 @@ In diesem Abschnitt zeigen wir, wie sich ein nicht-deterministischer endlicher A
 \hspace*{1.3cm}
 $A = \langle Q, \Sigma, \delta, q_0, F \rangle$ 
 \\[0.2cm]
-so in einen deterministischen endlichen Automaten $\textsl{det}(A)$ übersetzen läßt, dass die von beiden
+so in einen deterministischen endlichen Automaten $\textsl{det}(A)$ übersetzen lässt, dass die von beiden
 Automaten erkannte Sprache gleich ist, dass also 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -801,7 +801,7 @@ Zustand $q_3$ enthalten.  Also setzen wir
 \hspace*{1.3cm}
 $\widehat{F} := \{ S_3, S_5, S_6, S_7 \}$.
 \\[0.2cm]
-Damit können wir nun einen deterministischen endlichen Automaten $\textsl{det}(A)$ angeben, der die selbe 
+Damit können wir nun einen deterministischen endlichen Automaten $\textsl{det}(A)$ angeben, der dieselbe 
 Sprache akzeptiert wie der nicht-deterministische Automat $A$:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1697,7 +1697,7 @@ expression $r$.  Altogether, there are six different cases.
 
 \section{Übersetzung eines \textsc{EA} in einen regulären Ausdruck}
 Wir runden die Theorie ab indem wir zeigen, dass sich zu jedem deterministischen endlichen
-Automaten $A$ ein regulärer Ausdruck $r(A)$ angeben läßt, der die selbe Sprache spezifiziert,
+Automaten $A$ ein regulärer Ausdruck $r(A)$ angeben lässt, der dieselbe Sprache spezifiziert,
 die von dem Automaten $A$ akzeptiert wird, für den also
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1906,7 +1906,7 @@ Damit sehen wir jetzt, dass die Konzepte ``\emph{deterministischer endlicher Aut
       Ausdruck übersetzt werden.
 \item Jeder reguläre Ausdruck kann in einen äquivalenten nicht-deterministischen endlichen Automaten
       transformiert werden.
-\item Ein nicht-deterministischer endlicher Automat läßt sich durch die
+\item Ein nicht-deterministischer endlicher Automat lässt sich durch die
       Teilmengen-Konstruktion in einen endlichen Automaten überführen.
 \end{enumerate}
 
@@ -2037,7 +2037,7 @@ $r(A) = r^{(2)}(0, 1) = \texttt{a}^* \cdot \texttt{b} \cdot \texttt{a}^*$.
 Dieses Ergebnis, das wir mühevoll abgeleitet haben, hätten wir auch durch einen einfachen
 Blick auf den Automaten erhalten können, aber die oben gezeigte Rechnung formalisiert das,
 was der geübte Betrachter unmittelbar erkennt und der beschriebene Algorithmus hat den
-Vorteil, dass er sich implementieren läßt.
+Vorteil, dass er sich implementieren lässt.
 \qed
 
 \subsection{Implementing the Conversion of \textsc{FSM}s into Regular Expressions}

--- a/Lecture-Notes/grenzen-kontextfrei-save.tex
+++ b/Lecture-Notes/grenzen-kontextfrei-save.tex
@@ -65,7 +65,7 @@ ist eine \emph{erzeugende} Variable, wenn es ein Wort $w \in T^*$ gibt, so dass
 \hspace*{1.3cm}
 $A \Rightarrow^* w$
 \\[0.2cm]
-gilt, aus einer erzeugende Variable läßt sich also immer mindestens ein Wort aus $T^*$ herleiten. 
+gilt, aus einer erzeugende Variable lässt sich also immer mindestens ein Wort aus $T^*$ herleiten. 
 Die Notation $A \Rightarrow^* w$ drückt aus, dass das Wort $w$ aus der Variablen $A$ in endlich vielen
 Schritten abgeleitet werden kann.
 \qed 
@@ -138,7 +138,7 @@ Formal definieren wir für eine Grammatik $G = \langle V, T, R, S \rangle$ eine s
 \hspace*{1.3cm}
 $S \Rightarrow^* \alpha X \beta$
 \\[0.2cm]
-gilt. Für eine gegebene Grammatik $G$  läßt sich die Menge der Variablen, die erreichbar
+gilt. Für eine gegebene Grammatik $G$  lässt sich die Menge der Variablen, die erreichbar
 sind, mit dem folgenden 
 induktiven Algorithmus berechnen.
 \begin{enumerate}
@@ -209,7 +209,7 @@ können wir eine Grammatik $G_2$ finden, welche keine Regeln der Form
 \hspace*{1.3cm}
 $A \rightarrow \varepsilon$
 \\[0.2cm]
-enthält und welche die selbe Sprache beschreibt wie die Grammatik $G_1$, es gilt also $L(G_1) = L(G_2)$. 
+enthält und welche dieselbe Sprache beschreibt wie die Grammatik $G_1$, es gilt also $L(G_1) = L(G_2)$. 
 Regeln  der Form $A \rightarrow \varepsilon$ bezeichnen wir als $\varepsilon$-Regeln.  Bei
 bestimmten Algorithmen stören solche $\varepsilon$-Regeln, deswegen wollen wir jetzt ein Verfahren
 entwickeln, mit dem $\varepsilon$-Regeln eliminiert werden können.  
@@ -324,7 +324,7 @@ gegeben, so können wir die Regel $A \rightarrow B$ durch die Regeln
 \hspace*{1.3cm}
 $A \rightarrow \beta_1 \mid \cdots \mid \beta_n$ 
 \\[0.2cm]
-ersetzen und erhalten dabei eine Grammatik, die die selbe Sprache beschreibt.
+ersetzen und erhalten dabei eine Grammatik, die dieselbe Sprache beschreibt.
 
 \example
 Wir betrachten die folgende Grammatik für arithmetische Ausdrücke.
@@ -438,7 +438,7 @@ Bedingungen erfüllt sind:
 \end{Definition}
 
 \noindent
-Mit Hilfe der in diesem Abschnitt vorgeführten Verfahren läßt sich jede Grammatik $G$, deren Sprache
+Mit Hilfe der in diesem Abschnitt vorgeführten Verfahren lässt sich jede Grammatik $G$, deren Sprache
  $L(G)$ das leere Wort $\varepsilon$ nicht enthält,  zu einer äquivalenten
 Grammatik umschreiben, die in verallgemeinerter Chomsky-Normalform ist.
 Dazu führen wir die folgenden Schritte in nachstehender Reihenfolge durch:
@@ -685,7 +685,7 @@ kleiner-gleich  $k+2$ ist.
 \ref{lemma:length} folgt damit für die Länge von $vwx$ die Abschätzung
 \[ |vwx| \leq b^{k+2} = n. \]
 
-Zum Schluß müssen wir noch festlegen, was in dem Fall zu tun ist, wenn $\varepsilon \in L$ ist.  
+Zum Schluss müssen wir noch festlegen, was in dem Fall zu tun ist, wenn $\varepsilon \in L$ ist.  
 Überführen wir dann die Grammatik $G$ in verallgemeinerte Chomsky-Normalform, so erhalten wir eine
 Grammatik $G'$, für die
 \\[0.2cm]
@@ -715,7 +715,7 @@ nicht kontextfrei ist.  Wir führen diesen Nachweis indirekt und nehmen zunächst 
 kontextfrei ist.  Nach dem Pumping-Lemma gibt es dann eine natürliche Zahl $n$, so dass jeder String
 $s \in L$, dessen Länge größer oder gleich $n$ ist, sich in Teilstrings der Form
 \[ s = uvwxy \]
-zerlegen läßt, so dass außerdem folgendes gilt:
+zerlegen lässt, so dass außerdem folgendes gilt:
 \begin{enumerate}
 \item $|vwx| \leq n$,
 \item $vx \not= \varepsilon$,
@@ -773,7 +773,7 @@ möglichen  Fälle getrennt.
       und daraus folgt $uwy \not\in L$, was im Widerspruch zum Pumping-Lemma steht.
 \item Fall: In dem String $vwx$ kommt der Buchstabe \qote{a} nicht vor.
    
-      Dieser Fall läßt sich analog zum ersten Fall behandeln. \qed
+      Dieser Fall lässt sich analog zum ersten Fall behandeln. \qed
 \end{enumerate}
 
 \exercise

--- a/Lecture-Notes/grenzen-kontextfrei.tex
+++ b/Lecture-Notes/grenzen-kontextfrei.tex
@@ -44,7 +44,7 @@ ist eine \emph{erzeugende} Variable, wenn es ein Wort $w \in T^*$ gibt, so dass
 \hspace*{1.3cm}
 $A \Rightarrow^* w$
 \\[0.2cm]
-gilt, aus einer erzeugende Variable läßt sich also immer mindestens ein Wort aus $T^*$ herleiten. 
+gilt, aus einer erzeugende Variable lässt sich also immer mindestens ein Wort aus $T^*$ herleiten. 
 Die Notation $A \Rightarrow^* w$ drückt aus, dass das Wort $w$ aus der Variablen $A$ in endlich vielen
 Schritten abgeleitet werden kann.
 \qed 
@@ -116,7 +116,7 @@ Formal definieren wir für eine Grammatik $G = \langle V, T, R, S \rangle$ eine s
 \hspace*{1.3cm}
 $S \Rightarrow^* \alpha X \beta$
 \\[0.2cm]
-gilt. Für eine gegebene Grammatik $G$  läßt sich die Menge der Variablen, die erreichbar
+gilt. Für eine gegebene Grammatik $G$  lässt sich die Menge der Variablen, die erreichbar
 sind, mit dem folgenden 
 induktiven Algorithmus berechnen.
 \begin{enumerate}
@@ -478,7 +478,7 @@ nicht kontextfrei ist.  Wir führen diesen Nachweis indirekt und nehmen zunächst 
 kontextfrei ist.  Nach dem Pumping-Lemma gibt es dann eine natürliche Zahl $n$, so dass jeder String
 $s \in L$, dessen Länge größer oder gleich $n$ ist, sich in Teilstrings der Form
 \[ s = uvwxy \]
-zerlegen läßt, so dass außerdem folgendes gilt:
+zerlegen lässt, so dass außerdem folgendes gilt:
 \begin{enumerate}
 \item $|vwx| \leq n$,
 \item $vx \not= \varepsilon$,
@@ -536,7 +536,7 @@ möglichen  Fälle getrennt.
       und daraus folgt $uwy \not\in L$, was im Widerspruch zum Pumping-Lemma steht.
 \item Fall: In dem String $vwx$ kommt der Buchstabe \qote{a} nicht vor.
    
-      Dieser Fall läßt sich analog zum ersten Fall behandeln. \qed
+      Dieser Fall lässt sich analog zum ersten Fall behandeln. \qed
 \end{enumerate}
 
 \exercise
@@ -553,7 +553,7 @@ nicht kontextfrei ist.
 Wir führen den Beweis indirekt und nehmen an, dass die Sprache $L_{\mathrm{square}}$ kontextfrei
 wäre.  Nach dem Pumping-Lemma für kontextfreie Sprachen gibt es dann eine positive
 natürliche Zahl $n$, so dass sich jeder String $s \in L_{\mathrm{square}}$ mit $|s| \geq n$ in fünf 
-Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten läßt, so dass gilt:
+Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten lässt, so dass gilt:
 \begin{enumerate}
 \item $s = uvwxy$,
 \item $|vwx| \leq n$,
@@ -639,7 +639,7 @@ nicht kontextfrei ist.
 Wir führen den Beweis indirekt und nehmen an, dass die Sprache $L$ kontextfrei
 wäre.  Nach dem Pumping-Lemma für kontextfreie Sprachen gibt es dann eine positive
 natürliche Zahl $n$, so dass sich jeder String $s \in L$ mit $|s| \geq n$ in fünf 
-Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten läßt, so dass gilt:
+Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten lässt, so dass gilt:
 \begin{enumerate}
 \item $s = uvwxy$,
 \item $|vwx| \leq n$,
@@ -714,7 +714,7 @@ führt und untersuchen dazu die obigen drei Fälle der Reihe nach.
       \hspace*{1.3cm}
       $t't' = a^{n-k_1}b^{n-k_2}a^{n}b^{n}$ \quad für ein $t' \in \Sigma^*$
       \\[0.2cm]
-      hätten, so würde das erste Auftreten von $t'$ in den Teilstring $a^{n}$ hineinragen und müßte folglich
+      hätten, so würde das erste Auftreten von $t'$ in den Teilstring $a^{n}$ hineinragen und müsste folglich
       mit einem $a$ enden.  Das funktioniert aber nicht, denn
       das zweite Auftreten von $t'$ endet mit einem $b$.  Also kann dieser Fall nicht eintreten.
 \item Fall: \quad $vwx \sqsubseteq_{n+1,3\cdot n} a^{n}b^{n}a^{n}b^{n}$,  

--- a/Lecture-Notes/grenzen.tex
+++ b/Lecture-Notes/grenzen.tex
@@ -13,7 +13,7 @@ kann.  Dazu führen wir folgende Definition ein.
 \begin{Definition}[Test-Funktion] {\em Ein String $t$ ist eine \emph{Test-Funktion} mit Namen $n$ wenn $t$ ein
 String der Form \\[0.3cm]
 \hspace*{1.3cm} {\tt int $n$(char* x) \{ $\cdots$ \}} \\[0.3cm]
-ist, der sich als Definition einer $C$-Funktion parsen läßt.  Die Menge der
+ist, der sich als Definition einer $C$-Funktion parsen lässt.  Die Menge der
 Test-Funktionen bezeichnen wir mit $T\!F$.  Ist $t \in T\!F$ und hat den Namen $n$, so
 schreiben wir $\mathtt{name}(t) = n$.} \hspace*{\fill} $\Box$
 \end{Definition}
@@ -33,7 +33,7 @@ schreiben wir $\mathtt{name}(t) = n$.} \hspace*{\fill} $\Box$
       \texttt{C}-Funktion und keine Definition.
 \item $s_4$ = ``{\tt int hugo(char* x) begin i := 1; end;}''
 
-      $s_4$ ist keine Test-Funktion, denn es läßt sich mit einem
+      $s_4$ ist keine Test-Funktion, denn es lässt sich mit einem
       \texttt{C}-Compiler nicht fehlerfrei parsen.
 \item $s_5$ = ``{\tt int hugo(int x) \{ return i*i; \}}''
 
@@ -48,7 +48,7 @@ Ist $n$ der Name einer \texttt{C}-Funktion und sind $a_1$, $\cdots$, $a_k$ Argum
 vom Typ her der Deklaration von $n$ entsprechen, so schreiben wir \\[0.3cm]
 \hspace*{1.3cm} $n(a_1, \cdots, a_k) \leadsto r$ \\[0.3cm]
 wenn der Aufruf $n(a_1, \cdots, a_k)$ das Ergebnis $r$ liefert.  Sind wir an dem Ergebnis
-selbst nicht interessiert, sondern wollen nur angeben, daß ein Ergebnis existiert, so
+selbst nicht interessiert, sondern wollen nur angeben, dass ein Ergebnis existiert, so
 schreiben wir \\[0.3cm]
 \hspace*{1.3cm} $n(a_1, \cdots, a_k) \,\downarrow$ \\[0.3cm]
 und sagen, dass der Aufruf $n(a_1, \cdots, a_k)$ \emph{terminiert}.
@@ -60,7 +60,7 @@ und dagen, dass der Aufruf $n(a_1, \cdots, a_k)$ \emph{divergiert}.
 \end{Definition}
 
 \noindent
-\textbf{Beispiele}: Legen wir die Funktions-Definitionen zugrunde, die wir im Anschluß an
+\textbf{Beispiele}: Legen wir die Funktions-Definitionen zugrunde, die wir im Anschluss an
 die Definition des Begriffs der Test-Funktion gegeben haben, so gilt:
 \begin{enumerate}
 \item {\tt simple(\symbol{34}emil\symbol{34}) $\leadsto 0$}
@@ -196,7 +196,7 @@ Wenn es in dieses Programmier-Sprache Unterprogramme gibt, und wenn wir dort
 Programm-Texte als Argumente von Funktionen übergeben können, dann ist leicht zu sehen,
 dass der obige Beweis der 
 Unlösbarkeit des Halte-Problems sich durch geeignete syntaktische Modifikationen auch auf
-die andere Programmier-Sprache übertragen läßt.
+die andere Programmier-Sprache übertragen lässt.
 \vspace*{0.3cm}
 
 \noindent
@@ -265,7 +265,7 @@ möge folgender Spezifikation genügen:
   \item $p_2 \in T\!F \;\wedge\; \mathtt{name}(p_2) = n_2$ \quad und
   \item $n_1(a) \simeq n_2(a)$
   \end{enumerate}
-    gilt, dann muß gelten: \\[0.1cm]
+    gilt, dann muss gelten: \\[0.1cm]
    \hspace*{1.3cm}  $\mathtt{equal}(p_1, p_2, a) \leadsto 1$.
 \item Ansonsten gilt \\[0.1cm]
       \hspace*{1.3cm} $\mathtt{equal}(p_1, p_2, a) \leadsto 0$.
@@ -321,7 +321,7 @@ folgende Form:
 \end{verbatim}
 Es ist offensichtlich, dass die Funktion \texttt{loop} für kein Ergebnis terminiert.
 Ist also das Argument $p$ eine Test-Funktion mit Namen $n$, so liefert die Funktion \texttt{equal} immer dann den Wert 1,
-wenn $n(a)$ nicht terminiert, andernfalls muß sie den Wert 0 zurück geben.
+wenn $n(a)$ nicht terminiert, andernfalls muss sie den Wert 0 zurück geben.
 Damit liefert die Funktion \texttt{stops} aber für eine Test-Funktion $p$ mit Namen $n$ und ein Argument
 $a$ genau dann 1, wenn der Aufruf $n(a)$ terminiert und würde folglich das Halte-Problem
 lösen.  Das kann nicht sein, also kann es keine Funktion  \texttt{equal}
@@ -343,7 +343,7 @@ Hopfcroft, Motwani und Ullman \cite{hopcroft:06}.
       String $s \in L(G)$ genau einen Parse-Baum für $s$ gibt, unentscheidbar.  Für können
       also nicht entscheiden, ob eine Grammatik mehrdeutig ist.
 \item Für zwei gegeben kontextfreie Grammatiken $G_1$ und $G_2$ ist die Frage, ob
-      diese Grammatiken die selbe Sprache beschreiben, ob also
+      diese Grammatiken dieselbe Sprache beschreiben, ob also
       \\[0.2cm]
       \hspace*{1.3cm}
       $L(G_1) = L(G_2)$
@@ -363,7 +363,7 @@ formulieren wollen.
 
 \begin{Definition}[Post'sche Korrespondenz-Problem]
 Gegen sei ein Alphabet $\Sigma$ sowie zwei Listen $l_1$ und $l_2$ von Strings aus
-$\Sigma^*$, die beide die selbe Länge $n$ haben:
+$\Sigma^*$, die beide dieselbe Länge $n$ haben:
 \\[0.2cm]
 \hspace*{1.3cm}
 $l_1 = [X_1, \cdots, X_n]$ \quad mit $X_i \in \Sigma^*$ für $i=1,\cdots,n$ \quad und
@@ -416,13 +416,13 @@ $\quoted{babbb} + \quoted{b} + \quoted{b} + \quoted{ba} =
 Unentscheidbarkeit des Halte-Problems zurück geführt werden.  Dazu müssen allerdings erst
 \emph{Turing-Maschinen} eingeführt werden sowie eine Notation, um diese  programmieren.  
 Bei den Turing-Maschinen handelt es sich um ein sehr einfaches
-Maschinen-Konzept.  Es läßt sich jdoch zeigen, dass Programme für Turing-Maschinen
+Maschinen-Konzept.  Es lässt sich jdoch zeigen, dass Programme für Turing-Maschinen
 prinzipiell genau so leistungsfähig sind, wie \texttt{C-Programme}:
-Alles das, was wir mit einem \texttt{C}-Programm berechnen können, läßt sich auch mit
+Alles das, was wir mit einem \texttt{C}-Programm berechnen können, lässt sich auch mit
 einer Turing-Maschine berechnen.
 
 Weiter wird dann gezeigt, dass sich die Lösbarkeit des Halte-Problems für Turing-Maschinen
-in ein Post'sches Korrespondenz-Problem übersetzen läßt.  Könnten wir nun das Post'sche
+in ein Post'sches Korrespondenz-Problem übersetzen lässt.  Könnten wir nun das Post'sche
 Korrespondenz-Problem lösen, so könnten wir auch das Halte-Problem für Turing-Maschinen
 lösen und damit dann auch das Halte-Problem für \texttt{C}-Funktionen.
 

--- a/Lecture-Notes/javacc.tex
+++ b/Lecture-Notes/javacc.tex
@@ -142,11 +142,11 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
       Neben der Methode $\textsl{main}()$, die in jeder Parser-Klasse vorhanden
       sein muss, enthält die Klasse \texttt{Klausur} noch die Definition der statischen
       Methode $\texttt{note}()$, mit der später die Note berechnet wird.  Hier
-      wird die selbe Formel verwendet, die wir auch schon in dem entsprechenden
+      wird dieselbe Formel verwendet, die wir auch schon in dem entsprechenden
       \textsl{Flex}-Beispiel benutzt haben.
 \item Nun folgen nach dem Schlüsselwort \texttt{Token} und einem Doppelpunkt die
       einzelnen Token-Definitionen.  Diese werden insgesamt von geschweiften Klammern
-      eingefaßt und die einzelnen Token-Spezifikationen werden durch das
+      eingefasst und die einzelnen Token-Spezifikationen werden durch das
       Zeichen ``\texttt{|}'' voneinander getrennt.  Eine einzelne Token-Spezifikationen hat die
       Form
       \\[0.2cm]
@@ -214,7 +214,7 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
                   Ausdruck ``\texttt{\symbol{92}n}''.  Eckige Klammern geben, genau wie bei
                   \textsl{Flex}, eine Menge von Zeichen an.  Im Unterschied zu \textsl{Flex}\/ 
                   müssen die Zeichen aus dieser Menge allerdings alle in doppelten Hochkommata
-                  ``\texttt{\symbol{34}}'' eingefaßt werden.  
+                  ``\texttt{\symbol{34}}'' eingefasst werden.  
                   In dem obigen Fall enthält die Menge nur ein einziges
                   Zeichen.  \textbf{Vor} den eckigen Klammern finden wir aber das Zeichen
                   ``\texttt{\symbol{126}}''.  Dieses Zeichen bewirkt eine Komplementbildung:
@@ -226,7 +226,7 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
                   ``\texttt{\^}'' verwendet und dieser steht dann als erstes Zeichen \textbf{nach} der
                   öffnenden eckigen Klammer.
 
-                  Der ganze Ausdruck ist dann noch in runden Klammern eingefaßt, auf die der
+                  Der ganze Ausdruck ist dann noch in runden Klammern eingefasst, auf die der
                   Operator ``\texttt{*}'' folgt.  Genau wie bei \textsl{Flex}\/ steht dieser
                   Operator für eine beliebige Anzahl von Wiederholungen.
                   Im Unterschied zu \textsl{Flex}\/ muss das Argument, auf dass sich der
@@ -241,7 +241,7 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
       \item Die Definition von \texttt{NAME} sagt, dass eine Name aus zwei Gruppen
             von Buchstaben besteht, die durch ein Leerzeichen getrennt werden.
             Wichtig ist hier, dass das Leerzeichen in dem regulären Ausdruck in
-            doppelte Hochkommata ``\texttt{\symbol{34}}'' eingefaßt ist, denn (wie oben
+            doppelte Hochkommata ``\texttt{\symbol{34}}'' eingefasst ist, denn (wie oben
             bereits erwähnt) können reguläre Ausdrücke bei \textsl{JavaCC}\/ durch das
             Einfügen von Leerzeichen, Tabulatoren und Zeilenumbrüchen zur Verbesserung
             der Lesbarkeit formatiert werden.
@@ -287,7 +287,7 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
             der Scanner gibt später nie ein Token zurück, das als privat deklariert
             wurde.  Durch die Verwendung privater Token können reguläre Ausdrücke
             abgekürzt werden.  Die \emph{regulären Definitionen} in \textsl{Flex}\/ haben
-            die selbe Funktion.
+            dieselbe Funktion.
       \end{enumerate}
 \end{enumerate}
 Um das Beispiel zu übersetzen, geben wir die folgenden Befehle ein:

--- a/Lecture-Notes/jflex.tex
+++ b/Lecture-Notes/jflex.tex
@@ -143,7 +143,7 @@ die Spezifikation des Scanners aus Abbildung \ref{fig:count.jflex} jetzt Zeile f
       \texttt{Count} mit einer Methode $\texttt{main}()$ ausstatten.  Diese Methode wird alle
       Dateien, die ihr als Argument übergeben werden, scannen.
 
-      Einen Scanner, der selber mit einer $\texttt{main}$-Methode ausgestattet ist, werden wir im
+      Einen Scanner, derselber mit einer $\texttt{main}$-Methode ausgestattet ist, werden wir im
       Folgenden als \emph{Stand-Alone-Scanner} bezeichnen.
 \item Zeile 6 legt durch die Option ``\texttt{\%unicode} 
       fest, dass ein Scanner für Unicode erzeugt werden soll.  Zum Scannen von
@@ -327,7 +327,7 @@ Ausdrücke induktiv definieren.
 
       Die Konkatenation zweier regulärer Ausdrücke wird in \textsl{JFlex}\/ ohne den Infix-Operator
       ``$\cdot$'' geschrieben.  Der Ausdruck $r_1r_2$ steht also für einen String $s$ der
-      sich in die Form $s = uv$ so aufspalten läßt, dass $u$ durch $r_1$ und $v$ durch
+      sich in die Form $s = uv$ so aufspalten lässt, dass $u$ durch $r_1$ und $v$ durch
       $r_2$ spezifiziert wird.
 \item $r_1\texttt{|}r_2 \in \textsl{Regexp}$ \quad falls $r_1,r_2 \in \textsl{Regexp}$
 
@@ -399,7 +399,7 @@ Ausdrücke induktiv definieren.
       Der Ausdruck $r_1\texttt{/}r_2$ legt fest, dass auf den durch $r_1$ spezifizierten Text
       ein Text folgen muss, der der Spezifikation $r_2$ genügt.  Im Unterschied zur einfachen
       Konkatenation von $r_1$ und $r_2$ wird durch den regulären Ausdruck
-      $r_1\texttt{/}r_2$ aber der selbe Text 
+      $r_1\texttt{/}r_2$ aber derselbe Text 
       spezifiziert, der durch $r_1$ spezifiziert wird.  Der Operator ``\texttt{/}'' liefert
       also nur eine zusätzliche Bedingung, die für eine erfolgreiche Erkennung des regulären
       Ausdrucks erfüllt sein muss.  Die Methode ``\texttt{yytext()}'', die den erkannten Text
@@ -439,7 +439,7 @@ spezifizieren.  Dieser Ausdruck ist als Abkürzung zu verstehen, es gilt:
 \hspace*{1.3cm}
 $\texttt{[aeiou]} \doteq \texttt{a|e|i|o|u}$
 \\[0.2cm]
-Die Menge aller kleinen lateinischen Buchstaben läßt sich durch
+Die Menge aller kleinen lateinischen Buchstaben lässt sich durch
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{[a-z]}
@@ -512,7 +512,7 @@ Unsere bisherige Diskussion regulärer Ausdrücke ist noch nicht vollständig.
       \\[0.2cm]
       geklammert.  Wie nützlich dieser Operator ist, zeigt sich bei der Spezifikation von 
       mehrzeiligen \texttt{C}-Kommentaren.  Ein regulärer Ausdruck, der mehrzeilige
-      \texttt{C}-Kommentare erkennt, läßt sich mit dem Operator ``\texttt{!}''in der Form
+      \texttt{C}-Kommentare erkennt, lässt sich mit dem Operator ``\texttt{!}''in der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{\symbol{34}/*\symbol{34} !([\symbol{94}]* \symbol{34}*/\symbol{34} [\symbol{94}]*) 
@@ -763,7 +763,7 @@ beim Start übergeben wird.
 \end{figure}
 
 Abbildung \ref{fig:note.jflex} zeigt die \textsl{JFlex}-Spezifikation, aus der sich
-automatisch ein \textsl{Java}-Programm zur Noten-Berechnung erstellen läßt.
+automatisch ein \textsl{Java}-Programm zur Noten-Berechnung erstellen lässt.
 \begin{enumerate}
 \item Zeile 2 legt den Namen der Klasse fest.
 \item In Zeile 3 spezifizieren wir durch die Option ``\texttt{int}'', dass die
@@ -795,7 +795,7 @@ automatisch ein \textsl{Java}-Programm zur Noten-Berechnung erstellen läßt.
             \texttt{0|[1-9][0-9]*}
             \\[0.2cm]
             kürzer ``\texttt{\{ZAHL\}}'' schreiben.  Beachten Sie, dass der Name einer Abkürzung
-            bei der Verwendung der Abkürzung in geschweiften Klammern eingefaßt werden muss.
+            bei der Verwendung der Abkürzung in geschweiften Klammern eingefasst werden muss.
       \item Zeile 36 enthält die Definition von \texttt{NAME}.  In dem regulären Ausdruck
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -869,7 +869,7 @@ Wenn wir hier einen regulären Ausdruck angeben möchten, der weder den Upto-Opera
 den Negations-Operator verwendet\footnote{
   Die meisten anderen Werkzeuge, die mit regulären
   Ausdrücken arbeiten, unterstützen weder den Negations-Operator noch den Upto-Operator.},
-so müßten wir den folgenden regulären Ausdruck verwenden:
+so müssten wir den folgenden regulären Ausdruck verwenden:
 %\/\*([^*]|(\*+[^*/]))*\*+\/ 
 \begin{equation}
   \label{eq:multiline-comment}
@@ -906,7 +906,7 @@ ganz einfach.  Wir analysieren die einzelnen Komponenten dieses Ausdrucks:
       spezifiziert jetzt also entweder ein Zeichen, das von ``\texttt{*}'' verschieden
       ist, oder aber eine Folge von ``\texttt{*}''-Zeichen, auf die dann noch ein von
       ``\texttt{/}'' verschiedenes Zeichen folgt.  Da solche Folgen beliebig oft vorkommen
-      können, wird der ganze Ausdruck in Klammern eingefaßt und mit dem Quantor
+      können, wird der ganze Ausdruck in Klammern eingefasst und mit dem Quantor
       ``\texttt{*}'' dekoriert.   
 \item \texttt{\symbol{92}*+\symbol{92}/}
 

--- a/Lecture-Notes/keller-automaten.tex
+++ b/Lecture-Notes/keller-automaten.tex
@@ -619,7 +619,7 @@ Berechnungs-Schritte des Keller-Automaten $A(G)$.
 
                   Die Zustands-Übergänge des Keller-Automaten $A(G)$, bei denen ein Buchstabe
                   des Wortes gelesen wird, setzen alle voraus, dass auf dem Stack 
-                  der selbe Buchstabe liegt.
+                  derselbe Buchstabe liegt.
                   Falls der Keller-Automaten nur einen Schritt braucht, um von der
                   Konfiguration $\pair(w,X)$ zur Konfiguration $\pair(\varepsilon,[])$,
                   so kann also kein Buchstabe gelesen worden sein.
@@ -964,7 +964,7 @@ Diesen Beweis führen wir durch Induktion nach $n$.
                   \hspace*{1.3cm}
                   $\pair(w, X) = \pair(bv, X) \vdash \pair(v, \gamma) \vdash^n \pair(\varepsilon, [])$.
                   \\[0.2cm]
-                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $v$ läßt sich zerlegen
+                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $v$ lässt sich zerlegen
                   als $v = u_1 \cdots u_k$ und es ist $u_i$ gerade der Teil des Wortes $v$, der
                   gelesen wird, um die Variable $Y_i$ vom Stack zu entfernen, es gilt also
                   \\[0.2cm]
@@ -989,7 +989,7 @@ Diesen Beweis führen wir durch Induktion nach $n$.
                   \hspace*{1.3cm}
                   $\pair(w, X) \vdash \pair(w, \gamma) \vdash^n \pair(\varepsilon, [])$.
                   \\[0.2cm]
-                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $w$ läßt sich zerlegen
+                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $w$ lässt sich zerlegen
                   als $w = u_1 \cdots u_k$ und es ist $u_i$ gerade der Teil des Wortes $w$, der
                   gelesen wird, um die Variable $Y_i$ vom Stack zu entfernen, es gilt also
                   \\[0.2cm]
@@ -1031,7 +1031,7 @@ Dabei gelte:
       $\delta(\texttt{b}, S) := \{ \}$.
 \end{enumerate}
 Verwenden Sie das im Beweis von Satz \ref{satz:keller2grammar} verwendete Verfahren um eine
-Grammatik zu konstruieren, die die selbe Sprache beschreibt, die von dem Automaten $A(G)$ akzeptiert
+Grammatik zu konstruieren, die dieselbe Sprache beschreibt, die von dem Automaten $A(G)$ akzeptiert
 wird.  
 
 %%% Local Variables: 

--- a/Lecture-Notes/kontextfreie-sprachen.tex
+++ b/Lecture-Notes/kontextfreie-sprachen.tex
@@ -132,7 +132,7 @@ Bei den Nicht-Terminalen gibt es zwei Arten:
       ist dies ein String, der den Namen der Variablen wiedergibt.
 \end{enumerate}
 Üblicherweise werden Grammatik-Regeln in einer kompakteren Notation als der oben vorgestellten
-wiedergegeben, indem alle Regeln für ein Nicht-Terminal zusammengefaßt werden.  Für unser Beispiel
+wiedergegeben, indem alle Regeln für ein Nicht-Terminal zusammengefasst werden.  Für unser Beispiel
 sieht das dann wie folgt aus:
 \begin{eqnarray*}
   \textsl{ArithExpr} & \rightarrow & \textsl{ArithExpr} \quoted{+} \textsl{Product} \;\mid\;
@@ -291,7 +291,7 @@ erzeugt, wobei die Regeln $R$ wie folgt gegeben sind:
 
 \proof
 Wir zeigen zunächst, dass sich jedes Wort $w \in L$ aus dem
-Start-Symbol $S$ ableiten läßt:
+Start-Symbol $S$ ableiten lässt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $w \in L \;\Longrightarrow\; S \Rightarrow^* w$.
@@ -323,7 +323,7 @@ Es sei also $w_n = (^n)^n$.  Wir zeigen durch Induktion über $n$, dass $w_n \in 
             \\[0.2cm]
             Also gilt  $w_{n+1} \in L(G)$.
 \end{enumerate}
-Als nächstes zeigen wir, dass jedes Wort $w$, dass sich aus $S$ ableiten läßt, ein Element
+Als nächstes zeigen wir, dass jedes Wort $w$, dass sich aus $S$ ableiten lässt, ein Element
 der Sprache $L$ ist.  Wir führen den Beweis durch Induktion über die Anzahl $n$ der
 Ableitungs-Schritte:
 \begin{enumerate}
@@ -461,7 +461,7 @@ denn jeder String der Form $s=ww$ hat offenbar die Länge
 und das ist eine gerade Zahl.
 
 
-Gilt nun $s \in L$ mit $|s| = 2 \cdot n$, so läßt sich $s$ in zwei Teile $u$ und $v$ gleicher
+Gilt nun $s \in L$ mit $|s| = 2 \cdot n$, so lässt sich $s$ in zwei Teile $u$ und $v$ gleicher
 Länge zerlegen:
 \[  
    s = uv \quad \mbox{mit} \quad u = s[1\!:\!n], \quad v = s[n+1\!:\!2 \cdot n]
@@ -496,7 +496,7 @@ sind, befinden sich also genau in der Mitte der Strings $x$ und $y$.
 \vspace{0.3cm}
 
 \noindent
-\textbf{Bemerkung}: Wir haben soeben Folgendes gezeigt:  Falls $s \in L$ mit $|s| = 2 \cdot n$ ist, so läßt
+\textbf{Bemerkung}: Wir haben soeben Folgendes gezeigt:  Falls $s \in L$ mit $|s| = 2 \cdot n$ ist, so lässt
 sich $s$ so in zwei Strings $x$ und $y$ aufspalten, dass die Buchstaben, die jeweils in
 der Mitte von $x$ und $y$ liegen, unterschiedlich sind:
 \\[0.2cm]
@@ -574,7 +574,7 @@ L & =    & \bigl\{ s \in \Sigma^* \big|\; |s| \,\%\, 2 = 1 \bigr\}  \\[0.1cm]
                                     \wedge |y| \,\%\, 2 = 1  \wedge \hat{x} \not= \hat{y} \bigr\} 
 \end{array}
 \]
-Damit läßt sich die Menge $L$ durch die folgende Grammatik beschreiben
+Damit lässt sich die Menge $L$ durch die folgende Grammatik beschreiben
 \[ G = \langle \{ S, A, B, X, U \}, \{ a, b \}, R, S \rangle, \] 
 wobei die Menge der Regeln wie folgt gegeben ist:
 \[ 
@@ -617,11 +617,11 @@ $
       dieser Teile verschiedene Buchstaben stehen: Entweder steht im ersten Teil ein $a$
       und im zweiten Teil steht ein $b$ oder es ist umgekehrt.
 \end{enumerate}
-Um die obigen Behauptungen formal zu beweisen müßten wir nun einerseits noch durch eine Induktion
+Um die obigen Behauptungen formal zu beweisen müssten wir nun einerseits noch durch eine Induktion
 nach der Länge der Herleitung zeigen, dass die von den Grammatik-Symbolen erzeugten
-Strings tatsächlich in den oben angegebenen Mengen liegen.  Andererseits müßten wir für
+Strings tatsächlich in den oben angegebenen Mengen liegen.  Andererseits müssten wir für
 die oben angegebenen Mengen zeigen, dass sich jeder String der jeweiligen Menge auch tatsächlich mit den
-angegebenen Grammatik-Regeln erzeugen läßt.  Dieser Nachweis würde dann durch Induktion über die Länge der
+angegebenen Grammatik-Regeln erzeugen lässt.  Dieser Nachweis würde dann durch Induktion über die Länge der
 einzelnen Strings geführt werden.  Da diese Nachweise einfach sind und keine
 Überraschungen mehr bietet, verzichten wir hier darauf.
 \qed
@@ -759,7 +759,7 @@ deren Regeln wie folgt gegeben sind:
 $\textsl{S} \;\rightarrow\; \mathtt{a} S \mathtt{b} S \;\mid\; \textsl{b} S \mathtt{a} S \;\mid\; \varepsilon$
 \\[0.2cm]
 Diese Grammatik ist allerdings mehrdeutig: Betrachten wir beispielsweise den String 
-``\texttt{abab}'', so stellen wir fest, dass sich dieser prinzipiell auf zwei Arten ableiten läßt:
+``\texttt{abab}'', so stellen wir fest, dass sich dieser prinzipiell auf zwei Arten ableiten lässt:
 \begin{eqnarray*}
   S & \Rightarrow & \mathtt{a} S \mathtt{b} S                       \\
     & \Rightarrow & \mathtt{a} \mathtt{b} S                         \\
@@ -840,9 +840,9 @@ analog zum ersten Fall.    \qed
 \vspace*{0.3cm}
 
 In dem obigen Beispiel hatten wir Glück und konnten eine Grammatik finden, mit der sich
-die Sprache eindeutig parsen läßt.  Es  gibt allerdings auch kontextfreie Sprachen, die 
+die Sprache eindeutig parsen lässt.  Es  gibt allerdings auch kontextfreie Sprachen, die 
 \href{http://en.wikipedia.org/wiki/Ambiguous_grammar#Inherently_ambiguous_languages}{inhärent mehrdeutig}
-sind: Es läßt sich beispielsweise zeigen, dass für das Alphabet 
+sind: Es lässt sich beispielsweise zeigen, dass für das Alphabet 
 $\Sigma =  \{ \mathtt{a}, \texttt{b}, \mathtt{c}, \mathtt{d} \}$
 die Sprache
 \\[0.2cm]

--- a/Lecture-Notes/lalr-bison.tex
+++ b/Lecture-Notes/lalr-bison.tex
@@ -41,7 +41,7 @@ so werden von \textsl{Bison} zwei Dateien erzeugt:
       \texttt{cc.vcg}.  Die Datei-Endung \texttt{.vcg} steht als Abkürzung für 
       \emph{visualization of compiler graphs}.
       Diese Datei stellt den Goto-Graphen der Grammatik im
-      \emph{VCG-Format} dar und läßt sich mit Hilfe geeigneter Werkzeuge grafisch
+      \emph{VCG-Format} dar und lässt sich mit Hilfe geeigneter Werkzeuge grafisch
       darstellen.  
       Ein solches Werkzeug ist \texttt{aiSee}, dass Sie im Internet unter der Adresse
       \\[0.2cm]
@@ -166,7 +166,7 @@ Zeile für Zeile.
       \hspace*{1.3cm}
       $\textsc{M} = \textsl{closure}(\textsc{M}^-)$
       \\[0.2cm]
-      berechnen läßt.  Außerdem werden die Mengen der Folge-Token nicht angegeben.
+      berechnen lässt.  Außerdem werden die Mengen der Folge-Token nicht angegeben.
       Wir betrachten nun zwei der Zustände im Detail:
       \begin{enumerate}
       \item Der Zustand ``\texttt{state 1}'', der in der Zeile 25 spezifiziert
@@ -259,7 +259,7 @@ oder Reduce-Reduce-Konflikte auftreten.  Wir besprechen an Hand zweier typischer
 \noindent
 Wir beginnen mit der in Abbildung \ref{fig:shift-reduce-conflict.grammar} gezeigten Grammatik für
 arithmetische Ausdrücke.  Abbildung \ref{fig:conflict.y} zeigt, wie diese Grammatik sich für \textsl{Bison}
-darstellen läßt.   Hier haben wir in Zeile 1 festgelegt, dass ``\texttt{N}'' als Nicht-Terminal zu
+darstellen lässt.   Hier haben wir in Zeile 1 festgelegt, dass ``\texttt{N}'' als Nicht-Terminal zu
 interpretieren ist.  Übersetzen wir diese Grammatik mit dem Befehl
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -654,7 +654,7 @@ Datei.
       $E \rightarrow E \quoted{+} E \bullet$, 
       \\[0.2cm]
       denn die erste Regel verlangt nach einem Shift, während die zweite Regel eine Reduktion fordert.
-      Da die Regel $E \rightarrow E \quoted{+} E$ die selbe Präzedenz wie der Operator ``\texttt{+}''
+      Da die Regel $E \rightarrow E \quoted{+} E$ dieselbe Präzedenz wie der Operator ``\texttt{+}''
       hat, spielt nun die Assoziativität eine Rolle.  Da dieser Operator links-assoziativ ist, 
       wird mit dieser Regel reduziert.  Dies ist Teil des in Zeile 14 spezifizierten Falls.
 
@@ -705,7 +705,7 @@ Datei.
       $E \rightarrow E \bullet \quoted{\symbol{94}} E$ \quad und \quad
       $E \rightarrow E \quoted{\symbol{94}} E  \bullet$,
       \\[0.2cm]
-      wenn das nächste Token der Operator ``\texttt{\symbol{94}}'' ist.  Da der Operator die selbe Präzedenz
+      wenn das nächste Token der Operator ``\texttt{\symbol{94}}'' ist.  Da der Operator dieselbe Präzedenz
       hat wie die Regel, entscheidet wieder die Assoziativität.  Nun ist der Operator
       ``\texttt{\symbol{94}}'' rechts-assoziativ, daher wird in diesem Fall geshiftet.
 
@@ -738,7 +738,7 @@ Datei.
     \label{fig:state16}
   \end{figure}
 
-      Hier gibt es noch viele andere Shift-Reduce-Konflikte, die aber alle die selbe Struktur haben.
+      Hier gibt es noch viele andere Shift-Reduce-Konflikte, die aber alle dieselbe Struktur haben.
       Exemplarisch betrachten wir den Shift-Reduce-Konflikt zwischen den Regeln
       \\[0.2cm]
       \hspace*{1.3cm}

--- a/Lecture-Notes/lex.tex
+++ b/Lecture-Notes/lex.tex
@@ -215,10 +215,10 @@ achten.
       Regel-Abschnitt und der Regel-Abschnitt von dem Programm-Abschnitt getrennt werden, müssen am
       Anfang einer ansonsten leeren Zeile stehen.
 \item Bei den Regeln muss der reguläre Ausdruck am Anfang der Zeile stehen.
-\item Die Kommandos, die auf eine Regel folgen, müssen in der selben Zeile beginnen wie der
+\item Die Kommandos, die auf eine Regel folgen, müssen in derselben Zeile beginnen wie der
       zugehörige reguläre Ausdruck.  Es ist sinnvoll, diese Kommandos immer in
       geschweifte Klammern einzuschließen.  Dann müssen wir lediglich darauf achten, dass
-      die öffnende Klammer ``\texttt{\{}'' in der selben Zeile steht wie der zugehörige 
+      die öffnende Klammer ``\texttt{\{}'' in derselben Zeile steht wie der zugehörige 
       reguläre Ausdruck.  
 \end{enumerate}
 
@@ -332,7 +332,7 @@ Ausdrücke induktiv definieren.
   
       Der Ausdruck $r_1\texttt{/}r_2$ legt fest, dass auf den durch $r_1$ spezifizierten Text
       ein Text folgen muss, der der Spezifikation $r_2$ genügt.  Im Unterschied zur einfachen
-      Konkatenation von $r_1$ und $r_2$ wird durch den $r_1\texttt{/}r_2$ aber der selbe Text
+      Konkatenation von $r_1$ und $r_2$ wird durch den $r_1\texttt{/}r_2$ aber derselbe Text
       spezifiziert, der durch $r_1$ spezifiziert wird.  Der Operator ``\texttt{/}'' liefert
       also nur eine zusätzliche Bedingung, die für eine erfolgreiche Erkennung des regulären
       Ausdrucks erfüllt sein muss.  Die Variable ``\texttt{yytext}'', in der der erkannte Text
@@ -360,7 +360,7 @@ spezifizieren.  Dieser Ausdruck ist als Abkürzung zu verstehen, es gilt:
 \hspace*{1.3cm}
 $\texttt{[aeiou]} \doteq \texttt{a|e|i|o|u}$
 \\[0.2cm]
-Die Menge aller kleinen lateinischen Buchstaben läßt sich durch
+Die Menge aller kleinen lateinischen Buchstaben lässt sich durch
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{[a-z]}
@@ -545,7 +545,7 @@ löst.  Wir diskutieren dieses Programm jetzt Zeile für Zeile.
             \texttt{0|[1-9][0-9]*}
             \\[0.2cm]
             kürzer ``\texttt{\{ZAHL\}}'' schreiben.  Beachten Sie, dass der Name einer Abkürzung
-            bei der Verwendung der Abkürzung in geschweiften Klammern eingefaßt werden muss.
+            bei der Verwendung der Abkürzung in geschweiften Klammern eingefasst werden muss.
       \item Zeile 11 enthält die Definition von \texttt{NAME}.  In dem regulären Ausdruck
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -666,7 +666,7 @@ ganz einfach.  Wir analysieren die einzelnen Komponenten dieses Ausdrucks:
       spezifiziert jetzt also entweder ein Zeichen, das von ``\texttt{*}'' verschieden
       ist, oder aber eine Folge von ``\texttt{*}''-Zeichen, auf die dann noch ein von
       ``\texttt{/}'' verschiedenes Zeichen folgt.  Da solche Folgen beliebig oft vorkommen
-      können, wird der ganze Ausdruck in Klammern eingefaßt und mit dem Quantor
+      können, wird der ganze Ausdruck in Klammern eingefasst und mit dem Quantor
       ``\texttt{*}'' dekoriert.   
 \item \texttt{\symbol{92}*+\symbol{92}/}
 

--- a/Lecture-Notes/liveness.tex
+++ b/Lecture-Notes/liveness.tex
@@ -39,7 +39,7 @@ speichern zu können.  Wir werden zeigen, dass drei Register bereits ausreichend 
 \label{fig:liveness-example-1.c}
 \end{figure}
 
-Wenn wir analysieren wollen, welche Variablen gleichzeitig das selbe Register belegen
+Wenn wir analysieren wollen, welche Variablen gleichzeitig dasselbe Register belegen
 können,  müssen wir uns zunächst darüber klar werden, wann der Wert einer Variablen, der
 eventuell in einem Register liegt, noch benötigt wird.  Dazu definieren wir, dass eine
 Variable $v$ in einer Zeile $l$ im Programm \emph{lebendig} ist, wenn wir später noch

--- a/Lecture-Notes/ll.tex
+++ b/Lecture-Notes/ll.tex
@@ -199,7 +199,7 @@ syntaktische Variable $B$ auftritt.  Wir nennen die neu eingeführte Variable $D$
 
 
 \section{\textsl{First} und \textsl{Follow}}
-Nicht für jede links-faktorisierte Grammatik läßt sich ein LL(1)-Parser bauen.  Betrachten
+Nicht für jede links-faktorisierte Grammatik lässt sich ein LL(1)-Parser bauen.  Betrachten
 wir die folgenden Regeln:
 \begin{eqnarray*}
   A & \rightarrow & B \; \mid\; C \\
@@ -212,8 +212,8 @@ ob der Parser als nächstes die Regel
 \hspace*{1.3cm}
 $A \rightarrow B$ \quad oder \quad $A \rightarrow C$
 \\[0.2cm]
-verwenden soll.  Für die obige Grammatik läßt sich daher kein LL(1)-Parser implementieren.
-Zur Entscheidung, ob sich für eine gegebene Grammatik ein LL(1)-Parser implementieren läßt,
+verwenden soll.  Für die obige Grammatik lässt sich daher kein LL(1)-Parser implementieren.
+Zur Entscheidung, ob sich für eine gegebene Grammatik ein LL(1)-Parser implementieren lässt,
 benötigen wir die Funktionen $\textsl{First}()$ und $\textsl{Follow}()$, die wir gleich
 definieren werden.  Um diese Funktionen implementieren zu können, definieren wir vorher  den
 Begriff einer $\varepsilon$-erzeugenden syntaktischen Variablen.
@@ -226,7 +226,7 @@ syntaktische Variable, also $A \in V$.  Dann heißt die Variable $A$
 \hspace*{1.3cm}
 $A \Rightarrow^* \varepsilon$
 \\[0.2cm]
-gilt, also dann, wenn sich aus der Variablen $A$ das leere Wort ableiten läßt. 
+gilt, also dann, wenn sich aus der Variablen $A$ das leere Wort ableiten lässt. 
 Wir schreiben $\textsl{nullable}(A)$ wenn die Variable $A$ als $\varepsilon$-erzeugend
 nachgewiesen ist.
 \qed
@@ -404,7 +404,7 @@ $\textsl{Follow}(A) :=
   \}
 $.
 \\[0.2cm]
-Wenn sich aus dem Start-Symbol $\widehat{S}$ also irgendwie ein String $\beta A t\gamma$ ableiten läßt,
+Wenn sich aus dem Start-Symbol $\widehat{S}$ also irgendwie ein String $\beta A t\gamma$ ableiten lässt,
 bei dem das Token $t$ auf die Variable $A$ folgt, dann ist $t$ ein Element
 der Menge $\textsl{Follow}(A)$.
 \qed  
@@ -562,11 +562,11 @@ gibt, die folgenden Bedingungen erfüllt sind:
 \begin{enumerate}
 \item $\neg( \alpha \Rightarrow^* \varepsilon \wedge \beta \Rightarrow^* \varepsilon)$.
 
-      Die Rümpfe zweier verschiedener Regeln der selben Variablen
+      Die Rümpfe zweier verschiedener Regeln derselben Variablen
       dürfen nicht beide das leere Wort ableiten.
 \item $\textsl{First}(\alpha) \cap \textsl{First}(\beta) = \{\}$.
 
-      Die Ableitungen der Rümpfe zweier verschiedener Regeln der selben Variablen
+      Die Ableitungen der Rümpfe zweier verschiedener Regeln derselben Variablen
       dürfen nicht mit dem selben Token beginnen.
 \item   $(\beta  \Rightarrow^* \varepsilon) \rightarrow \textsl{First}(\alpha) \cap
 \textsl{Follow}(A) = \{\}$.
@@ -902,7 +902,7 @@ $A \rightarrow \beta$
 und einen String $\sigma \in \textsl{Follow}(k,A)$
 enthält die Menge $\textsl{First}(k, \beta \sigma)$ alle die Strings der Länge
 $\leq k$, die in einer Ableitung von $A$, welche die Regel $A \rightarrow \beta$ benutzt,
-folgen können.  Sind diese Mengen für verschiedene Regeln disjunkt, so läßt sich an Hand der
+folgen können.  Sind diese Mengen für verschiedene Regeln disjunkt, so lässt sich an Hand der
 $k$ folgenden Token entscheiden, welche der Regeln angewendet werden muss.
 \vspace*{0.2cm}
 

--- a/Lecture-Notes/lr-parser.tex
+++ b/Lecture-Notes/lr-parser.tex
@@ -115,7 +115,7 @@ Regeln.
 
 \noindent
 \textbf{Bemerkung}: Wenn Sie sich an den Earley-Algorithmus erinnern, dann sehen Sie, dass bei der
-Berechnung des Abschlusses die selbe Berechnung wie bei der Vorhersage-Operation
+Berechnung des Abschlusses dieselbe Berechnung wie bei der Vorhersage-Operation
 des  Earley-Algorithmus durchgeführt wird.
 \vspace*{0.3cm}
 
@@ -836,9 +836,9 @@ gezeigte Grammatik.   Diese Grammatik ist eindeutig, denn es gilt
 \hspace*{1.3cm}
 $L(S) = \{\; \squoted{xy}, \;\squoted{yx} \;\}$
 \\[0.2cm]
-und der String \qote{xy} läßt sich nur mit der Regel $S \rightarrow  A \quoted{x} A \quoted{y}$
+und der String \qote{xy} lässt sich nur mit der Regel $S \rightarrow  A \quoted{x} A \quoted{y}$
 herleiten, während sich der String \qote{yx} nur mit der Regel 
-$S \rightarrow B \quoted{y} B \quoted{x}$ erzeugen läßt.
+$S \rightarrow B \quoted{y} B \quoted{x}$ erzeugen lässt.
 Um zu zeigen, dass diese Grammatik Shift-Reduce-Konflikte enthält,
 berechnen wir den Start-Zustand eines SLR-Parsers für diese Grammatik.
 
@@ -883,7 +883,7 @@ berechnen wir den Start-Zustand eines SLR-Parsers für diese Grammatik.
             \bigr\},
  \end{array}
 \] 
-denn $A \rightarrow \bullet \varepsilon$ ist das Selbe wie $A \rightarrow \varepsilon \bullet$.
+denn $A \rightarrow \bullet \varepsilon$ ist dasselbe wie $A \rightarrow \varepsilon \bullet$.
 In diesem Zustand gibt es einen Reduce-Reduce-Konflikt zwischen den beiden markierten Regeln
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1286,7 +1286,7 @@ His theory is described in the paper
 
 \section{LALR-Parser}
 Die Zahl der Zustände eines LR-Parsers ist oft erheblich größer als die Zahl der Zustände, die ein
-SLR-Parser der selben Grammatik hätte.  Beispielsweise kommt ein SLR-Parser für die
+SLR-Parser derselben Grammatik hätte.  Beispielsweise kommt ein SLR-Parser für die
 \href{https://github.com/karlstroetmann/Formal-Languages/blob/master/SetlX/Examples/c-grammar.g}{\texttt{C}-Grammatik} 
 mit 349 Zuständen aus.  Da die Sprache \texttt{C} keine SLR-Sprache ist, gibt es beim Erzeugen
 einer SLR-Parse-Tabelle für \texttt{C} allerdings eine Reihe von 
@@ -1496,7 +1496,7 @@ Diese Inklusionen sind leicht zu verstehen:  Bei der Definition der LR-Parser ha
 zu den markierten Regeln  Mengen von Folge-Token hinzugefügt.  Dadurch war
 es möglich, in bestimmten Fällen Shift-Reduce- und Reduce-Reduce-Konflikte zu vermeiden.
 Da die Zustands-Mengen der kanonischen LR-Parser unter Umständen sehr groß werden können,
-hatten wir dann wieder solche Mengen von erweiterten markierten Regeln zusammen gefaßt,
+hatten wir dann wieder solche Mengen von erweiterten markierten Regeln zusammen gefasst,
 für die die Menge der Folge-Token identisch war.  So hatten wir die LALR-Parser
 erhalten.  Durch die Zusammenfassung von Regel-Menge können wir
 uns allerdings in bestimmten Fällen Reduce-Reduce-Konflikte einhandeln, so dass die 
@@ -1555,10 +1555,10 @@ Definition der Funktionen $\textsl{goto}()$ und $\textsl{action}()$ blieb unverä
 
 \subsection{\emph{LALR-Sprache} $\subsetneq$ \emph{kanonische LR-Sprache}}
 Wir hatten LALR-Parser dadurch definiert, dass wir verschiedene Zustände eines kanonischen LR-Parsers
-zusammen gefaßt haben.  Damit ist klar, dass kanonische LR-Parser mindestens so mächtig
+zusammen gefasst haben.  Damit ist klar, dass kanonische LR-Parser mindestens so mächtig
 sind wie LALR-Parser.  Um zu zeigen, dass kanonische LR-Parser tatsächlich mächtiger sind
 als LALR-Parser, benötigen wir eine Grammatik, für die sich zwar ein kanonischer LR-Parser,
-aber kein LALR-Parser erzeugen läßt.  Abbildung \ref{fig:lr-but-notlalr.g} zeigt eine
+aber kein LALR-Parser erzeugen lässt.  Abbildung \ref{fig:lr-but-notlalr.g} zeigt eine
 solche Grammatik, die ich dem Drachenbuch entnommen habe.
 
 \begin{figure}[htbp]
@@ -1658,7 +1658,7 @@ $\textsl{core}(s_4) = \{ A \rightarrow \squoted{x} \bullet,\;
                 B \rightarrow \squoted{x} \bullet \} = \textsl{core}(s_5)$.
 \\[0.2cm]
 Bei der Berechnung der LALR-Zustände werden diese beiden Zustände zu einem Zustand
-$s_{\{4,5\}}$ zusammen gefaßt.  Dieser neue Zustand hat die Form
+$s_{\{4,5\}}$ zusammen gefasst.  Dieser neue Zustand hat die Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $s_{\{4,5\}} = \bigl\{ A \rightarrow \squoted{x} \bullet: \{\squoted{y}, \squoted{z} \},\;
@@ -1681,7 +1681,7 @@ invention,  the space savings of LALR parsing in comparison to LR parsing were c
 
 \subsection{Bewertung der verschiedenen Methoden}
 Für die Praxis sind SLR-Parser nicht ausreichend, denn es gibt eine Reihe praktisch
-relevanter Sprach-Konstrukte, für die sich kein SLR-Parser erzeugen läßt.  Kanonische
+relevanter Sprach-Konstrukte, für die sich kein SLR-Parser erzeugen lässt.  Kanonische
 LR-Parser sind wesentlich mächtiger, benötigen allerdings oft deutlich mehr Zustände. 
 Hier stellen LALR-Parser einen Kompromiß dar:  Einerseits sind LALR-Sprachen fast so
 ausdrucksstark  wie kanonische LR-Sprachen, andererseits liegt der Speicherbedarf von

--- a/Lecture-Notes/minimization.tex
+++ b/Lecture-Notes/minimization.tex
@@ -14,7 +14,7 @@ endlichen Automaten
 \hspace*{1.3cm}
 $A^- = \langle Q^-, \Sigma, \delta^-, q_0, F^- \rangle$,
 \\[0.2cm]
-der die selbe Sprache akzeptiert wie der Automat $A$, für den also
+der dieselbe Sprache akzeptiert wie der Automat $A$, für den also
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(A^-) = L(A)$
@@ -139,7 +139,7 @@ gilt.  Diese Idee liefert einen Algorithmus, der aus zwei Schritten besteht:
 Haben wir alle Paare $\pair(p,q)$ von unterscheidbaren Zuständen gefunden,
 so können wir anschließend alle Zustände $p$ und $q$  identifizieren, die nicht
 unterscheidbar sind, für die also $\langle p, q \rangle \not\in V$ gilt.
-Es läßt sich zeigen, dass der so konstruierte Automat tatsächlich minimal ist.
+Es lässt sich zeigen, dass der so konstruierte Automat tatsächlich minimal ist.
 \pagebreak
 
 \vspace*{-0.5cm}

--- a/Lecture-Notes/register.tex
+++ b/Lecture-Notes/register.tex
@@ -769,8 +769,8 @@ erforderlich:
       ein Register, das von einer Variablen belegt wird, die an dieser Stelle des
       Programms nicht mehr lebendig ist, von einer anderen Variablen genutzt werden kann.
 \item Anschließend geschieht nun die Register-Allokation, bei der nun auch verschiedenen
-      Variablen das selbe Register zugeordnet werden kann.   Wird zwei verschiedenen
-      Variablen $x$ und $y$ das selbe Register zugewiesen, so muss lediglich gewährleistet 
+      Variablen dasselbe Register zugeordnet werden kann.   Wird zwei verschiedenen
+      Variablen $x$ und $y$ dasselbe Register zugewiesen, so muss lediglich gewährleistet 
       werden, dass es keinen Punkt im Programm gibt, bei dem gleichzeitig sowohl $x$ als
       auch $y$ lebendig sind.
 \item Bei dem Sichern und Wiederherstellen der Register auf dem Stack muss ausgehend von der Analyse

--- a/Lecture-Notes/regulaere-ausdruecke.tex
+++ b/Lecture-Notes/regulaere-ausdruecke.tex
@@ -465,7 +465,7 @@ Wir betrachten die F‰lle getrennt und beginnen mit dem einfacheren Fall.
       $x = x\varepsilon \in L(t) \cdot L(s^*)$.
 \item $x \in L(r) \cdot L(s)$.
 
-      Dann l‰ﬂt sich $x$ in zwei Teilstrings $y$ und $z$ aufspalten, so dass gilt
+      Dann l‰sst sich $x$ in zwei Teilstrings $y$ und $z$ aufspalten, so dass gilt
       \\[0.2cm]
       \hspace*{1.3cm}
       $x = yz$, \quad $y \in L(r)$ \quad und \quad  $z \in L(s)$.

--- a/Lecture-Notes/regulaere-sprachen.tex
+++ b/Lecture-Notes/regulaere-sprachen.tex
@@ -256,7 +256,7 @@ dann, ob diese Menge einen akzeptierenden Zustand enthält.
 
 \noindent
 \textbf{Bemerkung}:  Ist die reguläre Sprache $L$ nicht durch einen endlichen Automaten $A$,
-sondern durch einen regulären Ausdruck $r$ gegeben, so läßt sich durch einen einfachen
+sondern durch einen regulären Ausdruck $r$ gegeben, so lässt sich durch einen einfachen
 rekursiven Algorithmus, der dem Aufbau des regulären Ausdrucks folgt, entscheiden, ob
 $L(r)$ leer ist.
 \begin{enumerate}
@@ -468,7 +468,7 @@ gegebene Sprache nicht regulär ist.
   \item $|uv| \leq n$,
   \item $\forall h \in \mathbb{N}: uv^hw \in L$.
   \end{enumerate}
-  Das Pumping-Lemma für eine reguläre Sprache $L$ kann in einer einzigen Formel zusammen gefaßt
+  Das Pumping-Lemma für eine reguläre Sprache $L$ kann in einer einzigen Formel zusammen gefasst
   werden: 
   \\[0.2cm]
   \hspace*{0.1cm}
@@ -674,7 +674,7 @@ Zeigen Sie mit Hilfe des Pumping-Lemmas, dass die Sprache $L_{\mathrm{square}}$ 
 Wir führen den Beweis indirekt und nehmen an, dass $L_{\mathrm{square}}$ regulär
 wäre.  Nach dem Pumping-Lemma gibt es dann eine positive natürliche Zahl $n$ (dies war die Anzahl
 der Zustände des deterministischen Automaten, der die Sprache erkennt), so dass sich jeder String
-$s \in L_{\mathrm{square}}$ mit $|s| \geq n$ in drei Teilstrings $u$, $v$ und $w$ aufspalten läßt, so dass gilt:
+$s \in L_{\mathrm{square}}$ mit $|s| \geq n$ in drei Teilstrings $u$, $v$ und $w$ aufspalten lässt, so dass gilt:
 \begin{enumerate}
 \item $s = uvw$,
 \item $|uv| \leq n$,

--- a/Lecture-Notes/sed.tex
+++ b/Lecture-Notes/sed.tex
@@ -141,7 +141,7 @@ diskutieren wollen.  Im letzten Abschnitt hatten wir diskutiert, was wir für den
 Der Ausdruck \textsl{Replacement} spezifiziert den Text, durch den der Text, der dem
 regulären Ausdruck \textsl{Regexp} entspricht ersetzt werden kann.  Dabei kann innerhalb
 von dem Ausdruck \textsl{Replacement} auf geklammerte Teile zurückgegriffen werden.
-\texttt{\symbol{92}1} bezieht sich auf den ersten in Klammern eingefaßten  Teilausdruck,
+\texttt{\symbol{92}1} bezieht sich auf den ersten in Klammern eingefassten  Teilausdruck,
 \texttt{\symbol{92}2} auf den zweiten,
 \texttt{\symbol{92}3} auf den dritten, etc.
 

--- a/Lecture-Notes/shift-reduce-parser.tex
+++ b/Lecture-Notes/shift-reduce-parser.tex
@@ -139,7 +139,7 @@ zu dem String
 \hspace*{1.3cm}
 $E \texttt{ + } E \texttt{ * }  E$,
 \\[0.2cm]
-der sich dann  aber mit der oben angegebenen Grammatik nicht mehr reduzieren l‰ﬂt.  
+der sich dann  aber mit der oben angegebenen Grammatik nicht mehr reduzieren l‰sst.  
 Die Antwort auf die oben Fragen, welchen Teilstring wir ersetzen und welche Regel wir
 verwenden, setzt einiges an Theorie voraus, die wir
 in den folgenden Abschnitten entwickeln werden.

--- a/Lecture-Notes/type-checker.tex
+++ b/Lecture-Notes/type-checker.tex
@@ -986,7 +986,7 @@ Klassen-Generators
 \end{figure}
 
 Die Klasse \texttt{MartelliMontanari} enthält die in Abbildung \ref{fig:MartelliMontanari:solve.java}
-gezeigte Methode $\textsl{solve}()$, mit der sich ein syntaktisches Gleichungs-System lösen läßt.
+gezeigte Methode $\textsl{solve}()$, mit der sich ein syntaktisches Gleichungs-System lösen lässt.
 Wir diskutieren diese Methode jetzt im Detail.
 \begin{enumerate}
 \item Am Anfang wählen wir in  Zeilen 3 willkürlich die erste syntaktische Gleichung aus der Menge
@@ -1298,7 +1298,7 @@ Polymorphismus auftritt.  Wir zeigen exemplarisch ein Beispiel in Abbildung \ref
       Da \texttt{y} ein Feld von Objekten ist und eine Zahl ebenfalls als Objekt angesehen werden kann,
       sollte auch dies kein Problem sein.
 \end{enumerate}
-In der Tat läßt sich das Programm fehlerfrei übersetzen.  Bei der Ausführung wird aber eine Ausnahme
+In der Tat lässt sich das Programm fehlerfrei übersetzen.  Bei der Ausführung wird aber eine Ausnahme
 ausgelöst.  Der Grund ist, dass mit der Zuweisung in Zeile 5 die Variable \texttt{y} eine Referenz auf das
 Feld von Strings ist, das in Zeile 4 angelegt worden ist.  Wenn wir nun versuchen, in dieses Feld eine Zahl
 einzufügen, dann gibt es eine \texttt{ArrayStoreException}.  Dieses Beispiel zeigt, dass die Sprache

--- a/Probe-Klausur/Herbst/probe-klausur.tex
+++ b/Probe-Klausur/Herbst/probe-klausur.tex
@@ -44,7 +44,7 @@ Nehmen Sie dabei an, dass ein Euro einen Wert von 1,20 Franken hat.
       Wörtern der Sprache $\{a,b\}^*$ besteht,  bei denen auf jedes \qote{a} mindestens ein \qote{b} folgt.
 \item Geben Sie einen regulären Ausdruck an, der diese Sprache beschreibt.
 \item Berechnen Sie, ausgehend von dem unter (b) angegebenen regulären Ausdruck,
-      einen nicht-deterministischen endlichen Automaten, der die selbe Sprache erkennt.
+      einen nicht-deterministischen endlichen Automaten, der dieselbe Sprache erkennt.
 
       Benutzen Sie dabei das in der Vorlesung diskutierte Verfahren.
 \item Überführen Sie den unter (c) angegebenen Automaten in einen
@@ -166,7 +166,7 @@ Bearbeiten Sie die folgenden Teilaufgaben:
 
 %\noindent
 %Geben Sie eine Grammatik an, mit der sich die Struktur von Ausdrücken der oben
-%beschriebenen Art eindeutig beschreiben läßt.
+%beschriebenen Art eindeutig beschreiben lässt.
 
 
 \exercise

--- a/Probe-Klausur/Sommer/loesung-2011.tex
+++ b/Probe-Klausur/Sommer/loesung-2011.tex
@@ -436,7 +436,7 @@ Bearbeiten Sie die folgenden Teilaufgaben:
 
       \noindent
       \textbf{Bemerkung}:  Die in der Aufgabe angegebene Grammatik ist sowohl eine LR-Grammatik als
-      auch eine LALR-Grammatik.  Letzteres l‰ﬂt sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
+      auch eine LALR-Grammatik.  Letzteres l‰sst sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
       und Ersteres folgt aus der Tatsache, dass jede LALR-Grammatik auch eine LR-Grammatik ist.
 \end{enumerate}
 

--- a/Probe-Klausur/Sommer/loesung-2012.tex
+++ b/Probe-Klausur/Sommer/loesung-2012.tex
@@ -436,7 +436,7 @@ Bearbeiten Sie die folgenden Teilaufgaben:
 
       \noindent
       \textbf{Bemerkung}:  Die in der Aufgabe angegebene Grammatik ist sowohl eine LR-Grammatik als
-      auch eine LALR-Grammatik.  Letzteres l‰ﬂt sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
+      auch eine LALR-Grammatik.  Letzteres l‰sst sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
       und Ersteres folgt aus der Tatsache, dass jede LALR-Grammatik auch eine LR-Grammatik ist.
 \end{enumerate}
 

--- a/Probe-Klausur/Sommer/loesung-sommer-2008.tex
+++ b/Probe-Klausur/Sommer/loesung-sommer-2008.tex
@@ -225,7 +225,7 @@ die Sprache nicht kontextfrei ist.
       \end{enumerate}
       Zum Schluss muss noch gezeigt werden, dass alle Wörter aus 
       $L_1$ tatsächlich von der oben angegebenen Grammatik erzeugt werden.  Das ist aber offensichtlich,
-      denn das Wort $\texttt{a}^{m} \texttt{b}^{n} \texttt{c}^{m+n}$ läßt sich dadurch erzeugen,
+      denn das Wort $\texttt{a}^{m} \texttt{b}^{n} \texttt{c}^{m+n}$ lässt sich dadurch erzeugen,
       dass zunächst $m$ mal die Regel $S \rightarrow \texttt{a} S \texttt{c}$ verwendet wird.
       Darauf folgt eine Anwendung der Regel $S \rightarrow B$ und
       anschließend folgen $n$ Anwendungen der Regel $B \rightarrow \texttt{b} B \texttt{c}$ 

--- a/Probe-Klausur/Sommer/loesung-sommer-2009.tex
+++ b/Probe-Klausur/Sommer/loesung-sommer-2009.tex
@@ -403,7 +403,7 @@ Bearbeiten Sie die folgenden Teilaufgaben:
 
       \noindent
       \textbf{Bemerkung}:  Die in der Aufgabe angegebene Grammatik ist sowohl eine LR-Grammatik als
-      auch eine LALR-Grammatik.  Letzteres l‰ﬂt sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
+      auch eine LALR-Grammatik.  Letzteres l‰sst sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
       und Ersteres folgt aus der Tatsache, dass jede LALR-Grammatik auch eine LR-Grammatik ist.
 \end{enumerate}
 \pagebreak


### PR DESCRIPTION
Ich habe hier ebenfalls die Schreibweisen mit ß durch ss ersetzt, wo nötig. Des Weiteren wurden Wörter wie "das Selbe" durch "dasselbe" ersetzt.
