### PR TITLE
fixed all german umlaute, changed encoding of .tex - files to UTF-8

### DIFF
--- a/Lecture-Notes/antlr.tex
+++ b/Lecture-Notes/antlr.tex
@@ -1,11 +1,11 @@
 \chapter[ANTLR]{ANTLR --- \emph{Another Tool for Language Recognition}}
 Es gibt eine Reihe von Werkzeugen, die in der Lage sind, einen Top-Down-Parser automatisch
 zu erzeugen.  Das Werkzeug, das in meinen Augen am besten ausgereift ist, ist
-\textsc{Antlr} \cite{parr:2012,parr:2013}.  Der Name steht für 
+\textsc{Antlr} \cite{parr:2012,parr:2013}.  Der Name steht f\"ur 
 \emph{\underline{an}other \underline{t}ool for \underline{l}anguage \underline{r}ecognition}\footnote{
-Der Name \textsc{Antlr} kann außerdem auch als Abkürzung für \underline{ant}i \underline{LR} verstanden
-werden. Hier steht ``LR'' für \emph{LR-Parser}.  Dies ist eine Klasse von Parsern, die nicht \emph{top-down} 
-sondern statt dessen \emph{bottom-up} arbeiten.  Wir werden diese Klasse von Parsern später noch ausführlich 
+Der Name \textsc{Antlr} kann au{\ss}erdem auch als Abk\"urzung f\"ur \underline{ant}i \underline{LR} verstanden
+werden. Hier steht ``LR'' f\"ur \emph{LR-Parser}.  Dies ist eine Klasse von Parsern, die nicht \emph{top-down} 
+sondern statt dessen \emph{bottom-up} arbeiten.  Wir werden diese Klasse von Parsern sp\"ater noch ausf\"uhrlich 
 diskutieren.
 }.
 Sie finden dieses Werkzeug im Internet unter der folgenden Adresse 
@@ -16,17 +16,17 @@ Sie finden dieses Werkzeug im Internet unter der folgenden Adresse
 In dieser Vorlesung werden wir die Version 4.5.1 verwenden.  Das Werkzeug \textsc{Antlr} ist in der
 Lage, Parser in den Sprachen \textsl{Java}, \texttt{C\#} und \textsl{Python} zu erzeugen.
 
-Zunächst führen wir \textsc{Antlr} anhand verschiedener Beispiele ein, durch die wir die 
-wichtigsten Eigenschaften des Werkzeugs demonstrieren können.  In späteren Kapiteln werden wir
+Zun\"achst f\"uhren wir \textsc{Antlr} anhand verschiedener Beispiele ein, durch die wir die 
+wichtigsten Eigenschaften des Werkzeugs demonstrieren k\"onnen.  In sp\"ateren Kapiteln werden wir
 die Theorie von Top-Down-Parsern untersuchen.
-\textsc{Antlr} unterstützt die Verwendung von \textsc{Ebnf}-Grammatiken.  
+\textsc{Antlr} unterst\"utzt die Verwendung von \textsc{Ebnf}-Grammatiken.  
 
 
-\section{Ein Parser für arithmetische Ausdrücke}
-Wir beginnen mit einem Parser für arithmetische Ausdrücke, die entsprechend der in
+\section{Ein Parser f\"ur arithmetische Ausdr\"ucke}
+Wir beginnen mit einem Parser f\"ur arithmetische Ausdr\"ucke, die entsprechend der in
 Abbildung \ref{fig:Expr} auf Seite \pageref{fig:Expr} gezeigten Grammatik aufgebaut sind.
-Diese Grammatik lässt sich nun mit Hilfe von \textsc{Antlr} wie in Abbildung
-\ref{fig:Expr.g4} gezeigt implementieren.  Wir diskutieren diese Umsetzung Zeile für Zeile.
+Diese Grammatik l\"asst sich nun mit Hilfe von \textsc{Antlr} wie in Abbildung
+\ref{fig:Expr.g4} gezeigt implementieren.  Wir diskutieren diese Umsetzung Zeile f\"ur Zeile.
 
 \begin{figure}[!ht]
 \centering
@@ -59,18 +59,18 @@ Diese Grammatik lässt sich nun mit Hilfe von \textsc{Antlr} wie in Abbildung
     WS      : [ \v\t\n\r] -> skip;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{\textsc{Antlr}-Spezifikation eines Parsers für arithmetische Ausdrücke.}
+\caption{\textsc{Antlr}-Spezifikation eines Parsers f\"ur arithmetische Ausdr\"ucke.}
 \label{fig:Expr.g4}
 \end{figure}
 
 
 \begin{enumerate}
-\item In Zeile 1 spezifizieren wir mit dem Schlüsselwort \texttt{grammar} den Namen der Grammatik.
+\item In Zeile 1 spezifizieren wir mit dem Schl\"usselwort \texttt{grammar} den Namen der Grammatik.
       In unserem Fall hat die Grammatik also den Namen \texttt{Expr}.  Der Name  der Datei, in der
-      die Grammatik abgespeichert ist, wird aus dem Namen der Grammatik durch Anhängen der Endung ``\texttt{.g4}''
+      die Grammatik abgespeichert ist, wird aus dem Namen der Grammatik durch Anh\"angen der Endung ``\texttt{.g4}''
       gebildet, daher muss die gezeigte Grammatik in einer Datei mit dem Namen ``\texttt{Expr.g4}''
       abgespeichert werden.      
-\item Zeile 3 enthält die Grammatik-Regel für die syntaktische Variable
+\item Zeile 3 enth\"alt die Grammatik-Regel f\"ur die syntaktische Variable
       \textsl{start}.  Die dort gezeigte Grammatik-Regel entspricht mathematisch der Regel
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -79,63 +79,63 @@ Diese Grammatik lässt sich nun mit Hilfe von \textsc{Antlr} wie in Abbildung
       Beachten Sie, dass linke und rechte Seite einer Grammatik-Regel durch einen Doppelpunkt
       getrennt werden.
       Jede Grammatik-Regel wird durch ein Semikolon ``\texttt{;}'' beendet.
-\item Zeile 6 enthält die Grammatik-Regel für die syntaktische Variable
+\item Zeile 6 enth\"alt die Grammatik-Regel f\"ur die syntaktische Variable
       \textsl{expr}.  Zu beachten ist hier, dass die Terminale ``\texttt{+}'' und
-      ``\texttt{-}'' bei \textsc{Antlr} in einfache Anführungszeichen gesetzt werden
-      müssen.  Zusätzlich sehen wir, dass die
+      ``\texttt{-}'' bei \textsc{Antlr} in einfache Anf\"uhrungszeichen gesetzt werden
+      m\"ussen.  Zus\"atzlich sehen wir, dass die
       verschiedenen Grammatikregeln, welche dieselbe syntaktische
       Variable definieren, durch das Zeichen ``\texttt{|}'' von einander getrennt werden.
-\item Entsprechend enthalten die Zeilen 10 und 14 die Grammatik-Regeln für die syntaktischen
+\item Entsprechend enthalten die Zeilen 10 und 14 die Grammatik-Regeln f\"ur die syntaktischen
       Variablen \textsl{product} und \textsl{factor}.  
 
 \item Bei \textsc{Antlr} werden die grammatikalische Struktur und die lexikalische
       Struktur der Eingabe in derselben Datei definiert.  Um syntaktische Variablen und
-      Terminale von einander unterscheiden zu können, wird vereinbart, dass Terminale mit
-      einem Großbuchstaben beginnen,\footnote
+      Terminale von einander unterscheiden zu k\"onnen, wird vereinbart, dass Terminale mit
+      einem Gro{\ss}buchstaben beginnen,\footnote
       {Es ist Konvention, aber nicht vorgeschrieben, dass die 
-      Namen von Terminalen nur aus Großbuchstaben bestehen.}
-      während syntaktische Variablen immer mit einem kleinen
+      Namen von Terminalen nur aus Gro{\ss}buchstaben bestehen.}
+      w\"ahrend syntaktische Variablen immer mit einem kleinen
       Buchstaben beginnen.  
       Daher wissen wir, dass der String ``\texttt{NUMBER}'' in Zeile 8
       ein Terminal bezeichnet.
 \item In Zeile 18 wird die lexikalische Struktur der mit \texttt{NUMBER} bezeichneten
-      Terminale durch einen regulären Ausdruck definiert.  Der reguläre Ausdruck
+      Terminale durch einen regul\"aren Ausdruck definiert.  Der regul\"are Ausdruck
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{'0'|[1-9][0-9]*;}
       \\[0.2cm]
-      steht hier für eine Folge aus Ziffern.  Diese Folge von Ziffern kann nur dann mit der Ziffer
+      steht hier f\"ur eine Folge aus Ziffern.  Diese Folge von Ziffern kann nur dann mit der Ziffer
       ``\texttt{0}'' beginnen, wenn auf die ``\texttt{0}'' keine weitere Ziffer mehr folgt.
 
       Notice that we have to enclose the first occurrence of ``\texttt{0}'' in single quotes.
       On the other hand, we must not put the digits occurring in the square brackets ``\texttt{[}'' 
       and ``\texttt{]}'' in quotes, since these occur inside a range and characters inside a range
       must never be quoted.
-\item Zeile 19 definiert schließlich das Token \texttt{WS}, wobei der Name als Abkürzung
-      für \emph{white space} zu verstehen ist.  Hier werden Leerzeichen, Tabulatoren,
-      Zeilenumbrüche und Wagenrückläufe erkannt.  Nach der lexikalischen Spezifikation
+\item Zeile 19 definiert schlie{\ss}lich das Token \texttt{WS}, wobei der Name als Abk\"urzung
+      f\"ur \emph{white space} zu verstehen ist.  Hier werden Leerzeichen, Tabulatoren,
+      Zeilenumbr\"uche und Wagenr\"uckl\"aufe erkannt.  Nach der lexikalischen Spezifikation
       von \texttt{WS} folgt nach dem Operator ``\texttt{->}'' noch eine semantische Aktion.
-      Die spezielle Aktion ``\texttt{skip}'', die hier ausgeführt wird, wirft das erkannte
+      Die spezielle Aktion ``\texttt{skip}'', die hier ausgef\"uhrt wird, wirft das erkannte
       Token einfach weg, ohne es an den Parser weiterzureichen.  Aus diesem Grunde wird das Token
       \texttt{WS} in den Grammatik-Regeln nicht verwendet, denn der Scanner reicht dieses Token nie
       an den Parser weiter.  Insgesamt hat die Regel in Zeile 19 daher den Effekt, Leerzeichen, Tabulatoren,
-      Zeilenumbrüche und Wagenrückläufe aus der Eingabe zu entfernen.
+      Zeilenumbr\"uche und Wagenr\"uckl\"aufe aus der Eingabe zu entfernen.
 
       In most programming languages, white space has no purpose other than that of separating
       tokens.  Therefore, most \textsc{Antlr} parsers will have a scanner rule that is similar to
       the rule shown in line 19. 
 \end{enumerate}
 Zusammenfassend enthalten die Zeilen 3 -- 16 also die Definition der grammatikalischen
-Struktur, während die Zeilen 18 und 19 die lexikalische Struktur definieren.
+Struktur, w\"ahrend die Zeilen 18 und 19 die lexikalische Struktur definieren.
 
 Um aus der in Abbildung \ref{fig:Expr.g4} gezeigten Grammatik einen Parser erzeugen zu
-können,  übersetzen wir diese Datei mit dem folgenden Befehl:
+k\"onnen,  \"ubersetzen wir diese Datei mit dem folgenden Befehl:
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{java -jar /usr/local/lib/antlr-4.4-complete.jar Expr.g4}
 \\[0.2cm]
-Das setzt natürlich voraus, dass die angegebene Datei \texttt{antlr-4.4-complete.jar} auch
-tatsächlich in dem Verzeichnis \texttt{/usr/local/lib/} zu finden ist.
+Das setzt nat\"urlich voraus, dass die angegebene Datei \texttt{antlr-4.4-complete.jar} auch
+tats\"achlich in dem Verzeichnis \texttt{/usr/local/lib/} zu finden ist.
 \textsc{Antlr} erzeugt die folgenden Dateien:
 \begin{enumerate}
 \item \texttt{ExprParser.java}
@@ -144,11 +144,11 @@ tatsächlich in dem Verzeichnis \texttt{/usr/local/lib/} zu finden ist.
 \item \texttt{ExprLexer.java}
 
       Hier ist der Scanner implementiert.
-\item Zusätzlich werden noch die Dateien \texttt{ExprListener.java},
+\item Zus\"atzlich werden noch die Dateien \texttt{ExprListener.java},
       \texttt{ExprBaseListener.java}, \texttt{Expr.tokens} sowie \texttt{ExprLexer.tokens} erzeugt,
       auf die wir aber nicht weiter eingehen.
 \end{enumerate}
-Um den erzeugten Parser aufrufen zu können, benötigen wir noch ein Treiber-Programm.
+Um den erzeugten Parser aufrufen zu k\"onnen, ben\"otigen wir noch ein Treiber-Programm.
 Abbildung \ref{fig:ParseExpr.java} zeigt ein solches Programm.
 
 \begin{figure}[!ht]
@@ -177,7 +177,7 @@ Abbildung \ref{fig:ParseExpr.java} zeigt ein solches Programm.
     }
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Treiber-Programm für den von \textsc{Antlr} erzeugten Parser.}
+\caption{Treiber-Programm f\"ur den von \textsc{Antlr} erzeugten Parser.}
 \label{fig:ParseExpr.java}
 \end{figure}
 
@@ -191,13 +191,13 @@ Abbildung \ref{fig:ParseExpr.java} zeigt ein solches Programm.
       auf deren Verwendung wir angewiesen sind, definiert.
 \item In Zeile 7 wandeln wir die Standard-Eingabe in einen \texttt{ANTLRInputStream} um,
       der dann in Zeile 8 dazu benutzt werden kann, einen Scanner zu erzeugen. 
-\item Mit Hilfe des  Scanners erzeugen wir in Zeile 9 einen TokenStream und aus diesem können wir 
+\item Mit Hilfe des  Scanners erzeugen wir in Zeile 9 einen TokenStream und aus diesem k\"onnen wir 
       in Zeile 10 einen Parser erzeugen.
 \item Der Aufruf des Parsers erfolgt in Zeile 11, indem wir den Namen der syntaktischen Variable,
-      die wir parsen möchten, als Methode verwenden.
-\item Schließlich geben wir den erzeugten Baum noch als Text aus.
+      die wir parsen m\"ochten, als Methode verwenden.
+\item Schlie{\ss}lich geben wir den erzeugten Baum noch als Text aus.
 \end{enumerate}
-Übersetzen wir dieses Programm, so können wir den Parser durch den Befehl
+\"Ubersetzen wir dieses Programm, so k\"onnen wir den Parser durch den Befehl
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{echo  \symbol{34}1 + 2 * 3 - 4\symbol{34} | java -cp /usr/local/lib/antlr-4.4-complete.jar ParseExpr}
@@ -219,7 +219,7 @@ Datei ``\texttt{.bashrc}'' als
 \hspace*{1.3cm}
 \texttt{alias grun='java org.antlr.v4.runtime.misc.TestRig'}
 \\[0.2cm]
-definiert haben, so können wir den Syntax-Baum auch einfacher mit Hilfe des Befehls
+definiert haben, so k\"onnen wir den Syntax-Baum auch einfacher mit Hilfe des Befehls
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{echo \symbol{34}1 + 2 * 3 - 4\symbol{34} | grun Expr start -gui}
@@ -229,7 +229,7 @@ anzeigen lassen.  Zum Aufruf von \textsc{Antlr} bietet sich der Alias
 \hspace*{1.3cm}
 \texttt{alias antlr4='java -jar /usr/local/lib/antlr-4.4-complete.jar'}
 \\[0.2cm]
-an, denn damit können wir \textsc{Antlr}  dann über den Befehl
+an, denn damit k\"onnen wir \textsc{Antlr}  dann \"uber den Befehl
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{antlr4 Expr.g4}
@@ -245,15 +245,15 @@ aufrufen.
 
 
 
-\section{Ein Parser zur Auswertung arithmetischer Ausdrücke}
-Das letzte Beispiel ist noch nicht sehr spektakulär, weil die vom Parser erkannten
-Ausdrücke nicht ausgewertet werden.  Wir präsentieren jetzt ein komplexeres Beispiel, bei
-dem arithmetische Ausdrücke ausgewertet und die erhaltenen Ergebnisse in Variablen
-gespeichert werden können.  Wir gehen dabei in zwei Schritten vor und präsentieren
-zunächst eine reine Grammatik in \textsc{Antlr}-Notation.  Anschließend erweitern wir diese
-mit Aktionen, in denen die Ausdrücke ausgewertet werden können.
-Abbildung \ref{fig:Program.g4} zeigt diese Grammatik.  Gegenüber der vorher gezeigten
-Grammatik für arithmetische Ausdrücke gibt es die folgenden Änderungen:
+\section{Ein Parser zur Auswertung arithmetischer Ausdr\"ucke}
+Das letzte Beispiel ist noch nicht sehr spektakul\"ar, weil die vom Parser erkannten
+Ausdr\"ucke nicht ausgewertet werden.  Wir pr\"asentieren jetzt ein komplexeres Beispiel, bei
+dem arithmetische Ausdr\"ucke ausgewertet und die erhaltenen Ergebnisse in Variablen
+gespeichert werden k\"onnen.  Wir gehen dabei in zwei Schritten vor und pr\"asentieren
+zun\"achst eine reine Grammatik in \textsc{Antlr}-Notation.  Anschlie{\ss}end erweitern wir diese
+mit Aktionen, in denen die Ausdr\"ucke ausgewertet werden k\"onnen.
+Abbildung \ref{fig:Program.g4} zeigt diese Grammatik.  Gegen\"uber der vorher gezeigten
+Grammatik f\"ur arithmetische Ausdr\"ucke gibt es die folgenden \"Anderungen:
 
 \begin{figure}[!ht]
 \centering
@@ -291,13 +291,13 @@ Grammatik für arithmetische Ausdrücke gibt es die folgenden Änderungen:
     WS : [ \v\t\n\r] -> skip; 
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Eine Grammatik für die Auswertung von Ausdrücken.}
+\caption{Eine Grammatik f\"ur die Auswertung von Ausdr\"ucken.}
 \label{fig:Program.g4}
 \end{figure}
 
 
 \begin{enumerate}
-\item Das Start-Symbol ist jetzt \texttt{program}.  Es steht für eine Liste
+\item Das Start-Symbol ist jetzt \texttt{program}.  Es steht f\"ur eine Liste
       von Zuweisungen der folgenden Form:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -306,29 +306,29 @@ Grammatik für arithmetische Ausdrücke gibt es die folgenden Änderungen:
       Hier ist \texttt{var} der Name einer Variablen und \textsl{expr} ist ein
       arithmetischer Ausdruck.
 \item \texttt{stmnt} bezeichnet eine Zuweisung oder einen einzelnen Ausdruck.
-\item Wir haben die Regeln für die syntaktischen Variablen \textsl{expr} und \textsl{product}
+\item Wir haben die Regeln f\"ur die syntaktischen Variablen \textsl{expr} und \textsl{product}
       vereinfacht, indem wir jeweils die beiden Operatoren ``\texttt{+}'' und ``\texttt{-}'' bzw.
       \squoted{*} und \squoted{/} zusammengefasst haben.
-      Da \textsc{Antlr} \textsc{Ebnf}-Grammatiken unterstützt, können wir für \textsl{expr}
+      Da \textsc{Antlr} \textsc{Ebnf}-Grammatiken unterst\"utzt, k\"onnen wir f\"ur \textsl{expr}
       beispielsweise die Regel
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{expr : expr ('+'|'-') product | product ;}
       \\[0.2cm]
-      verwenden.  Die Grammatik-Regel für \textsl{product} haben wir in ähnlicher Weise
-      geändert.
+      verwenden.  Die Grammatik-Regel f\"ur \textsl{product} haben wir in \"ahnlicher Weise
+      ge\"andert.
 \item Das Terminal \texttt{ID} bezeichnet den Namen einer Variablen.  Ein solcher Name
       besteht aus einer beliebigen Folge von Buchstaben und Ziffern, die mit einem Buchstaben 
       beginnen muss.
 \end{enumerate}
-Mit diesem Parser können wir jetzt zum Beispiel die folgende Eingabe parsen:
+Mit diesem Parser k\"onnen wir jetzt zum Beispiel die folgende Eingabe parsen:
 \begin{verbatim}
     x = 2 * 3; y = 4 * 5; z = x * x + y * y; 
     z / 3;
 \end{verbatim}
 Wir wollen nun einen ganz einfachen Interpreter entwickeln, der eine Folge von solchen
 Zuweisungen auswertet und die bei der Auswertung berechneten Zwischen-Ergebnisse
-in Variablen abspeichert, auf die in folgenden Ausdrücken Bezug genommen werden kann.
+in Variablen abspeichert, auf die in folgenden Ausdr\"ucken Bezug genommen werden kann.
 Weiterhin soll jeder Ausdruck, der keiner Variablen zugewiesen wird, ausgewertet und
 ausgegeben werden.  Abbildung \ref{fig:Program.g4-2} zeigt die Realisierung eines solchen
 Interpreters mit \textsc{Antlr}.
@@ -388,29 +388,29 @@ Interpreters mit \textsc{Antlr}.
 \end{Verbatim} 
 %\$
 \vspace*{-0.3cm}
-\caption{Ein Interpreter zur Auswertung von Ausdrücken.}
+\caption{Ein Interpreter zur Auswertung von Ausdr\"ucken.}
 \label{fig:Program.g4-2}
 \end{figure}
 
 \begin{enumerate}
-\item Da wir die Werte der einzelnen Variablen in einer Tabelle abspeichern müssen,
+\item Da wir die Werte der einzelnen Variablen in einer Tabelle abspeichern m\"ussen,
       importieren wir in den Zeilen 3 -- 5 die Klasse \texttt{java.util.TreeMap}, denn
-      diese Klasse implementiert Tabellen effizient als binäre Bäume.
+      diese Klasse implementiert Tabellen effizient als bin\"are B\"aume.
 
-      Allgemein setzt \textsc{Antlr} all den Code, der durch das Schlüsselwort
+      Allgemein setzt \textsc{Antlr} all den Code, der durch das Schl\"usselwort
       ``\texttt{@header}'' spezifiert wird, an den Anfang der erstellten Parser-Datei.
-\item In den Zeilen 7 -- 9 definieren wir zusätzliche Member-Variablen für die erzeugte
+\item In den Zeilen 7 -- 9 definieren wir zus\"atzliche Member-Variablen f\"ur die erzeugte
       Klasse \texttt{ProgramParser}.  In unserem Fall definieren wir hier die Tabelle, die
-      später die Werte der Variablen enthält, als Abbildung, die Strings ganze Zahlen zuordnet.
+      sp\"ater die Werte der Variablen enth\"alt, als Abbildung, die Strings ganze Zahlen zuordnet.
 
-      Allgemein setzt \textsc{Antlr} all den Code, der durch das Schlüsselwort
+      Allgemein setzt \textsc{Antlr} all den Code, der durch das Schl\"usselwort
       ``\texttt{@members}'' spezifiert wird, an den Anfang der erstellten Parser-Klasse.
-      Dieses Feature kann sowohl zur Definition von zusätzlichen Klassen-Variablen als auch
+      Dieses Feature kann sowohl zur Definition von zus\"atzlichen Klassen-Variablen als auch
       von Methoden verwendet werden.
       
-      Wir reichern nun die Grammatik-Regeln mit Aktionen an, die durchgeführt werden, wenn
+      Wir reichern nun die Grammatik-Regeln mit Aktionen an, die durchgef\"uhrt werden, wenn
       der Parser die entsprechende Grammatik-Regel anwendet.  Die Aktionen werden von der
-      eigentlichen Grammatik-Regel, für die sie angewendet werden sollen, dadurch
+      eigentlichen Grammatik-Regel, f\"ur die sie angewendet werden sollen, dadurch
       abgesetzt, dass sie in den geschweiften Klammern ``\texttt{\{}'' und ``\texttt{\}}''
       eingefasst werden.
 \item Wird vom Parser in Zeile 13 eine Zuweisung der Form $\textsl{var} \;\mathtt{:=}\; \textsl{expr}$
@@ -423,10 +423,10 @@ Interpreters mit \textsc{Antlr}.
       \textsl{stmnt} $\rightarrow$ \texttt{ID} ':=' \textsl{expr} ';'
       \\[0.2cm]
       haben wir einerseits das Token \texttt{ID}, auf dessen Namen wir mit \texttt{\symbol{36}ID.text}
-      zugreifen können, andererseits haben wir die syntaktische Variable \textsl{expr}.
-      Wir werden später dieser syntaktischen Variable die \textsl{Java}-Variable
-      \texttt{result} als Ergebnis-Variable zuordnen, die den zugehörigen Wert enthält.  
-      Dann können wir mit
+      zugreifen k\"onnen, andererseits haben wir die syntaktische Variable \textsl{expr}.
+      Wir werden sp\"ater dieser syntaktischen Variable die \textsl{Java}-Variable
+      \texttt{result} als Ergebnis-Variable zuordnen, die den zugeh\"origen Wert enth\"alt.  
+      Dann k\"onnen wir mit
       \texttt{\symbol{36}expr.result} auf diesen Wert zugreifen.
 
       In Zeile 14 haben wir einen einzelnen arithmetischen Ausdruck, den wir auswerten und ausgeben.
@@ -435,7 +435,7 @@ Interpreters mit \textsc{Antlr}.
       \hspace*{1.3cm}
       \texttt{expr returns [int result]}
       \\[0.2cm]
-      dass die Methode, die eine \textsl{expr} parst, als Ergebnis ein \texttt{int} zurück
+      dass die Methode, die eine \textsl{expr} parst, als Ergebnis ein \texttt{int} zur\"uck
       gibt und dass dieses in der Variable mit dem Namen \texttt{result} abgespeichert wird.
 \item In der Grammatik-Regel
       \\[0.2cm]
@@ -444,35 +444,35 @@ Interpreters mit \textsc{Antlr}.
       \\[0.2cm]
       haben wir in Zeile 18 -- 20 den verschiedenen Auftreten der syntaktischen Variablen
       \texttt{expr} und \texttt{product} die Namen $e$ und $p$ zugeordnet, auf die wir dann in den
-      Aktionen zugreifen können.  In den Aktionen muss diesen Variablen allerdings ein Dollar-Zeichen
+      Aktionen zugreifen k\"onnen.  In den Aktionen muss diesen Variablen allerdings ein Dollar-Zeichen
       vorgestellt werden.
 
       Die Aktionen selber bestehen nun darin, dass wir der Variablen \texttt{result}
       das Ergebnis der jeweiligen Berechnung zuweisen.
 \item In den Zeilen 36 und 37 greifen wir auf die Strings, die den Token
-      \texttt{ID} und \texttt{INT} entsprechen, mit Hilfe der für Token vordefinierten
-      Variable \texttt{text} zurück.  Beachten Sie, dass wir in Zeile 36 den Wert, der zu einer
-      Variablen in der Tabelle \texttt{varTable} gespeichert ist, auslesen und als Ergebnis zurück
+      \texttt{ID} und \texttt{INT} entsprechen, mit Hilfe der f\"ur Token vordefinierten
+      Variable \texttt{text} zur\"uck.  Beachten Sie, dass wir in Zeile 36 den Wert, der zu einer
+      Variablen in der Tabelle \texttt{varTable} gespeichert ist, auslesen und als Ergebnis zur\"uck
       geben. 
 \end{enumerate}
 
-\section{Erzeugung abstrakter Syntax-Bäume}
-Bei der Auswertung arithmetischer Ausdrücke im letzten Abschnitt hatten wir Glück
+\section{Erzeugung abstrakter Syntax-B\"aume}
+Bei der Auswertung arithmetischer Ausdr\"ucke im letzten Abschnitt hatten wir Gl\"uck
 und konnten das Ergebnis eines Ausdrucks unmittelbar mit Hilfe von semantischen Aktionen
-berechnen.  Bei komplexeren Problemen ist es in der Regel erforderlich, zunächst einen
+berechnen.  Bei komplexeren Problemen ist es in der Regel erforderlich, zun\"achst einen
 abstrakten Syntax-Baum zu erzeugen.  Die eigentliche Berechnung findet dann erst nach dem
 Parsen auf dem Syntax-Baum statt.  Wir wollen dieses Verfahren an einem Beispiel
 demonstrieren.  Bei dem Beispiel geht es wieder um die symbolische Differentiation
-arithmetischer Ausdrücke.  Ist beispielsweise der arithmetische Ausdruck 
+arithmetischer Ausdr\"ucke.  Ist beispielsweise der arithmetische Ausdruck 
 \[ x \cdot \ln(x) \]
-gegeben, so findet sich für die Ableitung dieses Ausdrucks nach der Variable $x$ mit Hilfe
+gegeben, so findet sich f\"ur die Ableitung dieses Ausdrucks nach der Variable $x$ mit Hilfe
 der Produkt-Regel das
 Ergebnis 
 \[ 1 \cdot \ln(x) + x \cdot \frac{1}{x}. \]  
-Da die arithmetischen Ausdrücke nun
-zusätzlich zu den Operatoren, welche die vier Grundrechenarten beschreiben, auch noch 
-Funktionszeichen für die Exponential-Funktion und den natürlichen Logarithmus enthalten
-sollen, müssen wir die Grammatik aus dem letzten Abschnitt erweitern.
+Da die arithmetischen Ausdr\"ucke nun
+zus\"atzlich zu den Operatoren, welche die vier Grundrechenarten beschreiben, auch noch 
+Funktionszeichen f\"ur die Exponential-Funktion und den nat\"urlichen Logarithmus enthalten
+sollen, m\"ussen wir die Grammatik aus dem letzten Abschnitt erweitern.
 Abbildung \ref{fig:Expr-exp-ln} zeigt die entsprechend erweiterte EBNF-Grammatik.
 
 \begin{figure}[htbp]
@@ -496,7 +496,7 @@ Abbildung \ref{fig:Expr-exp-ln} zeigt die entsprechend erweiterte EBNF-Grammatik
 
   \end{minipage}}}
   \end{center}
-  \caption{EBNF-Grammatik für arithmetische Ausdrücke mit Exponential-Funktion und Logarithmus.}
+  \caption{EBNF-Grammatik f\"ur arithmetische Ausdr\"ucke mit Exponential-Funktion und Logarithmus.}
   \label{fig:Expr-exp-ln}
 \end{figure}
 
@@ -548,7 +548,7 @@ aus Abbildung \ref{fig:Expr-exp-ln}.
 \begin{enumerate}
 \item In Zeile 3 deklarieren wir durch ``\texttt{returns [Expr result]}'',
       dass beim Erkennen einer \textsl{expr} nun ein Objekt der Klasse \texttt{Expr}
-      zurück gegeben werden soll und dass dieses Objekt über den Namen
+      zur\"uck gegeben werden soll und dass dieses Objekt \"uber den Namen
       \texttt{result} angesprochen werden kann.  Die Klasse \texttt{Expr} ist hier eine abstrakte
       Klasse, von der wir die Klassen
       \begin{enumerate}
@@ -579,7 +579,7 @@ aus Abbildung \ref{fig:Expr-exp-ln}.
             $\mathtt{mLhs} * \mathtt{mRhs}$
             \\[0.2cm]
             interpretiert.
-      \item Zusätzlich gibt es eine Implementierung der Methode \texttt{diff}, in der die
+      \item Zus\"atzlich gibt es eine Implementierung der Methode \texttt{diff}, in der die
             Produkt-Regel umgesetzt wird.
       \item Zur Ausgabe ist weiterhin eine \texttt{toString}-Methode vorhanden.
       \end{enumerate}
@@ -618,9 +618,9 @@ aus Abbildung \ref{fig:Expr-exp-ln}.
 
       
       
-\item In Zeile 4 haben wir zunächst ein Produkt erkannt, dass wir unter der Variable
-      $p$ abspeichern.  Anschließend weisen wir der Variable \texttt{result} dieses
-      Produkt zu.  Falls nun später noch ein ``\texttt{+}''-- oder ``\texttt{-}''
+\item In Zeile 4 haben wir zun\"achst ein Produkt erkannt, dass wir unter der Variable
+      $p$ abspeichern.  Anschlie{\ss}end weisen wir der Variable \texttt{result} dieses
+      Produkt zu.  Falls nun sp\"ater noch ein ``\texttt{+}''-- oder ``\texttt{-}''
       Zeichen gefolgt von einem weiteren Ausdruck gelesen wird, so bauen wir aus dem neu
       gelesenen Ausdruck und dem alten Wert von \texttt{result} den neuen Wert von
       \texttt{result}.  Dies kann mehrmals passieren, da dieser Teil der Grammatik-Regel
@@ -631,7 +631,7 @@ aus Abbildung \ref{fig:Expr-exp-ln}.
       \hspace*{1.3cm}
       $p_1 + p_2 + p_3$
       \\[0.2cm]
-      übersetzt in ein Java-Objekt der Form
+      \"ubersetzt in ein Java-Objekt der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $\texttt{new\ Sum}(\texttt{new\ Sum}(p_1, p_2), p_3))$.       
@@ -639,18 +639,18 @@ aus Abbildung \ref{fig:Expr-exp-ln}.
 \end{enumerate}
 
 Zum Abschluss zeigt Abbildung \ref{fig:Differentiate.java} noch die Einbindung des Parsers.
-Gegenüber dem in Abbildung \ref{fig:ParseExpr.java} gezeigten Treiber gibt es nur einen
+Gegen\"uber dem in Abbildung \ref{fig:ParseExpr.java} gezeigten Treiber gibt es nur einen
 wesentlichen Unterschied: In Zeile 20 wird nun ein Objekt der Klasse \texttt{Expr} erzeugt.
 Beachten Sie, dass der Aufruf
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{parser.expr()}
 \\[0.2cm]
-zunächst ein Objekt der Klasse \texttt{ExprParser.ExprContext} erzeugt.  Bei dieser Klasse handelt
+zun\"achst ein Objekt der Klasse \texttt{ExprParser.ExprContext} erzeugt.  Bei dieser Klasse handelt
 es sich um eine innere Klasse der Klasse \texttt{ExprParser}.  Die innere Klasse
-\texttt{ExprContext} enthält nun eine Member-Variable mit dem Namen \texttt{result}, in der die
+\texttt{ExprContext} enth\"alt nun eine Member-Variable mit dem Namen \texttt{result}, in der die
 eigentliche \texttt{Expr} gespeichert ist.  
-Für dieses Objekt rufen wir dann in Zeile 21 die Methode $\textsl{diff}()$ auf, welche die
+F\"ur dieses Objekt rufen wir dann in Zeile 21 die Methode $\textsl{diff}()$ auf, welche die
 symbolische Ableitung berechnet.
 
 
@@ -690,7 +690,7 @@ symbolische Ableitung berechnet.
     }
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Ein Treiber für den Parser.}
+\caption{Ein Treiber f\"ur den Parser.}
 \label{fig:Differentiate.java}
 \end{figure}
 \pagebreak

--- a/Lecture-Notes/bison.tex
+++ b/Lecture-Notes/bison.tex
@@ -3,25 +3,25 @@ Wir wollen in diesem Kapitels einen ersten Einblick in die Verwendung
 des Parser-Generators \textsl{Bison} geben.  Die von \textsl{Bison} erzeugten Parser sind
 sogenannte \emph{LALR(1)-Parser}.  Die Theorie dieser Parser wurde von Franklin DeRemer
 \cite{deRemer:71,deRemer:82} entwickelt und baut auf der Theorie der \emph{LR(k)-Parser}
-auf, die von Donald Knuth \cite{knuth:65} begründet wurde.  Da diese Theorie wesentlich
-komplexer ist als die Theorie der \emph{LL(1)-Parser}, können wir diese Theorie erst in
-einem später Kapitel darstellen und müssen uns in diesem Kapitel mit einer
-oberflächlichen Betrachtung von \textsl{Bison} begnügen.  Dieses Vorgehen funktioniert,
+auf, die von Donald Knuth \cite{knuth:65} begr\"undet wurde.  Da diese Theorie wesentlich
+komplexer ist als die Theorie der \emph{LL(1)-Parser}, k\"onnen wir diese Theorie erst in
+einem sp\"ater Kapitel darstellen und m\"ussen uns in diesem Kapitel mit einer
+oberfl\"achlichen Betrachtung von \textsl{Bison} begn\"ugen.  Dieses Vorgehen funktioniert,
 weil die Theorie der LALR(1)-Parser solange unwichtig ist, wie die zu parsende Grammatik die
 LALR(1)-Eigenschaft hat.  Bei den einfachen Beispielen, die wir in diesem Kapitel
-betrachten werden, ist dies der Fall.  Für die Praxis ist ein LALR(1)-Parser jedoch oft
-dann zu schwach, wenn die Sprache vorgegeben ist und nicht mehr verändert werden kann.
-Falls Sie selber eine Sprache entwerfen wollen, so können Sie durch das Einfügen geeigneter
-Schlüsselwörter immer erreichen, dass die Sprache die LALR(1)-Eigenschaft besitzt.
+betrachten werden, ist dies der Fall.  F\"ur die Praxis ist ein LALR(1)-Parser jedoch oft
+dann zu schwach, wenn die Sprache vorgegeben ist und nicht mehr ver\"andert werden kann.
+Falls Sie selber eine Sprache entwerfen wollen, so k\"onnen Sie durch das Einf\"ugen geeigneter
+Schl\"usselw\"orter immer erreichen, dass die Sprache die LALR(1)-Eigenschaft besitzt.
 
-Unser Ziel in diesem Abschnitt ist es, für die in Abbildung \ref{fig:expr.gr}
+Unser Ziel in diesem Abschnitt ist es, f\"ur die in Abbildung \ref{fig:expr.gr}
 gezeigte Grammatik einen Parser mit Hilfe des Parser-Generators \textsl{Bison} zu
 erstellen.  Die von \textsl{Bison} erstellten Parser sind wahlweise \texttt{C}- oder
 \texttt{C++}-Programme.  
-Diese Grammatik ermöglicht es, einen arithmetischen Ausdruck auszuwerten und das
-Ergebnis dieser Auswertung einer Variablen zuzuweisen.  Dabei können die
-arithmetischen Ausdrücke neben den Operatoren, die für die Grundrechenarten stehen,
-auch den Aufruf unärer Funktionen, wie der Funktion $\textsl{sqrt}()$ zur Berechnung
+Diese Grammatik erm\"oglicht es, einen arithmetischen Ausdruck auszuwerten und das
+Ergebnis dieser Auswertung einer Variablen zuzuweisen.  Dabei k\"onnen die
+arithmetischen Ausdr\"ucke neben den Operatoren, die f\"ur die Grundrechenarten stehen,
+auch den Aufruf un\"arer Funktionen, wie der Funktion $\textsl{sqrt}()$ zur Berechnung
 der Quadratwurzel, enthalten.  Mit Hilfe dieser Grammatik werden wir einen
 Kommando-Zeilen-basierten Taschenrechner entwickeln.
 
@@ -54,28 +54,28 @@ Kommando-Zeilen-basierten Taschenrechner entwickeln.
 
   \end{minipage}}}
   \end{center}
-\caption{Eine Grammatik für den Taschenrechner.}
+\caption{Eine Grammatik f\"ur den Taschenrechner.}
 \label{fig:expr.gr}
 \end{figure}
 
 
 \section{Der Scanner}
-Bevor mit der Entwicklung des Parsers beginnen können, benötigen wir einen Scanner, der
+Bevor mit der Entwicklung des Parsers beginnen k\"onnen, ben\"otigen wir einen Scanner, der
 die Eingabe in unterschiedliche Token zerlegt.  Der Parser-Generator \textsl{Bison}
 arbeitet mit dem Scanner-Generator \textsl{Flex} zusammen.  Abbildung \ref{fig:calc.l}
-zeigt die \textsl{Flex}-Spezifikation eines Scanners, der für unsere Zwecke geeignet ist.
-Der Scanner gibt vier verschiedene Typen von Token zurück.
+zeigt die \textsl{Flex}-Spezifikation eines Scanners, der f\"ur unsere Zwecke geeignet ist.
+Der Scanner gibt vier verschiedene Typen von Token zur\"uck.
 \begin{enumerate}
-\item Der Typ \texttt{NUMBER} steht für Fließkomma-Zahlen.
-\item Der Typ \texttt{NAME} steht für den Namen einer Variablen.
-\item Der Typ \texttt{FUNC} steht für den Namen einer unären Funktion.
+\item Der Typ \texttt{NUMBER} steht f\"ur Flie{\ss}komma-Zahlen.
+\item Der Typ \texttt{NAME} steht f\"ur den Namen einer Variablen.
+\item Der Typ \texttt{FUNC} steht f\"ur den Namen einer un\"aren Funktion.
 
       Syntaktisch besteht kein Unterschied zwischen \texttt{NAME} und \texttt{FUNC},
       denn beide bestehen aus einer Folge von Buchstaben und Ziffern, die mit einem
       Buchstaben beginnt.  Der Scanner trifft die Unterscheidung anhand einer
       Tabelle, in der alle vordefinierten Funktions-Namen eingetragen sind.
-\item Schließlich gibt es noch die Operator- und Klammer-Symbole, die vom Scanner als
-      einzelne Zeichen zurück gegeben werden.
+\item Schlie{\ss}lich gibt es noch die Operator- und Klammer-Symbole, die vom Scanner als
+      einzelne Zeichen zur\"uck gegeben werden.
 \end{enumerate}
 
 \begin{figure}[!ht]
@@ -118,59 +118,59 @@ Der Scanner gibt vier verschiedene Typen von Token zurück.
     }
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Der Scanner für den Taschenrechner.}
+\caption{Der Scanner f\"ur den Taschenrechner.}
 \label{fig:calc.l}
 \end{figure}
 Wir diskutieren nun die Details der Abbildung \ref{fig:calc.l}.
 \begin{enumerate}
 \item In den Zeilen 2 wird die Dateien ``\texttt{calc.h}'' eingebunden.  Diese Datei
-      enthält die Definition der Daten-Struktur \texttt{SymbolTable}, sowie die
+      enth\"alt die Definition der Daten-Struktur \texttt{SymbolTable}, sowie die
       Deklaration verschiedener Variablen und Konstanten.  Abbildung \ref{fig:calc.h}
-      auf Seite \pageref{fig:calc.l} zeigt diese Datei, die wir später im Detail
+      auf Seite \pageref{fig:calc.l} zeigt diese Datei, die wir sp\"ater im Detail
       diskutieren werden.
-\item Die in Zeile 3 eingebundene Datei ``\texttt{calc.tab.h}'' enthält Makro-Definitionen 
-      für die verschiedenen Token, die vom Scanner zurück gegeben werden.
-      Zusätzlich wird hier die Datenstruktur \texttt{YYSTYPE} definiert.
+\item Die in Zeile 3 eingebundene Datei ``\texttt{calc.tab.h}'' enth\"alt Makro-Definitionen 
+      f\"ur die verschiedenen Token, die vom Scanner zur\"uck gegeben werden.
+      Zus\"atzlich wird hier die Datenstruktur \texttt{YYSTYPE} definiert.
       Diese Datei wird von dem Werkzeug \textsl{Bison} erzeugt.
       Die Datei ist in Abbildung \ref{fig:calc.tab.h} auf Seite \pageref{fig:calc.tab.h} gezeigt.
-      Wir werden diese Datei später genauer analysieren.
-\item Die Zeilen 5 und 6 enthalten zwei reguläre Definitionen.
-      \textsl{Fraction} steht für eine Zahl, die auch einen Fließpunkt enthalten kann
-      und \textsl{Exponent} steht für einen String wie ``\texttt{e+12}'', der später 
-      als Exponent  einer Fließkomma-Zahl interpretiert wird.
-\item Die Regel in Zeile 8 erkennt eine Fließkomma-Zahl.  Die Variable
+      Wir werden diese Datei sp\"ater genauer analysieren.
+\item Die Zeilen 5 und 6 enthalten zwei regul\"are Definitionen.
+      \textsl{Fraction} steht f\"ur eine Zahl, die auch einen Flie{\ss}punkt enthalten kann
+      und \textsl{Exponent} steht f\"ur einen String wie ``\texttt{e+12}'', der sp\"ater 
+      als Exponent  einer Flie{\ss}komma-Zahl interpretiert wird.
+\item Die Regel in Zeile 8 erkennt eine Flie{\ss}komma-Zahl.  Die Variable
       \texttt{yylval} bekommt den Wert dieser Zahl zugewiesen.  Diese Variable 
       ist von dem in der Datei ``\texttt{calc.tab.h}'' definierten Typ
       \texttt{YYSTYPE}.  Dieser Typ ist dort in Zeile 1 -- 4 als \texttt{union}
       von einem \texttt{double} und einem Zeiger auf den Typ \texttt{SymbolTable}
-      definiert, er enthält also wahlweise eine Zahl oder einen Zeiger.
+      definiert, er enth\"alt also wahlweise eine Zahl oder einen Zeiger.
       Da wir jetzt eine Zahl gelesen haben, die wir \texttt{yylval} zuweisen wollen,
-      greifen wir auf \texttt{yylval} über die Notation
+      greifen wir auf \texttt{yylval} \"uber die Notation
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{yylval.value}
       \\[0.2cm]
       zu um dem Compiler zu signalisieren, dass \texttt{yylval} in diesem Fall als
-      Fließkomma-Zahl zu interpretieren ist.
+      Flie{\ss}komma-Zahl zu interpretieren ist.
       
-      Außerdem geben wir das Token \texttt{NUMBER} zurück, da wir ja gerade eine Zahl
+      Au{\ss}erdem geben wir das Token \texttt{NUMBER} zur\"uck, da wir ja gerade eine Zahl
       gelesen haben.  Dieses Token ist in der Datei ``\texttt{calc.tab.h}'' als Makro
-      definiert.  Die Rückgabe eines Tokens haben wir bei unseren bisherigen
+      definiert.  Die R\"uckgabe eines Tokens haben wir bei unseren bisherigen
       \textsl{Flex}-Beispielen noch nicht gesehen, denn bislang hatten wir keinen
       Parser, mit dem \textsl{Flex} kommunizieren musste.  Wenn \textsl{Flex} und
       \textsl{Bison} zusammenarbeiten, dann muss jede \textsl{Flex}-Regel, die ein
-      Token erkannt hat, das später noch vom Parser gebraucht wird, dieses auch
-      zurückgeben.  Ein Token wird dabei durch eine natürliche Zahl dargestellt,
+      Token erkannt hat, das sp\"ater noch vom Parser gebraucht wird, dieses auch
+      zur\"uckgeben.  Ein Token wird dabei durch eine nat\"urliche Zahl dargestellt,
       wobei es folgende Konventionen gibt:
       \begin{enumerate}
       \item Das Token \texttt{EOF} (\emph{end of file}) wird durch die Zahl
-            0 repräsentiert.
+            0 repr\"asentiert.
       \item Token, die nur aus einem einzigen Buchstaben bestehen, werden durch den
-            entsprechenden \textsc{Ascii}-Code repräsentiert.  Beispielsweise hat
+            entsprechenden \textsc{Ascii}-Code repr\"asentiert.  Beispielsweise hat
             das Zeichen `\texttt{*}' den \textsc{Ascii}-Code 42 und damit hat das
             entsprechende Token den Wert 42.
-      \item Alle übrigen Token werden durch natürliche Zahlen größer als 256
-            repräsentiert.   Dabei wird von \textsl{Bison} für jedes dieser Token mittels
+      \item Alle \"ubrigen Token werden durch nat\"urliche Zahlen gr\"o{\ss}er als 256
+            repr\"asentiert.   Dabei wird von \textsl{Bison} f\"ur jedes dieser Token mittels
             ``\texttt{\#define}'' in der Datei \texttt{calc.tab.h} ein Makro definiert, 
             das zu der entsprechenden Zahl expandiert wird.
             
@@ -179,46 +179,46 @@ Wir diskutieren nun die Details der Abbildung \ref{fig:calc.l}.
             die Token \texttt{NAME}, \texttt{FUNC} und \texttt{NUMBER} als die
             Zahlen 257, 258 und 259 definiert.
       \end{enumerate}
-      Generell verläuft die Kommunikation zwischen dem von \textsl{Flex} erzeugten Scanner
-      und dem von \textsl{Bison} erzeugten Parser über drei Kanäle:
+      Generell verl\"auft die Kommunikation zwischen dem von \textsl{Flex} erzeugten Scanner
+      und dem von \textsl{Bison} erzeugten Parser \"uber drei Kan\"ale:
       \begin{enumerate}
-      \item Über den Rückgabewert der Funktion $\textsl{yylex}()$ wird das Token
+      \item \"Uber den R\"uckgabewert der Funktion $\textsl{yylex}()$ wird das Token
             spezifiziert.  Die Funktion $\textsl{yylex}()$ ist die Funktion, die in der
             \textsl{Flex}-Eingabe-Datei spezifiziert wird.  Jeder Aufruf dieser Funktion
-            liefert ein Token zurück.
+            liefert ein Token zur\"uck.
       \item Die Variable \texttt{yylval} speichert den Wert, der diesem Token zugeordnet
             ist.  Diese Variable hat den Typ \textsl{YYSTYPE}.  Dieser Typ wird von 
             \textsl{Bison} in der Datei \texttt{calc.tab.h} definiert.
-      \item Die Variable \texttt{yytext} enthält den Text, der dem letzten gelesenen Token
+      \item Die Variable \texttt{yytext} enth\"alt den Text, der dem letzten gelesenen Token
             entspricht.
       \end{enumerate}
-\item Die Regel in Zeile 12 entfernt Leerzeichen, Tabulatoren und Wagen-Rückläufe.
-      Da der Parser sich nicht für diese Zeichen nicht interessiert, steht hier
-      kein \texttt{return}-Befehl und damit wird auch kein Token zurückgegeben.
-      Daher sucht der  Scanner stattdessen das nächste Token.
+\item Die Regel in Zeile 12 entfernt Leerzeichen, Tabulatoren und Wagen-R\"uckl\"aufe.
+      Da der Parser sich nicht f\"ur diese Zeichen nicht interessiert, steht hier
+      kein \texttt{return}-Befehl und damit wird auch kein Token zur\"uckgegeben.
+      Daher sucht der  Scanner stattdessen das n\"achste Token.
 \item Die Regel in Zeile 13 erkennt Variablen und Funktions-Namen.  Das Problem
       ist hier, dass  Variablen und Funktions-Namen rein syntaktisch gar nicht
-      unterschieden werden können, denn beide bestehen aus Buchstaben und
-      Ziffern. Daher muss der Scanner mit Hilfe der später im Parser
+      unterschieden werden k\"onnen, denn beide bestehen aus Buchstaben und
+      Ziffern. Daher muss der Scanner mit Hilfe der sp\"ater im Parser
       definierten Funktion
       \\[0.2cm]
       \hspace*{1.3cm} \texttt{SymbolTable* lookUpSymbol(char* symbol)}
       \\[0.2cm]
-      überprüfen, ob ein gerade gelesener Name ein Funktions-Name oder aber ein
+      \"uberpr\"ufen, ob ein gerade gelesener Name ein Funktions-Name oder aber ein
       Variablen-Name ist.  Die vordefinierten Funktions-Namen wie ``\texttt{sqrt}'',
       ``\texttt{exp}'', etc.~sind in einer internen Symbol-Tabelle abgespeichert.  In
       dieser Tabelle werden auch die Variablen-Namen abgelegt.  Die Funktion
-      $\textsl{lookUpSymbol}(\textsl{name})$ überprüft für einen gegeben Namen
+      $\textsl{lookUpSymbol}(\textsl{name})$ \"uberpr\"uft f\"ur einen gegeben Namen
       $\textsl{name}$, ob zu diesem 
       Namen in der Tabelle bereits ein Eintrag existiert.  Wenn dies der Fall ist,
-      wird ein Zeiger auf den vorhandenen Eintrag zurückgegeben, ansonsten wird der 
-      String \textsl{name} in der Tabelle als Variablen-Name eingetragen.  Anschließend
-      wird ein Zeiger auf diesen Eintrag zurück gegeben.
+      wird ein Zeiger auf den vorhandenen Eintrag zur\"uckgegeben, ansonsten wird der 
+      String \textsl{name} in der Tabelle als Variablen-Name eingetragen.  Anschlie{\ss}end
+      wird ein Zeiger auf diesen Eintrag zur\"uck gegeben.
       
       Der Zeiger \texttt{sp} zeigt also in Zeile 14 in jedem Fall auf ein Objekt vom Typ
       \texttt{SymbolTable}.  Dieser Datentyp ist in der Datei ``\texttt{calc.h}'' als
-      Alias für ein \texttt{struct} definiert.  Dieser \texttt{struct} hat drei
-      Einträge. 
+      Alias f\"ur ein \texttt{struct} definiert.  Dieser \texttt{struct} hat drei
+      Eintr\"age. 
       \begin{enumerate}
       \item Der erste Eintrag \texttt{name} gibt den Namen der Variablen oder
             der Funktion an.  
@@ -229,9 +229,9 @@ Wir diskutieren nun die Details der Abbildung \ref{fig:calc.l}.
             \\[0.2cm]
             Ist dieser Zeiger von 0 verschieden, so hat der Scanner einen Funktions-Namen 
             erkannt, sonst handelt es sich um einen Variablen-Namen.  Entsprechend wird in
-            Zeile 17 entweder das Token \texttt{FUNC} zurückgegeben oder es wird in Zeile 19
-            das Token \texttt{NAME} zurückgegeben.
-      \item Der dritte Eintrag der \texttt{struct} hat den Namen \texttt{value} und gibt für
+            Zeile 17 entweder das Token \texttt{FUNC} zur\"uckgegeben oder es wird in Zeile 19
+            das Token \texttt{NAME} zur\"uckgegeben.
+      \item Der dritte Eintrag der \texttt{struct} hat den Namen \texttt{value} und gibt f\"ur
             Variablen den momentanen Wert an.
       \end{enumerate}
 \item Zeile 22 erkennt Token, die nur aus einem Zeichen bestehen.  Dies sind die
@@ -239,12 +239,12 @@ Wir diskutieren nun die Details der Abbildung \ref{fig:calc.l}.
       ``\texttt{/}'', die beiden Klammer-Symbole ``\texttt{(}'' und ``\texttt{)}'', das
       Gleichheitszeichen ``\texttt{=}'', das wir als Zuweisungs-Operator verwenden, sowie
       der Zeilen-Umbruch ``\texttt{\symbol{92}n}'', der dem Parser das Ende eines
-      arithmetischen Ausdrucks signalisiert.  Der Scanner gibt in allen diesen Fällen das
-      gelesene \textsc{Ascii}-Zeichen als Token zurück.
+      arithmetischen Ausdrucks signalisiert.  Der Scanner gibt in allen diesen F\"allen das
+      gelesene \textsc{Ascii}-Zeichen als Token zur\"uck.
 \item Am Ende der Scanner-Datei definieren wir die Funktion $\textsl{yyerror}()$, mit
-      der später vom Parser Fehlermeldungen ausgegeben werden können.  Da diese Funktion
+      der sp\"ater vom Parser Fehlermeldungen ausgegeben werden k\"onnen.  Da diese Funktion
       von der Variablen \texttt{yytext} Gebrauch macht, wird die Funktion
-      $\textsl{yyerror}()$ im Scanner definiert.  Die Variable \texttt{yytext} enthält den
+      $\textsl{yyerror}()$ im Scanner definiert.  Die Variable \texttt{yytext} enth\"alt den
       Text des zuletzt vom Scanner erkannten Tokens.
 \end{enumerate}
 
@@ -276,23 +276,23 @@ Wir diskutieren nun die Details der Abbildung \ref{fig:calc.l}.
 \caption{Die Header-Datei ``\texttt{calc.h}''.}
 \label{fig:calc.h}
 \end{figure}
-Die Datei ``\texttt{calc.h}'' definiert Variablen und Funktionen, die später sowohl
+Die Datei ``\texttt{calc.h}'' definiert Variablen und Funktionen, die sp\"ater sowohl
 vom Scanner als auch vom Parser verwendet werden.  
 \begin{enumerate}
-\item Zunächst wird in Zeile 3 -- 7 die \texttt{struct} \textsl{symtab} definiert
-      und der Name \texttt{SymbolTable} wird zum Alias für diese \texttt{struct}
-      erklärt.  Diese \texttt{struct} speichert später die Einträge der
-      Symbol-Tabelle. Diese Einträge sind entweder Variablen-Namen mit dem
+\item Zun\"achst wird in Zeile 3 -- 7 die \texttt{struct} \textsl{symtab} definiert
+      und der Name \texttt{SymbolTable} wird zum Alias f\"ur diese \texttt{struct}
+      erkl\"art.  Diese \texttt{struct} speichert sp\"ater die Eintr\"age der
+      Symbol-Tabelle. Diese Eintr\"age sind entweder Variablen-Namen mit dem
       der Variablen zugeordneten Werten \texttt{value} oder aber Namen von
       Funktionen mit einem Zeiger \texttt{funcPtr} auf diese Funktion.
 \item Die eigentliche Symbol-Tabelle wird dann in Zeile 9 als Feld mit
-      \texttt{NSYMS} Einträgen definiert.  Die Zahl \texttt{NSYMS} ist vorher in
+      \texttt{NSYMS} Eintr\"agen definiert.  Die Zahl \texttt{NSYMS} ist vorher in
       Zeile 1 als 1000 definiert worden.
-\item Schließlich werden noch die beiden Funktionen $\textsl{lookUpSymbol}()$
+\item Schlie{\ss}lich werden noch die beiden Funktionen $\textsl{lookUpSymbol}()$
       und $\textsl{yyerror}()$ deklariert.  Die Definition der Funktion
-      $\textsl{lookUpSymbol}()$ finden wir später in der Datei \texttt{calc.y},
+      $\textsl{lookUpSymbol}()$ finden wir sp\"ater in der Datei \texttt{calc.y},
       die in den Abbildungen \ref{fig:calc.y} und \ref{fig:calc-2.y}
-      gezeigt wird, während wir die Definition der Funktion
+      gezeigt wird, w\"ahrend wir die Definition der Funktion
       $\textsl{yyerror}()$ bereits in dem Scanner \texttt{calc.l} in  Abbildung
       \ref{fig:calc.l} gesehen haben.
 \end{enumerate}
@@ -328,21 +328,21 @@ wenn wir \textsl{Bison} mit der Option ``\texttt{-d}'' wie folgt aufrufen:
 \hspace*{1.3cm}
 \texttt{bison -d calc.y}
 \\[0.2cm]
-(Die Datei \texttt{calc.y} enthält die Definition der Grammatik und wird später besprochen.)
+(Die Datei \texttt{calc.y} enth\"alt die Definition der Grammatik und wird sp\"ater besprochen.)
 Die Datei \texttt{calc.tab.h} definiert die verschiedenen Token und den Typ
-\texttt{YYSTYPE}.  Damit hat es Folgendes auf sich: Jedes Token ist zunächst als eine
-natürliche Zahl definiert.  Zusätzlich wird aber jedem Token noch ein Wert zugeordnet.
+\texttt{YYSTYPE}.  Damit hat es Folgendes auf sich: Jedes Token ist zun\"achst als eine
+nat\"urliche Zahl definiert.  Zus\"atzlich wird aber jedem Token noch ein Wert zugeordnet.
 Dieser Wert wird in der Variablen \texttt{yylval} gespeichert.  Nun ist es so, dass
 unterschiedlichen Token auch unterschiedliche Arten von Werten zugeordnet werden.  So wird
 einem Token vom Typ \texttt{NUMBER} sinnvollerweise ein Wert vom Typ \texttt{double}
 zugeordnet, aber einer Variablen wird statt dessen ein Zeiger auf die Symbol-Tabelle
-zugeordnet.  Dort liegt dann für jede Variablen ein \texttt{struct} und wenn dieser
+zugeordnet.  Dort liegt dann f\"ur jede Variablen ein \texttt{struct} und wenn dieser
 Variablen schon ein Wert zugewiesen wurde, dann ist dieser Wert dort abgelegt.  Da es also
 je nach Art des Tokens verschiedene Werte gibt, wird \texttt{YYSTYPE} als \texttt{union}
 definiert.
 
 \section{Der Parser}
-Jetzt können wir die Spezifikation des Parsers angeben.
+Jetzt k\"onnen wir die Spezifikation des Parsers angeben.
 Generell hat eine \textsl{Bison}-Spezifikation die folgende, an \textsl{Flex}
 angelehnte Struktur: 
 \begin{figure}[!ht]
@@ -366,7 +366,7 @@ angelehnte Struktur:
         \textsl{C-Funktionen}
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Struktur einer Grammatik-Spezifikation für \textsl{Bison}}
+\caption{Struktur einer Grammatik-Spezifikation f\"ur \textsl{Bison}}
 \label{fig:bison}
 \end{figure}
 Die einzelnen Teile sind dabei durch die Interpunktions-Strings
@@ -375,17 +375,17 @@ Die einzelnen Teile sind dabei durch die Interpunktions-Strings
 ``\texttt{\symbol{37}\symbol{37}}''
 getrennt und haben die folgende Bedeutung:
 \begin{enumerate}
-\item Der \emph{Deklarations-Teil} enthält Include-Direktiven, sowie
-      Deklarationen von Funktionen und Variablen.  Dieser Teil wird später wörtlich
-      an den Anfang des für den Parser generierten \texttt{C}-Codes kopiert.
-\item Der \emph{Definitions-Teil} enthält die Definition der Token sowie der Typen 
+\item Der \emph{Deklarations-Teil} enth\"alt Include-Direktiven, sowie
+      Deklarationen von Funktionen und Variablen.  Dieser Teil wird sp\"ater w\"ortlich
+      an den Anfang des f\"ur den Parser generierten \texttt{C}-Codes kopiert.
+\item Der \emph{Definitions-Teil} enth\"alt die Definition der Token sowie der Typen 
       von Nicht-Terminalen.  (Genau wie den verschiedenen Token Werte
-      unterschiedlicher Typen zugeordnet werden können, können auch den
+      unterschiedlicher Typen zugeordnet werden k\"onnen, k\"onnen auch den
       Nicht-Terminalen Werte verschiedener Typen zugeordnet werden.)
-\item Die \emph{Grammatik-Regeln} spezifizieren die Grammatik, für die ein Parser
+\item Die \emph{Grammatik-Regeln} spezifizieren die Grammatik, f\"ur die ein Parser
       erzeugt werden soll.
 \item Die \texttt{C}-Funktionen enthalten die Definition der Funktion $\textsl{main}()$ 
-      sowie die Definitionen weiterer Funktionen, die in Scanner oder Parser benötigt
+      sowie die Definitionen weiterer Funktionen, die in Scanner oder Parser ben\"otigt
       werden.
 \end{enumerate}
 
@@ -445,12 +445,12 @@ getrennt und haben die folgende Bedeutung:
     %%
 \end{Verbatim} 
 \vspace*{-0.3cm}
-\caption{Grammatik-Spezifikation für den Taschenrechner, Teil 1.}
+\caption{Grammatik-Spezifikation f\"ur den Taschenrechner, Teil 1.}
 \label{fig:calc.y}
 \end{figure} %$
 Die Abbildungen \ref{fig:calc.y} und \ref{fig:calc-2.y} zeigen den Inhalt der Datei
 \texttt{calc.y}, die die Grammatik aus Abbildung \ref{fig:expr.gr} in
-\textsl{Bison}-gerechter Form darstellt.  Wir diskutieren zunächst den Deklarations-Teil,
+\textsl{Bison}-gerechter Form darstellt.  Wir diskutieren zun\"achst den Deklarations-Teil,
 den Definitions-Teil und die Grammatik-Spezifikation.
 \begin{enumerate}
 \item Die Zeilen 2 -- 6 binden verschiedene Header-Dateien ein.
@@ -480,9 +480,9 @@ den Definitions-Teil und die Grammatik-Spezifikation.
       \texttt{type <}\textsl{field}\texttt{> }\textsl{NonTerminal}.
 
       Es ist eine Konvention, dass in \textsl{Bison}-Spezifikationen Terminale nur aus
-      Groß-Buchstaben bestehen, während Nicht-Terminale nur aus Klein-Buchstaben aufgebaut
+      Gro{\ss}-Buchstaben bestehen, w\"ahrend Nicht-Terminale nur aus Klein-Buchstaben aufgebaut
       sind.
-\item Die Syntax von Grammatik-Regeln für \textsl{Bison} ist erfreulich kompakt.
+\item Die Syntax von Grammatik-Regeln f\"ur \textsl{Bison} ist erfreulich kompakt.
       Die Grammatik-Regeln 
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -504,7 +504,7 @@ den Definitions-Teil und die Grammatik-Spezifikation.
       \(\;\)  ;
       \end{Verbatim}
       %$
-      Aus dem Pfeil ``$\rightarrow$'' wird also ein Doppelpunkt ``\texttt{:}'' und außerdem
+      Aus dem Pfeil ``$\rightarrow$'' wird also ein Doppelpunkt ``\texttt{:}'' und au{\ss}erdem
       werden die Regeln einer Gruppe durch ein Semikolon abgeschlossen\footnote{
         In den neueren Versionen von \textsl{Bison} ist das Semikolon optional.
         Es ist aber guter Stil, es trotzdem zu verwenden.}.
@@ -512,12 +512,12 @@ den Definitions-Teil und die Grammatik-Spezifikation.
       enthalten.  Dies ist \texttt{C}-Code, der in gescheiften Klammern eingeschlossen
       ist.  Typischerweise stehen solche semantische Optionen am Ende einer Regel.
 \item Zeile 23 behandelt eine Zuweisung.  Falls eine Zuweisung erkannt wurde, muss diese
-      anschließend ausgeführt werden.  Dazu dient die semantische Aktion
+      anschlie{\ss}end ausgef\"uhrt werden.  Dazu dient die semantische Aktion
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{\{ \symbol{36}1->value = \symbol{36}3; \}}
       \\[0.2cm]
-      Um zu verstehen, wie diese semantische Aktion funktioniert, müssen wir wissen, dass die
+      Um zu verstehen, wie diese semantische Aktion funktioniert, m\"ussen wir wissen, dass die
       Terminale und Nicht-Terminal im Rumpf einer Regel mit 1 beginnend durchnummeriert
       werden.  In der Regel
       \\[0.2cm]
@@ -527,15 +527,15 @@ den Definitions-Teil und die Grammatik-Spezifikation.
       bekommt \texttt{NAME} also die Nummer 1, das Token `\texttt{=}' bekommt die Nummer
       2 und das Nicht-Terminal \texttt{arithExpr} bekommt die Nummer 3.  Dem Terminal
       \texttt{NUMBER} und dem Nicht-Terminal \texttt{arithExpr} werden vom Parser Werte
-      zugeordnet.  Auf diese Werte können wir zurück greifen, wenn wir der entsprechenden
+      zugeordnet.  Auf diese Werte k\"onnen wir zur\"uck greifen, wenn wir der entsprechenden
       Nummer, die das Token oder Nicht-Terminal identifiziert, ein Dollar-Zeichen
       ``\texttt{\symbol{36}}'' voranstellen.  Die Variable ``\texttt{\symbol{36}1}''
-      enthält als den Wert, der dem Token \texttt{NAME} zugeordnet ist, während die
+      enth\"alt als den Wert, der dem Token \texttt{NAME} zugeordnet ist, w\"ahrend die
       Variable ``\texttt{\symbol{36}3}'' den Wert des Nicht-Terminals \texttt{arithExpr}
-      enthält.   Dem Token \texttt{NAME} wird ein Zeiger auf die Symbol-Table zugeordnet,
-      während dem Nicht-Terminal \texttt{arithExpr} eine Zahl vom Typ \texttt{double}
+      enth\"alt.   Dem Token \texttt{NAME} wird ein Zeiger auf die Symbol-Table zugeordnet,
+      w\"ahrend dem Nicht-Terminal \texttt{arithExpr} eine Zahl vom Typ \texttt{double}
       zugeordnet ist.  Der Zeiger, der \texttt{NAME} zugeordnet ist, zeigt auf eine
-      Struktur, die ein Feld \texttt{value} enthält und in dieses Feld schreiben wir den
+      Struktur, die ein Feld \texttt{value} enth\"alt und in dieses Feld schreiben wir den
       Wert des geparsten arithmetischen Ausdrucks.
 \item Zeile 27 zeigt exemplarisch die Behandlung einer Addition.  Hier sehen wir, wie der
       Parser die Werte, die den Nicht-Terminalen zugeordnet sind, berechnet.  Der Wert
@@ -595,7 +595,7 @@ den Definitions-Teil und die Grammatik-Spezifikation.
     }
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{\texttt{C}-Funktionen für den Taschenrechner}
+\caption{\texttt{C}-Funktionen f\"ur den Taschenrechner}
 \label{fig:calc-2.y}
 \end{figure}
 
@@ -603,30 +603,30 @@ Abbildung \ref{fig:calc-2.y} zeigt die Implementierung der \texttt{C}-Funktionen
 unserem Parser benutzt werden.
 \begin{enumerate}
 \item Die Funktion $\textsl{lookUpSymbol}()$ bekommt als Argument einen String
-      \texttt{symbol} übergeben.  Dieser String ist entweder der Name einer Variablen oder der
+      \texttt{symbol} \"ubergeben.  Dieser String ist entweder der Name einer Variablen oder der
       Name eine Funktion.  Die in \texttt{calc.h} definierte globale Variable \texttt{symtab}
-      bezeichnet ein Feld von Einträgen, die den Typ \texttt{SymbolTable} haben.  Aufgabe von
+      bezeichnet ein Feld von Eintr\"agen, die den Typ \texttt{SymbolTable} haben.  Aufgabe von
       $\textsl{lookUpSymbol}()$ ist es, den Namen \texttt{symbol} in diesem Feld
-      zu suchen, oder aber aber einen neuen Eintrag für diesen Namen anzulegen.
-      Dazu läuft die
-      \texttt{for}-Schleife in Zeile 8 -- 19 über alle Einträge in dem Feld \texttt{symtab}.
-      Für jeden Eintrag wird geprüft, ob der Name dieses Eintrags mit dem Argument
-      \texttt{symbol} übereinstimmt.  Wenn dies der Fall ist, wird ein Zeiger auf diesen
-      Eintrag zurück gegeben.  Andernfalls überprüfen wir in Zeile 14, ob der
+      zu suchen, oder aber aber einen neuen Eintrag f\"ur diesen Namen anzulegen.
+      Dazu l\"auft die
+      \texttt{for}-Schleife in Zeile 8 -- 19 \"uber alle Eintr\"age in dem Feld \texttt{symtab}.
+      F\"ur jeden Eintrag wird gepr\"uft, ob der Name dieses Eintrags mit dem Argument
+      \texttt{symbol} \"ubereinstimmt.  Wenn dies der Fall ist, wird ein Zeiger auf diesen
+      Eintrag zur\"uck gegeben.  Andernfalls \"uberpr\"ufen wir in Zeile 14, ob der
       entsprechende Eintrag noch unbenutzt ist.  In diesem Fall tragen wir den Namen
       an der entsprechenden Stelle ein und geben einen Zeiger auf den neuen  Eintrag
-      zurück. 
+      zur\"uck. 
 \item Die Funktion $\mathtt{addfunc}$ dient dazu, Funktionen in das Feld \texttt{symtab}
       einzutragen.  Die Funktion $\mathtt{addfunc}$ bekommt dazu den Namen der
       einzutragenden Funktion, sowie einen Zeiger auf die einzutragende Funktion als Argument.
 
-      Zunächst sucht die Funktion durch den Aufruf von \texttt{lookUpSymbol} einen freien
+      Zun\"achst sucht die Funktion durch den Aufruf von \texttt{lookUpSymbol} einen freien
       Platz in der Symbol-Tabelle.  Dort wird dann 
       der Name der Funktion und der Zeiger auf die Funktion eingetragen.
 \item Die Funktion $\mathtt{main}()$ initialsiert die Symbol-Tabelle \texttt{symtab},
       indem sie die vordefinierten Funktionen $\textsl{sqrt}()$, $\textsl{exp}()$ und
-      $\textsl{log}()$ einträgt.  Anschließend wird der Parser durch den Aufruf von 
-      $\textsl{yyparse}()$ gestartet.  Hier könnten wir problemlos auch alle
+      $\textsl{log}()$ eintr\"agt.  Anschlie{\ss}end wird der Parser durch den Aufruf von 
+      $\textsl{yyparse}()$ gestartet.  Hier k\"onnten wir problemlos auch alle
       trigonometrischen Funktionen sowie deren Umkehrfunktionen in die Tabelle eintragen.
 \end{enumerate}
 

--- a/Lecture-Notes/compiler-2.tex
+++ b/Lecture-Notes/compiler-2.tex
@@ -1,8 +1,8 @@
 \section{Darstellung der Assembler-Befehle}
-Die Abbildungen \ref{fig:sum.jas} und \ref{fig:sum.jas-2} zeigen eine mögliche Übersetzung
+Die Abbildungen \ref{fig:sum.jas} und \ref{fig:sum.jas-2} zeigen eine m\"ogliche \"Ubersetzung
 des Programms zur Berechnung der Summe $\sum_{i=1}^n i$ aus Abbildungen \ref{fig:sum.c}
 in Java-Assembler.  Um solche Assembler-Programme innerhalb des Programms darstellen zu
-können, implementieren wir für jeden Java-Assembler-Befehl eine eigene Klasse, die diesen
+k\"onnen, implementieren wir f\"ur jeden Java-Assembler-Befehl eine eigene Klasse, die diesen
 Befehl darstellen kann.   Auch die Deklarationen, wie beispielsweise 
 ``\texttt{.limit}'' oder ``\texttt{.end method}'' werden jeweils durch eine Klasse
 dargestellt.  Abbildung \ref{fig:program.ep-2} zeigt die Spezifikation dieser Klassen.  
@@ -43,7 +43,7 @@ dargestellt.  Abbildung \ref{fig:program.ep-2} zeigt die Spezifikation dieser Kl
     .end method
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Eine Übersetzung des Programms aus Abbildung \ref{fig:sum.c} in
+\caption{Eine \"Ubersetzung des Programms aus Abbildung \ref{fig:sum.c} in
   Java-Assembler, 1. Teil.}
 \label{fig:sum.jas}
 \end{figure}
@@ -88,7 +88,7 @@ dargestellt.  Abbildung \ref{fig:program.ep-2} zeigt die Spezifikation dieser Kl
     .end method
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Übersetzung des Programms aus Abbildung \ref{fig:sum.c} in Java-Assembler, 2. Teil.}
+\caption{\"Ubersetzung des Programms aus Abbildung \ref{fig:sum.c} in Java-Assembler, 2. Teil.}
 \label{fig:sum.jas-2}
 \end{figure}
 
@@ -138,18 +138,18 @@ dargestellt.  Abbildung \ref{fig:program.ep-2} zeigt die Spezifikation dieser Kl
 
 \begin{enumerate}
 \item Wir haben in den  Klassen \texttt{GOTO}, \texttt{IFEQ} und \texttt{IFLT} 
-      das Sprungziel als Zahl dargestellt.  Später wird bei der Ausgabe eines
+      das Sprungziel als Zahl dargestellt.  Sp\"ater wird bei der Ausgabe eines
       Sprungziels diesen Zahlen noch der Buchstabe \qote{l} vorangestellt, so dass das
       Sprungziel als String interpretiert werden kann.
       Um die Generierung von Sprungzielen zu verstehen, betrachten wir die Klasse
       \texttt{LABEL}, die in Abbildung \ref{fig:LABEL.java} gezeigt wird.  Diese Klasse
-      verfügt über die statische Variable \texttt{sLabelCount}, die in Zeile 2 mit 0
+      verf\"ugt \"uber die statische Variable \texttt{sLabelCount}, die in Zeile 2 mit 0
       initialisiert wird.  Der Konstruktor der Klasse \texttt{LABEL} erzeugt bei jedem
       Aufruf ein neues Objekt, dessen Member-Variable \texttt{mLabel} einen nur einmal
       vergebenen Wert hat.  Dies wird dadurch erreicht, dass die statische Variable \texttt{sLabelCount} nach
       jedem Anlegen eines neuen Objektes vom Typ \texttt{LABEL} inkrementiert wird. 
       Dadurch wird sichergestellt, dass zwei verschiedene Objekte der Klasse
-      \texttt{LABEL} später  tatsächlich verschiedene Sprungziele bezeichnen.
+      \texttt{LABEL} sp\"ater  tats\"achlich verschiedene Sprungziele bezeichnen.
 
       Zeile 9 zeigt die Umwandlung eines \texttt{LABEL}-Objektes in einen String, die
       zur Ausgabe der Assembler-Kommandos benutzt wird.  Der eindeutigen Zahl wird
@@ -222,32 +222,32 @@ dargestellt.  Abbildung \ref{fig:program.ep-2} zeigt die Spezifikation dieser Kl
 \pagebreak
 
 \section{Die Code-Erzeugung}
-Nun haben wir alles Material zusammen, um die eigentliche Code-Erzeugung diskutieren zu können.
-Wir gliedern unsere Darstellung, indem wir die Übersetzung arithmetischer Ausdrücke,
-Boole'schen Ausdrücke, Befehle und Funktionen getrennt behandeln.  Wir beginnen damit, dass wir
-zeigen, wie arithmetische Ausdrücke übersetzt werden.
+Nun haben wir alles Material zusammen, um die eigentliche Code-Erzeugung diskutieren zu k\"onnen.
+Wir gliedern unsere Darstellung, indem wir die \"Ubersetzung arithmetischer Ausdr\"ucke,
+Boole'schen Ausdr\"ucke, Befehle und Funktionen getrennt behandeln.  Wir beginnen damit, dass wir
+zeigen, wie arithmetische Ausdr\"ucke \"ubersetzt werden.
 
 
-\subsection{Übersetzung arithmetischer Ausdrücke}
-Die Übersetzung eines arithmetischen Ausdrucks \textsl{expr} soll Code erezeugen, durch dessen
-Ausführung das Ergebnis der Auswertung auf den Stack gelegt wird.  Zu diesem Zweck deklariert
+\subsection{\"Ubersetzung arithmetischer Ausdr\"ucke}
+Die \"Ubersetzung eines arithmetischen Ausdrucks \textsl{expr} soll Code erezeugen, durch dessen
+Ausf\"uhrung das Ergebnis der Auswertung auf den Stack gelegt wird.  Zu diesem Zweck deklariert
 die abstrakte Klasse \texttt{Expr}, die in Abbildung \ref{fig:Expr.java2} gezeigt ist, die Methode
 \[  \texttt{public abstract List<AssemblerCmd> compile(Map<String, Integer> symbolTable);} \]
 die als Ergebnis eine Liste von Assembler-Kommandos erzeugt.  Werden diese Kommandos
-ausgeführt, so liegt anschließend der Wert des Ausdrucks auf dem Stack.
-Bei dem Parameter \texttt{symbolTable}, welcher der Methode \texttt{compile} als Argument übergeben
+ausgef\"uhrt, so liegt anschlie{\ss}end der Wert des Ausdrucks auf dem Stack.
+Bei dem Parameter \texttt{symbolTable}, welcher der Methode \texttt{compile} als Argument \"ubergeben
 wird, handelt es sich um eine Funktion, die jeder Variablen eine eindeutige Position im Stack
 zuordnet, an der diese Variable im Stack gespeichert wird.  Diese Positionen werden bei der
 Deklaration der einzelnen Variablen berechnet.  Die Details dieser Berechnung diskutieren wir, wenn
 wie die Implementierung der Klasse \texttt{Function} diskutieren.
 
-Außerdem deklariert die Klasse \texttt{Expr} noch die Methode \texttt{stackSize}.  Aufgabe dieser
-Methode ist es zu berechnen, wie groß der Stack bei der Auswertung des Ausdrucks maximal werden
-kann. Diese Information benötigen wir um später mit Hilfe der Direktive ``\texttt{.limit stack}''
-die maximale Größe des Stacks spezifizieren zu können.  Dies ist erforderlich, da in \textsl{Java}
-jede Methode angeben muss, wie groß der Stack maximal werden kann.
+Au{\ss}erdem deklariert die Klasse \texttt{Expr} noch die Methode \texttt{stackSize}.  Aufgabe dieser
+Methode ist es zu berechnen, wie gro{\ss} der Stack bei der Auswertung des Ausdrucks maximal werden
+kann. Diese Information ben\"otigen wir um sp\"ater mit Hilfe der Direktive ``\texttt{.limit stack}''
+die maximale Gr\"o{\ss}e des Stacks spezifizieren zu k\"onnen.  Dies ist erforderlich, da in \textsl{Java}
+jede Methode angeben muss, wie gro{\ss} der Stack maximal werden kann.
 
-Im Folgenden betrachten wir die Übersetzung der verschiedenen arithmetischen Ausdrücke der Reihe
+Im Folgenden betrachten wir die \"Ubersetzung der verschiedenen arithmetischen Ausdr\"ucke der Reihe
 nach.
 
 \begin{figure}[!ht]
@@ -271,20 +271,20 @@ nach.
 \label{fig:Expr.java2}
 \end{figure}
 
-\subsubsection{Übersetzung einer Variablen}
+\subsubsection{\"Ubersetzung einer Variablen}
 Um eine Variable $v$ auszuwerten, laden wir diese Variable mit dem Kommando 
 \[  \texttt{iload}\;\; v  \]
 auf den Stack.  Daher hat die Klasse \texttt{Variable} die in Abbildung \ref{fig:Expr:Variable.java}
 gezeigte Form.  Die Klasse Variable verwaltet eine Member-Variable mit dem Namen
 \texttt{mName}, die den Namen der Variablen angibt.  Die Methode $\textsl{compile}()$ legt
-zunächst in Zeile 8 eine neue Liste von Assembler-Kommandos an und erzeugt dann in Zeile
+zun\"achst in Zeile 8 eine neue Liste von Assembler-Kommandos an und erzeugt dann in Zeile
 9 das Assembler-Kommando
 \[ \texttt{iload}\;\;v, \]
-das als einziges Kommando in diese Liste eingefügt wird.  Hierbei ist $v$ die Nummer der Variablen,
-die in der Symbol-Tabelle, die dem Konstruktor als Argument übergeben wird, gespeichert ist.
-Anschließend kann die Liste als Ergebnis zurück gegeben werden.
+das als einziges Kommando in diese Liste eingef\"ugt wird.  Hierbei ist $v$ die Nummer der Variablen,
+die in der Symbol-Tabelle, die dem Konstruktor als Argument \"ubergeben wird, gespeichert ist.
+Anschlie{\ss}end kann die Liste als Ergebnis zur\"uck gegeben werden.
 
-Die Methode \texttt{stackSize} gibt beim Laden einer Variablen  den Wert $1$ zurück, denn es
+Die Methode \texttt{stackSize} gibt beim Laden einer Variablen  den Wert $1$ zur\"uck, denn es
 wird ja nur ein Objekt auf dem Stack abgelegt.
 
 \begin{figure}[!ht]
@@ -319,7 +319,7 @@ wird ja nur ein Objekt auf dem Stack abgelegt.
 \label{fig:Expr:Variable.java}
 \end{figure}
 
-\subsubsection{Übersetzung einer Konstanten}
+\subsubsection{\"Ubersetzung einer Konstanten}
 Eine Konstante $c$ kann mit Hilfe des Befehls
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -364,54 +364,54 @@ Abbildung \ref{fig:Expr:MyNumber.java} zeigt die Implementierung der Klasse
 \texttt{MyNumber}, die eine Konstante darstellt.  Die Konstante selbst wird in der 
 Member-Variablen \texttt{mNumber} gespeichert.  
 Die Methode $\textsl{compile}()$ gibt eine 
-Liste zurück, die den Befehl \texttt{ldc} enthält.
+Liste zur\"uck, die den Befehl \texttt{ldc} enth\"alt.
 
-Die Methode \texttt{stackSize} gibt  den Wert $1$ zurück, den es wird ja nur eine Zahl auf den
+Die Methode \texttt{stackSize} gibt  den Wert $1$ zur\"uck, den es wird ja nur eine Zahl auf den
 Stack gelegt.
 
-\subsubsection{Übersetzung zusammengesetzter Ausdrücke}
+\subsubsection{\"Ubersetzung zusammengesetzter Ausdr\"ucke}
 Um einen Ausdruck der Form
 \[ \textsl{lhs} \quoted{+} \textsl{rhs} \]
-zu übersetzen, muss zunächst Code erzeugt werden, der die Ausdrücke \textsl{lhs} und
-\textsl{rhs} rekursiv übersetzt.  Wird dieser Code ausgeführt, so liegen  auf dem Stack
-anschließend die Werte von \textsl{lhs} und \textsl{rhs}.  Durch den Befehl \texttt{iadd} werden diese
-nun addiert.  Die Übersetzung kann also wie folgt spezifiziert werden:
+zu \"ubersetzen, muss zun\"achst Code erzeugt werden, der die Ausdr\"ucke \textsl{lhs} und
+\textsl{rhs} rekursiv \"ubersetzt.  Wird dieser Code ausgef\"uhrt, so liegen  auf dem Stack
+anschlie{\ss}end die Werte von \textsl{lhs} und \textsl{rhs}.  Durch den Befehl \texttt{iadd} werden diese
+nun addiert.  Die \"Ubersetzung kann also wie folgt spezifiziert werden:
 \[ \textsl{compile}(\textsl{lhs} \quoted{+} \textsl{rhs}) = 
    \textsl{lhs}.\textsl{compile}() + \textsl{rhs}.\textsl{compile}() + [ \texttt{iadd} ],  
 \]
 wobei der Operator ``+'' auf der rechten Seite dieser Gleichung der Verkettung von Listen dient.  Abbildung
-\ref{fig:Expr:Sum.java} zeigt die Umsetzung dieser Überlegung.  
+\ref{fig:Expr:Sum.java} zeigt die Umsetzung dieser \"Uberlegung.  
 
-Bei der Berechnung der Größe des benötigten Stacks gehen wir von folgenden Überlegungen aus:
+Bei der Berechnung der Gr\"o{\ss}e des ben\"otigten Stacks gehen wir von folgenden \"Uberlegungen aus:
 \begin{enumerate}
-\item Zunächst benötigen wir für die Auswertung von \textsl{lhs} einen Stack der Größe
+\item Zun\"achst ben\"otigen wir f\"ur die Auswertung von \textsl{lhs} einen Stack der Gr\"o{\ss}e
       $\textsl{lhs}.\mathtt{stackSize}()$.  Nachdem \textsl{lhs ausgewertet}  worden ist, verbleibt
       aber nur der Wert von \textsl{lhs} auf dem Stack.
-\item Falls wir für die Auswertung von \textsl{rhs} weniger Platz auf dem Stack benötigen als für
-      die Auswertung von \textsl{lhs}, dann reicht insgesamt der Stack aus, der für die Auswertung
+\item Falls wir f\"ur die Auswertung von \textsl{rhs} weniger Platz auf dem Stack ben\"otigen als f\"ur
+      die Auswertung von \textsl{lhs}, dann reicht insgesamt der Stack aus, der f\"ur die Auswertung
       von \textsl{lhs} allokiert worden ist, denn das Ergebnis der Auswertung von \textsl{lhs}
-      benötigt nur eine Speicherstelle und da die Auswertung von \textsl{rhs} nach Voraussetzung
-      weniger Platz auf dem Stack benötigt als die Auswertung von \textsl{lhs} benötigt hat, reicht
+      ben\"otigt nur eine Speicherstelle und da die Auswertung von \textsl{rhs} nach Voraussetzung
+      weniger Platz auf dem Stack ben\"otigt als die Auswertung von \textsl{lhs} ben\"otigt hat, reicht
       der verbleibende Platz auf dem Stack aus um \textsl{rhs} auszuwerten.
 \item Falls die Auswertung von \textsl{rhs} genauso viel oder mehr Platz braucht als die Auswertung von \textsl{lhs},
-      dann muss der Stack insgesamt die Höhe
+      dann muss der Stack insgesamt die H\"ohe
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{rhs}.\texttt{stackSize}() + 1$
       \\[0.2cm]
-      haben, denn wir müssen zusätzlich ja noch das Ergebnis der Auswertung von \textsl{lhs} speichern.
+      haben, denn wir m\"ussen zus\"atzlich ja noch das Ergebnis der Auswertung von \textsl{lhs} speichern.
 \end{enumerate}
-Insgesamt sehen wir, dass die Höhe des Stacks durch die Formel
+Insgesamt sehen wir, dass die H\"ohe des Stacks durch die Formel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\texttt{max}(\textsl{lhs}.\texttt{stackSize}(), \textsl{rhs}.\texttt{stackSize}() + 1)$
 \\[0.2cm]
 gegeben ist.
-Die Übersetzung von Ausdrücken der Form 
+Die \"Ubersetzung von Ausdr\"ucken der Form 
 \[ \textsl{lhs} - \textsl{rhs}, \quad\textsl{lhs} * \textsl{rhs} 
    \quad \mbox{und} \quad\textsl{lhs} / \textsl{rhs} 
 \]
-verläuft nach dem selben Schema.  Statt des Befehls \texttt{iadd} verwenden wir hier die
+verl\"auft nach dem selben Schema.  Statt des Befehls \texttt{iadd} verwenden wir hier die
 entsprechenden Befehle \texttt{isub}, \texttt{imul} und \texttt{idiv}.
 
 
@@ -452,23 +452,23 @@ entsprechenden Befehle \texttt{isub}, \texttt{imul} und \texttt{idiv}.
 
 
 
-\subsubsection{Übersetzung von Funktions-Aufrufen}
-Ein Funktions-Aufruf der Form $f(e_1, \cdots, e_n)$ kann übersetzt werden, indem zunächst die
-Ausdrücke $e_1$, $\cdots$, $e_n$ übersetzt werden.  Anschließend wird dann die Funktion
+\subsubsection{\"Ubersetzung von Funktions-Aufrufen}
+Ein Funktions-Aufruf der Form $f(e_1, \cdots, e_n)$ kann \"ubersetzt werden, indem zun\"achst die
+Ausdr\"ucke $e_1$, $\cdots$, $e_n$ \"ubersetzt werden.  Anschlie{\ss}end wird dann die Funktion
 $f$ mit Hilfe des Kommandos \texttt{invokevirtual} aufgerufen.  
- Damit hat die Übersetzung im Allgemeinen die folgende Form:
+ Damit hat die \"Ubersetzung im Allgemeinen die folgende Form:
 \\[0.2cm]
 $ \textsl{compile}\bigl(f(e_1,\cdots,e_n)\bigr) = 
    \textsl{compile}(e_1) + \cdots + \textsl{compile}(e_n) + [ \texttt{invokevirtual}\; f] 
 $
 \\[0.2cm]
-Allerdings müssen wir noch einen Sonderfall berücksichtigen. Falls es sich bei der Funktion $f$
-um die Funktion \texttt{println}() handelt, so müssen wir vor der eigentlichen Ausgabe
-noch den \texttt{PrintStream} auf den Stack legen, anschließend ist das Argument auszuwerten und zum
-Schluss können wir dann die Methode \texttt{println} aufrufen.  Da die Funktion \texttt{println}
+Allerdings m\"ussen wir noch einen Sonderfall ber\"ucksichtigen. Falls es sich bei der Funktion $f$
+um die Funktion \texttt{println}() handelt, so m\"ussen wir vor der eigentlichen Ausgabe
+noch den \texttt{PrintStream} auf den Stack legen, anschlie{\ss}end ist das Argument auszuwerten und zum
+Schluss k\"onnen wir dann die Methode \texttt{println} aufrufen.  Da die Funktion \texttt{println}
 selber kein Ergebnis berechnet, ist es in diesem Fall erforderlich, einen Dummy-Wert auf dem Stack abzulegen.
-Philosophische Betrachtungen, die über den Rahmen der Vorlesung hinausgehen, legen nahe, hierfür den
-Wert 42 zu wählen. 
+Philosophische Betrachtungen, die \"uber den Rahmen der Vorlesung hinausgehen, legen nahe, hierf\"ur den
+Wert 42 zu w\"ahlen. 
 
 
 \begin{figure}[!ht]
@@ -534,34 +534,34 @@ Wert 42 zu wählen.
 \end{figure}
 
 Abbildung \ref{fig:Expr:FunctionCall.java} zeigt die Implementierung der Klasse
-\texttt{FunctionCall}, die einen Funktions-Aufruf repräsentiert.  Die Klasse hat zwei
+\texttt{FunctionCall}, die einen Funktions-Aufruf repr\"asentiert.  Die Klasse hat zwei
 Member-Variablen.
 \begin{enumerate}
 \item \texttt{mName} ist der Name der aufgerufenen Funktion.
 \item \texttt{mArgs} ist die Liste der Argumente, mit der die Funktion aufgerufen wird.
 \end{enumerate}
-Falls es sich bei der Funktion nicht um die Methode \texttt{println} handelt, werden zunächst alle
+Falls es sich bei der Funktion nicht um die Methode \texttt{println} handelt, werden zun\"achst alle
 Argumente der Funktion ausgewertet und die Ergebnisse dieser Argumente auf dem Stack abgelegt.
-Schließlich wird die Funktion über den Befehl \texttt{invokevirtual} aufgerufen, der durch die
+Schlie{\ss}lich wird die Funktion \"uber den Befehl \texttt{invokevirtual} aufgerufen, der durch die
 Klasse \texttt{INVOKE} dargestellt wird.
 
-Bei der Berechnung der Größe des benötigten Stacks ist zu berücksichtigen, das bei der Auswertung
+Bei der Berechnung der Gr\"o{\ss}e des ben\"otigten Stacks ist zu ber\"ucksichtigen, das bei der Auswertung
 des Arguments mit dem Index $i$ bereits $i$ Werte auf dem Stack liegen.
 \pagebreak
 
 
-\subsection{Übersetzung von Boole'schen Ausdrücken}
-Boole'sche Ausdrücke werden aus Gleichungen und Ungleichungen mit Hilfe der logischen Operatoren
+\subsection{\"Ubersetzung von Boole'schen Ausdr\"ucken}
+Boole'sche Ausdr\"ucke werden aus Gleichungen und Ungleichungen mit Hilfe der logischen Operatoren
 \qote{!} (Negation), \qote{\&\&} (Konjunktion) und \qote{||} (Disjunktion) aufgebaut.
-Wir beginnen mit der Übersetzung von Gleichungen.
+Wir beginnen mit der \"Ubersetzung von Gleichungen.
 
-\subsubsection{Übersetzung von Gleichungen}
+\subsubsection{\"Ubersetzung von Gleichungen}
 Bevor wir eine Gleichung der Form
 \[ \textsl{lhs}\; \texttt{==} \;\textsl{rhs} \]
-übersetzen können, müssen wir uns überlegen, was der erzeugte Code überhaupt erreichen soll.  Eine
+\"ubersetzen k\"onnen, m\"ussen wir uns \"uberlegen, was der erzeugte Code \"uberhaupt erreichen soll.  Eine
 naheliegende Forderung ist, dass am Ende auf dem Stack eine 1 abgelegt wird, wenn die Werte der
-beiden Ausdrücke \textsl{lhs} und \textsl{rhs} übereinstimmen.  Andernfalls soll auf dem Stack eine
-0 abgelegt werden.  Die Übersetzung kann unter diesen Annahmen wie folgt ablaufen:
+beiden Ausdr\"ucke \textsl{lhs} und \textsl{rhs} \"ubereinstimmen.  Andernfalls soll auf dem Stack eine
+0 abgelegt werden.  Die \"Ubersetzung kann unter diesen Annahmen wie folgt ablaufen:
 
 
 \begin{figure}[!ht]
@@ -610,10 +610,10 @@ beiden Ausdrücke \textsl{lhs} und \textsl{rhs} übereinstimmen.  Andernfalls soll
 \end{figure}
 
 \begin{enumerate}
-\item Zunächst erzeugen wir in den Zeilen 10 und 11 den Code zur Auswertung von \textsl{lhs} und \textsl{rhs}.
+\item Zun\"achst erzeugen wir in den Zeilen 10 und 11 den Code zur Auswertung von \textsl{lhs} und \textsl{rhs}.
       Wenn dieser Code abgearbeitet worden ist, liegen die Werte von \textsl{lhs} und \textsl{rhs}
       auf dem Stack.
-\item Anschließend überprüfen wir mit Hilfe des Befehls \texttt{if\_icmpeq}, ob die beiden Werte
+\item Anschlie{\ss}end \"uberpr\"ufen wir mit Hilfe des Befehls \texttt{if\_icmpeq}, ob die beiden Werte
       gleich sind.  Falls dies so ist, legen wir eine 1 auf den Stack, sonst eine 0.
 \end{enumerate}
 Damit hat der erzeugte Code insgesamt die folgende Form
@@ -632,10 +632,10 @@ Damit hat der erzeugte Code insgesamt die folgende Form
 \]
 Diese Gleichung ist in der Methode $\textsl{compile}()$ der Klasse \texttt{Equation} eins zu eins umgesetzt worden.
 
-\subsubsection{Übersetzung von negierten Gleichungen}
-Die Übersetzung einer negierten Gleichung der Form
+\subsubsection{\"Ubersetzung von negierten Gleichungen}
+Die \"Ubersetzung einer negierten Gleichung der Form
 \[ \textsl{lhs}\;\texttt{!=}\;\textsl{rhs} \]
-verläuft analog zu der Übersetzung einer Gleichung, denn wir müssen hier nur den Befehl \texttt{if\_icmpeq}
+verl\"auft analog zu der \"Ubersetzung einer Gleichung, denn wir m\"ussen hier nur den Befehl \texttt{if\_icmpeq}
 durch den Befehl \texttt{if\_icmpne} ersetzen.  Daher lautet die Spezifikation
 \[
    \begin{array}[t]{lcl}
@@ -650,10 +650,10 @@ durch den Befehl \texttt{if\_icmpne} ersetzen.  Daher lautet die Spezifikation
    & + & [ \;\textsl{next}\texttt{:}\; ]  \\
    \end{array}
 \]
-Dies kann wieder eins zu eins umgesetzt werden.  Aus Platzgründen verzichten wir darauf, die Klasse 
-\texttt{Inequation} zu präsentieren.
+Dies kann wieder eins zu eins umgesetzt werden.  Aus Platzgr\"unden verzichten wir darauf, die Klasse 
+\texttt{Inequation} zu pr\"asentieren.
 
-\subsubsection{Übersetzung von Ungleichungen}
+\subsubsection{\"Ubersetzung von Ungleichungen}
 The compilation of inequations of the form 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -666,8 +666,8 @@ is essentially the same as the compilation of equations.  We only have to replac
 command \texttt{if\_icmpeq} with either \texttt{if\_icmple}, \texttt{if\_icmplt},
 \texttt{if\_icmpge}, or \texttt{if\_icmpgt}.
 
-\subsubsection{Übersetzung von Konjunktionen}
-Die Übersetzung einer Konjunktion der Form
+\subsubsection{\"Ubersetzung von Konjunktionen}
+Die \"Ubersetzung einer Konjunktion der Form
 \[ \textsl{lhs}\;\texttt{\&\&}\;\textsl{rhs} \]
 kann wie folgt spezifiziert werden:
 \[
@@ -716,7 +716,7 @@ Abbildung \ref{fig:Expr:Conjunction.java} zeigt die Umsetzung dieser Gleichung.
 \end{figure}
 
 Die obige Umsetzung entspricht allerdings nicht dem, was in der Sprache \texttt{C}
-tatsächlich passiert.  Dort wird die Auswertung eines Ausdrucks der Form 
+tats\"achlich passiert.  Dort wird die Auswertung eines Ausdrucks der Form 
 \\[0.2cm]
 \hspace*{1.3cm}
 \textsl{lhs} \texttt{\&\&} \textsl{rhs}
@@ -726,16 +726,16 @@ von \textsl{lhs} als Ergebnis eine $0$, so wird der Ausdruck \textsl{rhs} nicht 
 ausgewertet.  Falls dieser Ausdruck Seiteneffekte hat, ist das Ergebnis der Auswertung dann
 also verschieden von unserer Auswertung.
 
-Eine Disjunktion wird in analoger Weise auf den Assembler-Befehl \texttt{ior} zurück geführt.
+Eine Disjunktion wird in analoger Weise auf den Assembler-Befehl \texttt{ior} zur\"uck gef\"uhrt.
 
-\subsubsection{Übersetzung von Negationen}
-Die Übersetzung einer Negation der Form $\texttt{!}\textsl{expr}$ kann nicht so geradlinig behandelt
-werden wie die Übersetzung von Konjunktionen und Disjunktionen.  Das liegt daran, dass es einen
+\subsubsection{\"Ubersetzung von Negationen}
+Die \"Ubersetzung einer Negation der Form $\texttt{!}\textsl{expr}$ kann nicht so geradlinig behandelt
+werden wie die \"Ubersetzung von Konjunktionen und Disjunktionen.  Das liegt daran, dass es einen
 Assembler-Befehl \texttt{inot}, der den oben auf dem Stack liegenden Wert negiert, nicht gibt.
-Aber es geht auch anders, denn weil wir die Wahrheitswerte durch 1 und 0 darstellen, können wir die
+Aber es geht auch anders, denn weil wir die Wahrheitswerte durch 1 und 0 darstellen, k\"onnen wir die
 Negation arithmetisch wie folgt spezifizieren:
 \[ \texttt{!}x = 1 - x. \]
-Damit verläuft die Übersetzung einer Negation nach dem folgenden Schema:
+Damit verl\"auft die \"Ubersetzung einer Negation nach dem folgenden Schema:
 \[
    \begin{array}[t]{lcl}
    \textsl{compile}(\texttt{!}\textsl{expr}) & = & 
@@ -791,13 +791,13 @@ grow.  But once the execution of the statement has finished, the stack has to be
 intermediate values that have been put on the stack during the execution of the statement.
 
 
-\subsubsection{Übersetzung von Zuweisungen}
+\subsubsection{\"Ubersetzung von Zuweisungen}
 Wir untersuchen als erstes, wie eine Zuweisung der Form
 \[ x \;\texttt{=}\; \textsl{expr} \]
-übersetzt werden kann.  Die Grundidee besteht darin, zunächst den Ausdruck \textsl{expr}
-auszuwerten.  Als Folge dieser Auswertung wird dann ein Wert auf dem Stack zurück bleiben, der das
-Ergebnis dieser Auswertung ist.  Diesen Wert können wir mit dem Befehl \texttt{istore} unter der
-Variable $x$ abspeichern.  Folglich kann die Übersetzung einer Zuweisung wie folgt spezifiziert werden:
+\"ubersetzt werden kann.  Die Grundidee besteht darin, zun\"achst den Ausdruck \textsl{expr}
+auszuwerten.  Als Folge dieser Auswertung wird dann ein Wert auf dem Stack zur\"uck bleiben, der das
+Ergebnis dieser Auswertung ist.  Diesen Wert k\"onnen wir mit dem Befehl \texttt{istore} unter der
+Variable $x$ abspeichern.  Folglich kann die \"Ubersetzung einer Zuweisung wie folgt spezifiziert werden:
 \[
    \begin{array}[t]{lcl}
    \textsl{compile}(x \texttt{=} \textsl{expr}) & = & 
@@ -842,12 +842,12 @@ Die Idee wird in der in Abbildung \ref{fig:Statement:Assign.java} gezeigten Klas
 \label{fig:Statement:Assign.java}
 \end{figure}
 
-\subsubsection{Übersetzung von Ausdrücken als Befehlen}
-Die Übersetzung eines Ausdrucks, der als Befehl verwendet wird, birgt eine Tücke:
-Die Übersetzung des Ausdrucks selber hinterlässt auf dem Stack einen Wert.  Dieser muss aber bei
-Beendigung des Befehls vom Stack entfernt werden!  Daher müssen wir den Befehl \texttt{pop} an das
-Ende der Liste der Assembler-Befehle anfügen, die bei der Übersetzung des Ausdrucks erzeugt werden.
-Die Übersetzung eines  Befehls vom Typ \texttt{ExprStatement} wird also
+\subsubsection{\"Ubersetzung von Ausdr\"ucken als Befehlen}
+Die \"Ubersetzung eines Ausdrucks, der als Befehl verwendet wird, birgt eine T\"ucke:
+Die \"Ubersetzung des Ausdrucks selber hinterl\"asst auf dem Stack einen Wert.  Dieser muss aber bei
+Beendigung des Befehls vom Stack entfernt werden!  Daher m\"ussen wir den Befehl \texttt{pop} an das
+Ende der Liste der Assembler-Befehle anf\"ugen, die bei der \"Ubersetzung des Ausdrucks erzeugt werden.
+Die \"Ubersetzung eines  Befehls vom Typ \texttt{ExprStatement} wird also
 wie folgt spezifiziert:
 \[
    \begin{array}[t]{lcl}
@@ -857,7 +857,7 @@ wie folgt spezifiziert:
 \end{array}
 \]
 Abbildung \ref{fig:Statement:ExprStatement.java} zeigt die Klasse \texttt{ExprStatement}, in der
-diese Überlegung umgesetzt wird.
+diese \"Uberlegung umgesetzt wird.
 
 \begin{figure}[!ht]
 \centering
@@ -891,14 +891,14 @@ diese Überlegung umgesetzt wird.
 \label{fig:Statement:ExprStatement.java}
 \end{figure}
 
-\subsubsection{Die Übersetzung von Verzweigungs-Befehlen}
-Als nächstes überlegen wir, wie ein Verzweigungs-Befehl der Form
+\subsubsection{Die \"Ubersetzung von Verzweigungs-Befehlen}
+Als n\"achstes \"uberlegen wir, wie ein Verzweigungs-Befehl der Form
 \[ \texttt{if}\; (\textsl{expr})\; \textsl{statement} \]
-übersetzt werden kann.  Offenbar muss zunächst der Boole'sche Ausdruck \textsl{expr} übersetzt
+\"ubersetzt werden kann.  Offenbar muss zun\"achst der Boole'sche Ausdruck \textsl{expr} \"ubersetzt
 werden.  Die Auswertung dieses Ausdrucks wird auf dem Stack entweder eine 1 oder eine 0
 hinterlassen, je nachdem, ob die Bedingung des Tests wahr oder falsch wahr.  Mit dem Befehl
-\texttt{ifeq} können wir überprüfen, welcher dieser beiden Fälle vorliegt.  
-Das führt zu der folgenden Spezifikation:
+\texttt{ifeq} k\"onnen wir \"uberpr\"ufen, welcher dieser beiden F\"alle vorliegt.  
+Das f\"uhrt zu der folgenden Spezifikation:
 \[
    \begin{array}[t]{lcl}
    \textsl{compile}\bigl(\texttt{if}\; (\textsl{expr})\;\textsl{statement}\bigr) & = & 
@@ -951,7 +951,7 @@ Diese Spezifikation ist in der Abbildung \ref{fig:Statement:IfThen.java} umgeset
 
 \vspace*{0.1cm}
 
-Die Übersetzung eines Verzweigungs-Befehls der Form
+Die \"Ubersetzung eines Verzweigungs-Befehls der Form
 \[ \texttt{if}\; (\textsl{expr})\; \textsl{thenStmnt} \;\texttt{else}\; \textsl{elseStmnt} \]
 erfolgt in analoger Art und Weise.  Diesmal lautet die Spezifikation:
 \[
@@ -1012,8 +1012,8 @@ Diese Spezifikation ist in der Abbildung \ref{fig:Statement:IfThenElse.java} umg
 \label{fig:Statement:IfThenElse.java}
 \end{figure}
 
-\subsubsection{Die Übersetzung einer Schleife}
-Die Übersetzung einer \texttt{while}-Schleife der Form
+\subsubsection{Die \"Ubersetzung einer Schleife}
+Die \"Ubersetzung einer \texttt{while}-Schleife der Form
 \[ \texttt{while}\;(\textsl{cond})\;\textsl{statement} \]
 orientiert sich an der folgenden Spezifikation:
 \[
@@ -1070,11 +1070,11 @@ Die Umsetzung dieser Spezifikation sehen Sie in Abbildung \ref{fig:Statement:Whi
 \label{fig:Statement:While.java}
 \end{figure}
 
-\subsubsection{Übersetzen einer Liste von Befehlen}
+\subsubsection{\"Ubersetzen einer Liste von Befehlen}
 Eine in geschweiften Klammern eingeschlossene Liste von Befehlen der Form
 \[ \{ \textsl{stmnt}_1\texttt{;}\; \cdots\; \textsl{stmnt}_n\texttt{;} \} \]
-wird dadurch übersetzt, dass die Listen, die bei der Übersetzung der einzelnen Befehle
-$\textsl{stmnt}_i$ entstehen, aneinander gehängt werden:
+wird dadurch \"ubersetzt, dass die Listen, die bei der \"Ubersetzung der einzelnen Befehle
+$\textsl{stmnt}_i$ entstehen, aneinander geh\"angt werden:
 \[
    \begin{array}[t]{lcl}
    \textsl{compile}\bigl(\texttt{\{} \textsl{stmnt}_1\texttt{;}\; \cdots\; \textsl{stmnt}_n\texttt{;} \texttt{\}}\bigr) & = & 
@@ -1123,15 +1123,15 @@ Diese Idee ist in der Klasse \texttt{Block} realisiert worden. Abbildung
 
 \subsection{Zusammenspiel der Komponenten}
 Nachdem wir jetzt gesehen haben, wie die einzelnen Teile eines Programms in Listen von
-Assembler-Befehlen übersetzt werden können, müssen wir noch zeigen, wie die einzelnen Komponenten
+Assembler-Befehlen \"ubersetzt werden k\"onnen, m\"ussen wir noch zeigen, wie die einzelnen Komponenten
 unseres Programms zusammen spielen.  Dazu sind noch zwei Klassen zu diskutieren:
 \begin{enumerate}
-\item Die Klasse \texttt{Function} repräsentiert die Definition einer Funktion.
-\item Die Klasse \texttt{Program}  repräsentiert das vollständige Programm.
+\item Die Klasse \texttt{Function} repr\"asentiert die Definition einer Funktion.
+\item Die Klasse \texttt{Program}  repr\"asentiert das vollst\"andige Programm.
 \end{enumerate}
 Wir beginnen mit der Diskussion der Klasse \texttt{Function}.  Abbildung
 \ref{fig:Compiler:Function.java} zeigt die Klasse \texttt{Function}, allerdings ohne die
-Implementierung der Methode $\textsl{compile}()$, die wir aus Platzgründen in die Abbildung
+Implementierung der Methode $\textsl{compile}()$, die wir aus Platzgr\"unden in die Abbildung
 \ref{fig:Compiler:Function.compile} ausgelagert haben.
 
 \begin{figure}[!ht]
@@ -1173,14 +1173,14 @@ Implementierung der Methode $\textsl{compile}()$, die wir aus Platzgründen in di
 \end{figure}
 
 
-Die Klasse \texttt{Function} enthält vier Member-Variablen:
+Die Klasse \texttt{Function} enth\"alt vier Member-Variablen:
 \begin{enumerate}
 \item \texttt{mName} gibt den Namen der Funktion an.
 \item \texttt{mParameterList} ist die Liste der Parameter, 
       mit der die Funktion aufgerufen wird.
 \item \texttt{mDeclarations} ist die Liste der Variablen-Deklarationen.
 \item \texttt{mBody} ist die Liste von Befehlen, die im Rumpf der Funktion
-      ausgeführt werden.
+      ausgef\"uhrt werden.
 \end{enumerate}
 
 \begin{figure}[!ht]
@@ -1253,9 +1253,9 @@ Die Klasse \texttt{Function} enthält vier Member-Variablen:
 \pagebreak
 
 Die eigentliche Arbeit der Klasse \texttt{Funktion} wird in der Methode $\textsl{compile}()$, die in Abbildung
-\ref{fig:Compiler:Function.compile} gezeigt ist, geleistet.  Es sind zwei Fälle zu unterscheiden:
+\ref{fig:Compiler:Function.compile} gezeigt ist, geleistet.  Es sind zwei F\"alle zu unterscheiden:
 \begin{enumerate}
-\item Falls die zu übersetzende Funktion den Namen \squoted{main} hat, so hat der erzeugte
+\item Falls die zu \"ubersetzende Funktion den Namen \squoted{main} hat, so hat der erzeugte
       Code die folgende Form:
 
       \begin{Verbatim}[ frame         = lines, 
@@ -1280,8 +1280,8 @@ Die eigentliche Arbeit der Klasse \texttt{Funktion} wird in der Methode $\textsl
        % \$
 
        Hier bezeichnet $l$ die Anzahl der in der Funktion \texttt{main} verwendeten lokalen Variablen,
-       $s$ ist die maximale Höhe des Stacks
-       und $s_1$, $\cdots$, $s_n$ bezeichnen die einzelnen Assemblerbefehle, die bei der Übersetzung
+       $s$ ist die maximale H\"ohe des Stacks
+       und $s_1$, $\cdots$, $s_n$ bezeichnen die einzelnen Assemblerbefehle, die bei der \"Ubersetzung
        des Rumpfes der Funktion erzeugt werden.
 
 \item Andernfalls hat der erzeugte Code die folgende Form:
@@ -1307,12 +1307,12 @@ Die eigentliche Arbeit der Klasse \texttt{Funktion} wird in der Methode $\textsl
        % $
        
        Hier bezeichnet $f$ den Namen der Funktion,  $l$ ist die Anzahl der in der Funktion verwendeten lokalen Variablen
-       und $s$ ist die maximale Höhe des Stacks.
+       und $s$ ist die maximale H\"ohe des Stacks.
        Weiter sind $s_1$, $\cdots$, $s_n$ die Assemblerbefehle des Rumpfes der Funktion.
 \end{enumerate}
 Abbildung \ref{fig:Compiler:Function.stackSize} zeigt die Implementierung der Funktion
-\texttt{stackSize}. Da die einzelnen Befehle nichts auf dem Stack zurück lassen dürfen, ergibt sich
-die Höhe des Stacks, der zur Ausführung aller Befehle benötigt wird, als das Maximum der Höhen der
+\texttt{stackSize}. Da die einzelnen Befehle nichts auf dem Stack zur\"uck lassen d\"urfen, ergibt sich
+die H\"ohe des Stacks, der zur Ausf\"uhrung aller Befehle ben\"otigt wird, als das Maximum der H\"ohen der
 einzelnen Befehle.
 
 
@@ -1378,25 +1378,25 @@ einzelnen Befehle.
 \noindent
 Zum Abschluss diskutieren wir die Klasse \texttt{Program}, die in Abbildung
 \ref{fig:Program.java} gezeigt wird.  Diese Klasse verwaltet in der Member-Variablen
-\texttt{mFunctionList} die Liste aller zu übersetzenden Funktionen.  
+\texttt{mFunctionList} die Liste aller zu \"ubersetzenden Funktionen.  
 
-Bei der Übersetzung der Funktionen ist darauf zu achten, dass zuerst die Funktion $\textsl{main}()$
-übersetzt wird, denn diese muss am Anfang der erzeugten Assembler-Datei stehen.  In der
+Bei der \"Ubersetzung der Funktionen ist darauf zu achten, dass zuerst die Funktion $\textsl{main}()$
+\"ubersetzt wird, denn diese muss am Anfang der erzeugten Assembler-Datei stehen.  In der
 \texttt{C}-Datei ist die Funktion $\textsl{main}()$ aber die letzte Funktion, denn in der Sprache
-\texttt{C} müssen alle Funktionen vor ihrer Verwendung deklariert worden sein.
+\texttt{C} m\"ussen alle Funktionen vor ihrer Verwendung deklariert worden sein.
 
-Wie übersetzen in Zeile 11 als erstes die Funktion $\textsl{main}()$.  Anschließend werden in der
-Schleife, die sich von Zeile 12 bis 15 erstreckt, die restlichen Funktionen übersetzt.
-Der erzeugte Code befindet sich dann in der Liste \texttt{fctList}, die als Ergebnis zurück gegeben wird.  
+Wie \"ubersetzen in Zeile 11 als erstes die Funktion $\textsl{main}()$.  Anschlie{\ss}end werden in der
+Schleife, die sich von Zeile 12 bis 15 erstreckt, die restlichen Funktionen \"ubersetzt.
+Der erzeugte Code befindet sich dann in der Liste \texttt{fctList}, die als Ergebnis zur\"uck gegeben wird.  
 
 
-Übersetzen wir die in Abbildung
+\"Ubersetzen wir die in Abbildung
 \ref{fig:sum.c} gezeigte Funktion zur Berechnung der Summe $\sum_{i=1}^n i$ mit dem Compiler, so
 erhalten wir die in den Abbildungen \ref{fig:sum.jas} und \ref{fig:sum.jas-2} gezeigten
 Assembler-Datei.  Vergleichen wir dieses Programm mit dem in Abbildung \ref{fig:sum.jas} gezeigten
-Assembler-Programm, das wir von Hand geschrieben haben, so fällt auf, dass das vom Compiler erzeugte Programm 
-deutlich länger ist.  Es wäre nun Aufgabe eines Code-Optimierers, den erzeugten Code zu verkürzen
-und dadurch zu optimieren.  Eine Diskussion von Techniken zur Code-Optimierung geht allerdings über
+Assembler-Programm, das wir von Hand geschrieben haben, so f\"allt auf, dass das vom Compiler erzeugte Programm 
+deutlich l\"anger ist.  Es w\"are nun Aufgabe eines Code-Optimierers, den erzeugten Code zu verk\"urzen
+und dadurch zu optimieren.  Eine Diskussion von Techniken zur Code-Optimierung geht allerdings \"uber
 den Rahmen der Vorlesung heraus. 
 
 \exerciseEng

--- a/Lecture-Notes/compiler.tex
+++ b/Lecture-Notes/compiler.tex
@@ -1,32 +1,32 @@
 \chapter{Entwicklung eines einfachen Compilers} 
 In diesem Kapitel konstruieren wir einen Compiler, der ein Fragment der Sprache \texttt{C}
-in \textsl{Java}-Assembler übersetzt.  
-Das von dem Compiler übersetzte Fragment der Sprache \texttt{C} bezeichnen wir als
-\textsl{Integer}-\texttt{C}, denn es steht dort nur der Datentyp \texttt{int} zur Verfügung.
+in \textsl{Java}-Assembler \"ubersetzt.  
+Das von dem Compiler \"ubersetzte Fragment der Sprache \texttt{C} bezeichnen wir als
+\textsl{Integer}-\texttt{C}, denn es steht dort nur der Datentyp \texttt{int} zur Verf\"ugung.
 Ein Compiler besteht prinzipiell aus den folgenden Komponenten:
 \begin{enumerate}
-\item Der Scanner liest die zu übersetzende Datei ein und zerlegt diese in eine Folge von Token.
+\item Der Scanner liest die zu \"ubersetzende Datei ein und zerlegt diese in eine Folge von Token.
       
       Wir werden unseren Scanner mit Hilfe des Werkzeugs \textsl{JFlex} entwickeln.
 \item Der Parser liest die Folge von Token und produziert als Ergebnis einen abstrakten Syntax-Baum.
 
       Wir werden den Parser mit Hilfe von \textsc{Cup} generieren.
-\item Der Typ-Checker überprüft den abstrakten Syntax-Baum auf Typ-Fehler.
+\item Der Typ-Checker \"uberpr\"uft den abstrakten Syntax-Baum auf Typ-Fehler.
 
-      Da die von uns übersetzte Sprache nur einen einzelnen Datentyp enthält, erübrigt
-      sich diese Phase für den von uns entwickelten Compiler.
-\item In realen Compilern erfolgt nun eine \emph{Optimierungsphase}, die wir aus Zeitgründen aber nicht betrachten.
-\item Der Code-Generator übersetzt schließlich den Parse-Baum in eine Folge von
+      Da die von uns \"ubersetzte Sprache nur einen einzelnen Datentyp enth\"alt, er\"ubrigt
+      sich diese Phase f\"ur den von uns entwickelten Compiler.
+\item In realen Compilern erfolgt nun eine \emph{Optimierungsphase}, die wir aus Zeitgr\"unden aber nicht betrachten.
+\item Der Code-Generator \"ubersetzt schlie{\ss}lich den Parse-Baum in eine Folge von
       \textsc{Java}-Assembler-Befehlen.  
 \end{enumerate}
 Bei unseren Compiler sind wir an dieser Stelle schon fertig.  Bei Compilern, deren Zielcode ein
-\textsc{Risc}-Assembler-Programm ist, wird normalerweise zunächst auch ein Code erzeugt, der dem
-\textsc{Jvm}-Code ähnelt.  Ein solcher Code wird als \emph{Zwischen-Code} bezeichnet.  Es bleibt
-dann die Aufgabe eines sogenannten \emph{Backends}, daraus ein Assembler-Programm für einen gegebene
-Prozessor-Architektur zur erzeugen.  Die schwierigste Aufgabe besteht hier darin, für die
-verwendeten Variablen eine Register-Zuordnung zu finden, bei der möglichst alle Variablen in
-Registern vorgehalten werden können.  
-Aus Zeitgründen können wir das Thema der Register-Zuordnung in dieser Vorlesung nicht behandeln.
+\textsc{Risc}-Assembler-Programm ist, wird normalerweise zun\"achst auch ein Code erzeugt, der dem
+\textsc{Jvm}-Code \"ahnelt.  Ein solcher Code wird als \emph{Zwischen-Code} bezeichnet.  Es bleibt
+dann die Aufgabe eines sogenannten \emph{Backends}, daraus ein Assembler-Programm f\"ur einen gegebene
+Prozessor-Architektur zur erzeugen.  Die schwierigste Aufgabe besteht hier darin, f\"ur die
+verwendeten Variablen eine Register-Zuordnung zu finden, bei der m\"oglichst alle Variablen in
+Registern vorgehalten werden k\"onnen.  
+Aus Zeitgr\"unden k\"onnen wir das Thema der Register-Zuordnung in dieser Vorlesung nicht behandeln.
 % Dieses Thema ist allerdings so komplex, dass wir es in einem separaten Kapitel diskutieren.
 
 \section{Die Programmiersprache \textsl{Integer}-\texttt{C}}
@@ -58,43 +58,43 @@ Aus Zeitgründen können wir das Thema der Register-Zuordnung in dieser Vorlesung 
 
   \end{minipage}
   \end{center}
-  \caption{Eine \textsc{Ebnf}-Grammatik für \textsl{Integer}-\textsc{C}}
+  \caption{Eine \textsc{Ebnf}-Grammatik f\"ur \textsl{Integer}-\textsc{C}}
 \label{fig:compiler.cup}
 \end{figure}
 
 \noindent
-Wir stellen nun die Sprache \textsl{Integer}-\texttt{C} vor, die unser Compiler übersetzen
+Wir stellen nun die Sprache \textsl{Integer}-\texttt{C} vor, die unser Compiler \"ubersetzen
 soll.  In diesem Zusammenhang sprechen wir auch von der \emph{Quellsprache} unseres Compilers.
 Abbildung \ref{fig:compiler.cup} zeigt die Grammatik der Quellsprache in 
 erweiterter Backus-Naur-Form (\textsc{Ebnf}). 
-Die Grammatik für \textsl{Integer}-\texttt{C} verwendet die folgenden beiden Terminale:
+Die Grammatik f\"ur \textsl{Integer}-\texttt{C} verwendet die folgenden beiden Terminale:
 \begin{enumerate}
-\item \textsc{Id} steht für eine Folge von Ziffern, Buchstaben und dem Unterstrich, die 
+\item \textsc{Id} steht f\"ur eine Folge von Ziffern, Buchstaben und dem Unterstrich, die 
       mit einem Buchstaben beginnt.  Eine \textsc{Id} bezeichnet entweder eine Variable oder
       den Namen einer Funktion.
-\item \textsc{Number} steht für eine Folge von Ziffern, die als Dezimalzahl interpretiert wird.
+\item \textsc{Number} steht f\"ur eine Folge von Ziffern, die als Dezimalzahl interpretiert wird.
 \end{enumerate}
 Nach der oben angegebenen Grammatik ist ein Programm eine Liste von Funktionen.
 Eine Funktion besteht aus der Deklaration der Signatur, worauf in geschweiften Klammern
 eine Liste von Deklarationen (\textsl{decl}) und Befehlen (\textsl{stmt}) folgt.  Jeder Befehl wird
 durch ein Semikolon abgeschlossen.  Der Aufbau der einzelnen Befehle ist dann
-ähnlich wie bei der Sprache \textsc{Sl}, für die wir im Kapitel \ref{chapter:interpreter}
+\"ahnlich wie bei der Sprache \textsc{Sl}, f\"ur die wir im Kapitel \ref{chapter:interpreter}
 einen Interpreter entwickelt haben.
 Die in Abbildung \ref{fig:compiler.cup} gezeigte Grammatik ist mehrdeutig:
 \begin{enumerate}
 \item Die Grammatik hat das \emph{Dangling-Else-Problem}.
 
       Da wir im Kapitel \ref{chapter:cup} bereits gesehen haben, wie dieses Problem
-      professionell gelöst werden kann, nehme ich mir hier die Freiheit, \textsc{Cup} mit der Option
+      professionell gel\"ost werden kann, nehme ich mir hier die Freiheit, \textsc{Cup} mit der Option
       \\[0.2cm]
       \hspace*{1.3cm}
       ``\texttt{-expect 1}
       \\[0.2cm]
-      aufzurufen und dadurch die Fehlermeldung zu unterdrücken, denn wir hatten ja bereits gesehen, dass
+      aufzurufen und dadurch die Fehlermeldung zu unterdr\"ucken, denn wir hatten ja bereits gesehen, dass
       \textsc{Cup} per default den durch die Mehrdeutigkeit entstehenden Shift-Reduce-Konflikt in unserem
-      Sinne auflöst. 
-\item Für die bei arithmetischen und Boole'schen Ausdrücken verwendeten Operatoren
-      müssen Präzedenzen festgelegt werden.
+      Sinne aufl\"ost. 
+\item F\"ur die bei arithmetischen und Boole'schen Ausdr\"ucken verwendeten Operatoren
+      m\"ussen Pr\"azedenzen festgelegt werden.
 \end{enumerate}
 
 \begin{figure}[!ht]
@@ -207,7 +207,7 @@ discuss this scanner in more detail.
     "/*" ~"*/"            { /* skip multi  line comments */ }   
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Der Scanner für \textsl{Integer}-\texttt{C}}
+\caption{Der Scanner f\"ur \textsl{Integer}-\texttt{C}}
 \label{fig:compiler.jflex}
 \end{figure}
 

--- a/Lecture-Notes/cup.tex
+++ b/Lecture-Notes/cup.tex
@@ -1,12 +1,12 @@
 \chapter{Der Parser-Generator \textsc{Cup} \label{chapter:cup}}
-LALR-Parser erlauben es, die Grammatiken vieler Programmiersprachen in natürlicher Weise
+LALR-Parser erlauben es, die Grammatiken vieler Programmiersprachen in nat\"urlicher Weise
 zu parsen.  Da die meisten von Ihnen in der Praxis vermutlich mit \textsl{Java} arbeiten, 
-möchte ich Ihnen in diesem Kapitel einen LALR-Parser-Generator vorstellen, der einen Parser für die
+m\"ochte ich Ihnen in diesem Kapitel einen LALR-Parser-Generator vorstellen, der einen Parser f\"ur die
 Programmiersprache \textsl{Java} erzeugt.  Dieses Kapitel gibt daher eine
-Einführung in die Verwendung des Parser-Generators \textsc{Cup} \cite{hudson:1999}, der auch
+Einf\"uhrung in die Verwendung des Parser-Generators \textsc{Cup} \cite{hudson:1999}, der auch
 unter dem Namen \textsl{JavaCup} bekannt ist.
 \textsc{Cup} selber ist nur ein Parser-Generator.  Da wir
-zusätzlich einen Scanner benötigen, werden wir diesen in unseren Beispielen von \textsl{JFlex}
+zus\"atzlich einen Scanner ben\"otigen, werden wir diesen in unseren Beispielen von \textsl{JFlex}
 erzeugen lassen.  Wir werden die Version 0.11b des Parser-Generators \textsc{Cup} 
 verwenden.  Sie finden diese Version im Netz unter 
 \\[0.2cm]
@@ -16,26 +16,26 @@ verwenden.  Sie finden diese Version im Netz unter
 Sie finden dort eine komprimierte ``\texttt{.tar}''-Datei, in der sich zwei
 ``\texttt{.jar}''-Dateien befinden.
 \begin{enumerate}
-\item Die Datei \texttt{java-cup-11b.jar} beinhaltet das ausführbare Programm.
-\item Die Datei \texttt{java-cup-11b-runtime.jar} enthält die Klassen, die Sie beim Übersetzen des
-      von \textsc{Cup} erzeugten Parsers benötigen.
+\item Die Datei \texttt{java-cup-11b.jar} beinhaltet das ausf\"uhrbare Programm.
+\item Die Datei \texttt{java-cup-11b-runtime.jar} enth\"alt die Klassen, die Sie beim \"Ubersetzen des
+      von \textsc{Cup} erzeugten Parsers ben\"otigen.
 \end{enumerate}
 
-\section{Spezifikation einer Grammatik für  \textsc{Cup}}
+\section{Spezifikation einer Grammatik f\"ur  \textsc{Cup}}
 Eine \textsc{Cup}-Spezifikation besteht aus vier Teilen.
 \begin{enumerate}
-\item Der erste Teil enthält eine (optionale) Paket-Deklaration sowie die benötigten
-      Import-Deklarationen.  Außerdem können wir hier den Namen der Klasse spezifizieren, die den
-      von \textsc{Cup} erzeugten Parser enthält.
+\item Der erste Teil enth\"alt eine (optionale) Paket-Deklaration sowie die ben\"otigten
+      Import-Deklarationen.  Au{\ss}erdem k\"onnen wir hier den Namen der Klasse spezifizieren, die den
+      von \textsc{Cup} erzeugten Parser enth\"alt.
 \item Der zweite Teil deklariert die verwendeten Symbole.  Hier werden also die Terminale
       und die syntaktischen Variablen spezifiziert.
-\item Der dritte Teil ist wieder optional und spezifiziert die Präzedenzen und Assoziativitäten 
+\item Der dritte Teil ist wieder optional und spezifiziert die Pr\"azedenzen und Assoziativit\"aten 
       der verwendeten Operator-Symbolen.
-\item Der vierte Teil enthält die Grammatik-Regeln.
+\item Der vierte Teil enth\"alt die Grammatik-Regeln.
 \end{enumerate}
 Abbildung \ref{fig:calc.cup} auf Seite \pageref{fig:calc.cup} zeigt eine \textsl{Cup}-Spezifikation,
-mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
-\textsl{Cup}-Spezifikation sind die Schlüsselwörter unterstrichen.
+mit deren Hilfe arithmetische Ausdr\"ucke ausgewertet werden k\"onnen.  In dieser
+\textsl{Cup}-Spezifikation sind die Schl\"usselw\"orter unterstrichen.
 
 \begin{figure}[!ht]
 \centering
@@ -84,24 +84,24 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
           ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{\textsc{Cup}-Spezifikation eines Parsers für arithmetische Ausdrücke}
+\caption{\textsc{Cup}-Spezifikation eines Parsers f\"ur arithmetische Ausdr\"ucke}
 \label{fig:calc.cup}
 \end{figure}
 
 \begin{enumerate}
-\item Die gezeigte \textsc{Cup}-Spezifikation enthält keine Paket-Deklarationen.
+\item Die gezeigte \textsc{Cup}-Spezifikation enth\"alt keine Paket-Deklarationen.
 \item Die Spezifikation beginnt in Zeile 1 mit dem Import der Klassen von
       \texttt{java\_cup.runtime}.  Dieses Paket muss immer importiert werden, denn dort wird
       beispielsweise die Klasse \texttt{Symbol} 
-      definiert, die wir auch später noch in dem in Abbildung \ref{fig:calc.jflex} gezeigten Scanner
+      definiert, die wir auch sp\"ater noch in dem in Abbildung \ref{fig:calc.jflex} gezeigten Scanner
       verwenden werden.
 
-      Würden noch weitere Pakete benötigt, so könnten diese hier ebenfalls importiert werden.
+      W\"urden noch weitere Pakete ben\"otigt, so k\"onnten diese hier ebenfalls importiert werden.
 \item In Zeile 2 spezifizieren wir, dass die erzeugte Parser-Klasse den Namen \texttt{ExprParser}
       haben soll.
 \item In den Zeilen 4 bis 6 werden die Terminale deklariert.  Es gibt zwei Arten von Terminalen:
       \begin{enumerate}
-      \item Terminale, die keinen zusätzlichen Wert haben.  Hierbei handelt es sich 
+      \item Terminale, die keinen zus\"atzlichen Wert haben.  Hierbei handelt es sich 
             um die Operator-Symbole, die beiden Klammer-Symbole und das Semikolon.  Die Syntax zur
             Deklaration solcher Terminale ist 
             \\[0.2cm]
@@ -111,7 +111,7 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
             Durch diese Deklaration werden die Symbole $t_1$, $\cdots$, $t_n$ als Terminale
             deklariert.
       \item Terminale, denen ein Wert zugeordnet ist.  In diesem Fall muss der Typ
-            dieses Wertes deklariert werden.  Die Syntax dafür ist 
+            dieses Wertes deklariert werden.  Die Syntax daf\"ur ist 
             \\[0.2cm]
             \hspace*{1.3cm}
             \texttt{terminal} \textsl{type} $t_1$, $\cdots$, $t_n$;
@@ -120,28 +120,28 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
             zugeordnet wird.
             
             Bei der Spezifikation eines Typs ist es wichtig zu beachten, dass zwischen dem Typ und
-            dem ersten Terminal kein Komma steht, denn sonst würde der Typ ebenfalls als Terminal
+            dem ersten Terminal kein Komma steht, denn sonst w\"urde der Typ ebenfalls als Terminal
             interpretiert.  
             
             In Zeile 6 spezifizieren wir beispielsweise, dass dem Terminal \texttt{NUMBER} ein
             Wert vom Typ \texttt{Integer} zugeordnet ist.  Damit das funktioniert, muss der Scanner
             jedes Mal,
-            wenn er ein Terminal \texttt{NUMBER} an den Parser zurück geben soll, ein Objekt der
+            wenn er ein Terminal \texttt{NUMBER} an den Parser zur\"uck geben soll, ein Objekt der
             Klasse  \texttt{Symbol} erzeugen, dass die entsprechende Zahl als Wert beinhaltet.
             In dem auf Seite \pageref{fig:calc.jflex}
             in Abbildung \ref{fig:calc.jflex} gezeigten Scanner geschieht dies beispielsweise
             in dadurch, dass mit Hilfe der Methode $\texttt{symbol}()$ der Konstruktor der
-            Klasse \texttt{Symbol} aufgerufen wird, dem als zusätzliches Argument der Wert der Zahl
-            übergeben wird.
+            Klasse \texttt{Symbol} aufgerufen wird, dem als zus\"atzliches Argument der Wert der Zahl
+            \"ubergeben wird.
       \end{enumerate}
 \item In den Zeilen 8 und 9 werden die syntaktischen Variablen, die wir auch als Nicht-Terminale
       bezeichnen, deklariert.  Die Syntax ist dieselbe wie bei der Deklaration der Terminale, nur
-      dass wir jetzt das Schlüsselwort ``\texttt{nonterminal}'' an Stelle von ``\texttt{terminal}''
-      verwenden.  Auch hier gibt es wieder zwei Fälle:  Den in Zeile 8 deklarierten Nicht-Terminalen
-      \texttt{expr\_list} und \texttt{expr\_part} wird kein Wert zugeordnet, während wir dem
+      dass wir jetzt das Schl\"usselwort ``\texttt{nonterminal}'' an Stelle von ``\texttt{terminal}''
+      verwenden.  Auch hier gibt es wieder zwei F\"alle:  Den in Zeile 8 deklarierten Nicht-Terminalen
+      \texttt{expr\_list} und \texttt{expr\_part} wird kein Wert zugeordnet, w\"ahrend wir dem
       Nicht-Terminal \textsl{expr} einen Wert vom Typ \texttt{Integer} zuordnen, der sich aus der
       Auswertung des entsprechenden arithmetischen Ausdrucks ergibt.
-\item Der letzte Teil einer \textsc{Cup}-Grammatik-Spezifikation enthält die Grammatik-Regeln. 
+\item Der letzte Teil einer \textsc{Cup}-Grammatik-Spezifikation enth\"alt die Grammatik-Regeln. 
       Die allgemeine Form einer \textsc{Cup}-Grammatik-Regel ist
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -156,8 +156,8 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
       \item \textsl{body}$_i$ ist der Rumpf der $i$-ten Grammatik-Regel, der aus einer
             Liste von Terminalen und syntaktischen Variablen besteht.
       \item \textsl{action}$_i$ ist eine durch Semikolons getrennte Folge von \textsl{Java}-Anweisungen,
-            die ausgeführt werden, falls der Stack des Shift/Reduce-Parsers, der die
-            Symbole enthält, mit der zugehörigen Regel reduziert wird.
+            die ausgef\"uhrt werden, falls der Stack des Shift/Reduce-Parsers, der die
+            Symbole enth\"alt, mit der zugeh\"origen Regel reduziert wird.
       \end{enumerate}
       Bei der Spezifikation einer Grammatik-Regel mit \textsc{Cup} weicht die Syntax von der
       Syntax, die in \textsc{Antlr} verwendet wird, an mehreren Stellen ab: 
@@ -165,21 +165,21 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
       \item Statt eines einfachen Doppelpunkts ``\texttt{:}'' wird die Zeichenreihe ``\texttt{::=}''
             verwendet, um die zu definierende Variable vom Rumpf der Grammatik-Regel zu trennen.
       \item Die Kommandos werden bei \textsc{Cup} in den Zeichenreihen ``\texttt{\{:}'' und
-            ``\texttt{:\}}'' eingeschlossen, während bei \textsc{Antlr} die geschweiften Klammern
+            ``\texttt{:\}}'' eingeschlossen, w\"ahrend bei \textsc{Antlr} die geschweiften Klammern
             ``\texttt{\{}'' und ``\texttt{\}}'' ausgereicht haben.
       \item Um auf die Werte, die einem Terminal oder einer syntaktischen Variablen zugeordnet sind,
             zuzugreifen, hatten wir bei \textsc{Antlr} Zuweisungen  verwendet.
-            Stattdessen müssen wir nun jedem Symbol, 
+            Stattdessen m\"ussen wir nun jedem Symbol, 
             dessen Wert wir verwenden wollen, eine eigene Variable zuordnen, deren Namen wir
             getrennt von einem Doppelpunkt hinter das Symbol schreiben.  Um der durch die
             Grammatik-Regel definierten syntaktischen Variablen einen Wert zuzuweisen, verwenden wir
-            das Schlüsselwort ``\texttt{RESULT}''.  Betrachten wir als Beispiel die folgende Regel:
+            das Schl\"usselwort ``\texttt{RESULT}''.  Betrachten wir als Beispiel die folgende Regel:
             \\[0.2cm]
             \hspace*{1.3cm}
             \texttt{expr ::= expr:e PLUS prod:p \{: RESULT = e + p; :\};}
             \\[0.2cm]
             Mit \texttt{expr:e} sucht der Parser nach einem arithmetischen Ausdruck, dessen Wert in
-            der Variablen \texttt{e} gespeichert wird.  Anschließend wird ein Plus-Zeichen gelesen
+            der Variablen \texttt{e} gespeichert wird.  Anschlie{\ss}end wird ein Plus-Zeichen gelesen
             und darauf folgt wieder ein Produkt, dessen Wert jetzt in \texttt{p}
             gespeichert wird.  Der Wert des insgesamt gelesenen Ausdrucks wird dann durch die Zuweisung
             \\[0.2cm]
@@ -188,30 +188,30 @@ mit deren Hilfe arithmetische Ausdrücke ausgewertet werden können.  In dieser
             \\[0.2cm]
             berechnet und der linken Seite der Grammatik-Regel zugewiesen.
       \item Ein weiterer Unterschied zwischen \textsc{Cup} und \textsc{Antlr} besteht darin,
-            dass Nicht-Terminale nicht mehr durch den ihnen zugeordneten String repräsentiert werden
-            können.  Daher können wir den String ``\texttt{PLUS}'' nicht durch den String
+            dass Nicht-Terminale nicht mehr durch den ihnen zugeordneten String repr\"asentiert werden
+            k\"onnen.  Daher k\"onnen wir den String ``\texttt{PLUS}'' nicht durch den String
             ``\texttt{'+'}'' ersetzen.  
             An dieser Stelle sind \textsc{Cup}-Grammatiken leider nicht so gut lesbar wie die
             entsprechenden \textsc{Antlr}-Grammatiken.
-            Der Grund dafür ist, dass bei  \textsc{Cup} zum Scannen ein separates
-            Werkzeug, nämlich \textsl{JFlex}, zum Scannen verwendet wird.  Demgegenüber
+            Der Grund daf\"ur ist, dass bei  \textsc{Cup} zum Scannen ein separates
+            Werkzeug, n\"amlich \textsl{JFlex}, zum Scannen verwendet wird.  Demgegen\"uber
             wird bei \textsc{Antlr} der Scanner zusammen mit dem Parser in derselben
             Datei spezifiziert und das Werkzeug \textsc{Antlr} erzeugt aus dieser Datei
             sowohl einen Parser als auch einen Scanner.
       \item Ein weiterer wichtiger Unterschied zwischen \textsc{Cup} und \textsc{Antlr} besteht
             darin, dass \textsc{Cup} im Gegensatz zu \textsc{Antlr} keine \textsc{Ebnf}-Grammatiken
-            akzeptiert sondern nur gewöhnliche kontextfreie Grammatiken verarbeiten kann.  Damit stehen
+            akzeptiert sondern nur gew\"ohnliche kontextfreie Grammatiken verarbeiten kann.  Damit stehen
             uns die Operatoren ``\texttt{*}'', ``\texttt{+}'' und ``\texttt{?}'' bei der
-            Spezifikation der Grammatik nicht zur Verfügung.
+            Spezifikation der Grammatik nicht zur Verf\"ugung.
       \end{enumerate}
 \end{enumerate}
 Um aus der in Abbildung \ref{fig:calc.cup} gezeigten \textsc{Cup}-Spezifikation einen Parser zu
-erzeugen, müssen wir diese zunächst mit dem Befehl
+erzeugen, m\"ussen wir diese zun\"achst mit dem Befehl
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{java -jar /usr/local/lib/java-cup-11b.jar calc.cup}
 \\[0.2cm]
-übersetzen.  Damit dies funktioniert müssen Sie die Datei
+\"ubersetzen.  Damit dies funktioniert m\"ussen Sie die Datei
 \\[0.2cm]
 \hspace*{1.3cm}
  \texttt{java-cup-11b.jar} 
@@ -221,27 +221,27 @@ in dem Verzeichnis
 \hspace*{1.3cm}
 \texttt{/usr/local/lib}
 \\[0.2cm]
-ablegen.  Sollten Sie unter \textsl{Windows} arbeiten, müssen Sie statt dessen ein geeignetes anderes
-Verzeichnis wählen.  Eine Möglichkeit, den Aufruf zu vereinfachen, besteht unter Unix darin, dass Sie sich
+ablegen.  Sollten Sie unter \textsl{Windows} arbeiten, m\"ussen Sie statt dessen ein geeignetes anderes
+Verzeichnis w\"ahlen.  Eine M\"oglichkeit, den Aufruf zu vereinfachen, besteht unter Unix darin, dass Sie sich
 eine Datei \texttt{cup} mit folgendem Inhalt irgendwo in Ihrem Pfad ablegen:
 \begin{verbatim}
     #!/bin/bash 
     java -jar /usr/local/lib/java-cup-11b.jar  $@
 \end{verbatim} %$
-Unter \textsl{Windows} können Sie sich statt dessen eine entsprechende \texttt{.bat}-Datei anlegen.
-Danach können Sie \textsc{Cup} einfacher mit dem Befehl
+Unter \textsl{Windows} k\"onnen Sie sich statt dessen eine entsprechende \texttt{.bat}-Datei anlegen.
+Danach k\"onnen Sie \textsc{Cup} einfacher mit dem Befehl
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{cup} \textsl{calc.cup}
 \\[0.2cm]
 aufrufen.  Dieser Befehl erzeugt verschiedene \textsl{Java}-Dateien.
 \begin{enumerate}
-\item Die Datei \texttt{ExprParser.java} enthält die Klasse \texttt{ExprParser}, die den eigentlichen
-      Parser enthält.  Wenn Sie diese Klassse später übersetzen wollen, müssen Sie dafür
+\item Die Datei \texttt{ExprParser.java} enth\"alt die Klasse \texttt{ExprParser}, die den eigentlichen
+      Parser enth\"alt.  Wenn Sie diese Klassse sp\"ater \"ubersetzen wollen, m\"ussen Sie daf\"ur
       sorgen, dass die Datei \texttt{java-cup-11b-runtime.jar} im \texttt{CLASSPATH} liegt.
-\item Die Datei \texttt{ExprParserSym.java} enthält die Klasse \texttt{ExprParserSym}, welche die verschiedenen
+\item Die Datei \texttt{ExprParserSym.java} enth\"alt die Klasse \texttt{ExprParserSym}, welche die verschiedenen
       Symbole als statische Konstanten  der  Klasse \texttt{ExprParserSym} definiert.  
-      Diese Konstanten werden später im von \textsl{JFlex} erzeugten Scanner verwendet. Abbildung
+      Diese Konstanten werden sp\"ater im von \textsl{JFlex} erzeugten Scanner verwendet. Abbildung
       \ref{fig:sym.java} auf Seite \pageref{fig:sym.java} zeigt diese Klasse.
 \end{enumerate}
 
@@ -289,18 +289,18 @@ aufrufen.  Dieser Befehl erzeugt verschiedene \textsl{Java}-Dateien.
 \end{figure}
 
 \noindent
-Neben dem Parser wird noch ein Scanner benötigt.  Diesen werden wir im nächsten Abschnitt präsentieren.
-Um mit dem Parser arbeiten zu können, brauchen wir eine Klasse, welche die Methode
-$\texttt{main}()$ enthält.  Abbildung \ref{fig:Calculator.java} auf Seite
+Neben dem Parser wird noch ein Scanner ben\"otigt.  Diesen werden wir im n\"achsten Abschnitt pr\"asentieren.
+Um mit dem Parser arbeiten zu k\"onnen, brauchen wir eine Klasse, welche die Methode
+$\texttt{main}()$ enth\"alt.  Abbildung \ref{fig:Calculator.java} auf Seite
 \pageref{fig:Calculator.java} zeigt eine solche Klasse.  Wir
 erzeugen dort in Zeile 7 einen \texttt{InputStream}, der aus der Datei liest, deren Name wir als
-erstes Argument übergeben.   In der darauf folgenden Zeile wird der \texttt{InputStream} in einen
+erstes Argument \"ubergeben.   In der darauf folgenden Zeile wird der \texttt{InputStream} in einen
 \texttt{Reader} verwandelt.  Aus dem \texttt{Reader} erzeugen wir einen \texttt{Scanner}.  Mit
-diesem \texttt{Scanner} können wir schließlich den Parser erzeugen, den wir dann in Zeile 11 mit
-Hilfe der Methode \texttt{parse()} starten, wobei eventuelle Ausnahmen noch abgefangen werden müssen.
+diesem \texttt{Scanner} k\"onnen wir schlie{\ss}lich den Parser erzeugen, den wir dann in Zeile 11 mit
+Hilfe der Methode \texttt{parse()} starten, wobei eventuelle Ausnahmen noch abgefangen werden m\"ussen.
 Falls mit dem Start-Symbol der Grammatik ein Wert assoziert ist, so wird dieser Wert von
-der Methode $\texttt{parse}()$ als Ergebnis zurück gegeben, andernfalls gibt die Methode den Wert
-\texttt{null} zurück.
+der Methode $\texttt{parse}()$ als Ergebnis zur\"uck gegeben, andernfalls gibt die Methode den Wert
+\texttt{null} zur\"uck.
 
 
 \begin{figure}[!ht]
@@ -341,8 +341,8 @@ der Methode $\texttt{parse}()$ als Ergebnis zurück gegeben, andernfalls gibt die
 
 \section{Generierung eines \textsc{Cup}-Scanner mit Hilfe von \textsl{Flex}}
 Wir zeigen in diesem Abschnitt, wie wir mit Hilfe von \textsl{JFlex} einen Scanner
-für den im letzten Abschnitt erzeugten Parser erstellen können.
-Der Scanner, den wir benötigen, muss in der Lage sein, Zahlen und arithmetische
+f\"ur den im letzten Abschnitt erzeugten Parser erstellen k\"onnen.
+Der Scanner, den wir ben\"otigen, muss in der Lage sein, Zahlen und arithmetische
 Operatoren zu erkennen.  Abbildung \ref{fig:calc.jflex} auf Seite 
 \pageref{fig:calc.jflex} zeigt einen solchen Scanner, den wir jetzt im Detail diskutieren.
 
@@ -401,37 +401,37 @@ Operatoren zu erkennen.  Abbildung \ref{fig:calc.jflex} auf Seite
                                     ", column "  + yycolumn); }
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Ein Scanner für arithmetische Ausdrücke}
+\caption{Ein Scanner f\"ur arithmetische Ausdr\"ucke}
 \label{fig:calc.jflex}
 \end{figure}
 
 \begin{enumerate}
 \item In Zeile 1 importieren wir alle Klassen des Paketes \texttt{java\_cup.runtime}.
-      Dieses Paket enthält insbesondere die Definition der Klasse \texttt{Symbol}, mit der 
+      Dieses Paket enth\"alt insbesondere die Definition der Klasse \texttt{Symbol}, mit der 
       in einem \textsc{Cup}-Parser Terminale und Nicht-Terminale beschrieben werden.
       Daher muss dieses Paket bei jedem Scanner importiert werden, der an einen von
       \textsc{Cup} erzeugten Parser angeschlossen werden soll.
 \item In den Zeilen 5 bis 7 spezifizieren wir, dass der Scanner die Anzahl der insgesamt
       gelesenen Zeichen, die Anzahl der gelesenen Zeilen und die Anzahl der in der aktuellen Zeile
-      gelesenen Zeichen automatisch berechnen soll.  Dadurch können wir später im Parser
-      Syntax-Fehler präzise lokalisieren.
-\item Zeile 8 spezifiziert mit dem Schlüsselwort ``\texttt{\%cupsym}'', 
-      dass die vom Scanner zurückzugebenden Symbole in der Klasse \texttt{ExprParserSym} definiert
+      gelesenen Zeichen automatisch berechnen soll.  Dadurch k\"onnen wir sp\"ater im Parser
+      Syntax-Fehler pr\"azise lokalisieren.
+\item Zeile 8 spezifiziert mit dem Schl\"usselwort ``\texttt{\%cupsym}'', 
+      dass die vom Scanner zur\"uckzugebenden Symbole in der Klasse \texttt{ExprParserSym} definiert
       werden.  Diese Klasse wurde von \textsc{Cup} erzeugt.  Der Name dieser Klasse ergibt sich aus
-      dem Namen der Klasse des Parsers durch Anhängen von ``\texttt{Sym}'', das für \emph{Symbol} steht.
+      dem Namen der Klasse des Parsers durch Anh\"angen von ``\texttt{Sym}'', das f\"ur \emph{Symbol} steht.
       Die Klasse des Parsers hatten wir seinerzeit in der Datei ``\texttt{calc.cup}''  mit Hilfe 
-      des Schlüsselworts ``\texttt{class}'' spezifiziert.
-\item Zeile 9 spezifiziert mit dem Schlüsselwort ``\texttt{\%cup}'', 
+      des Schl\"usselworts ``\texttt{class}'' spezifiziert.
+\item Zeile 9 spezifiziert mit dem Schl\"usselwort ``\texttt{\%cup}'', 
       dass der Scanner an einen \textsc{Cup}-Parser angeschlossen  werden soll.
 \item In den Zeilen 12 bis 20 definieren wir zwei Hilfs-Methoden, die Objekte vom Typ 
-      \texttt{Symbol} erzeugen.  Der Scanner muss Objekte von diesem Typ an den Parser zurück
+      \texttt{Symbol} erzeugen.  Der Scanner muss Objekte von diesem Typ an den Parser zur\"uck
       liefern.  Die in dem Paket \texttt{java\_cup.runtime} definierte Klasse \texttt{Symbol} stellt
-      verschiedene Konstruktoren für diese Klasse zur Verfügung.  Wir stellen die wichtigsten 
+      verschiedene Konstruktoren f\"ur diese Klasse zur Verf\"ugung.  Wir stellen die wichtigsten 
       Konstruktoren vor.
       \begin{enumerate}
       \item \texttt{public Symbol(int \textsl{symbolID});}
 
-            Dieser Konstruktor bekommt als Argument eine natürliche Zahl, die festlegt,
+            Dieser Konstruktor bekommt als Argument eine nat\"urliche Zahl, die festlegt,
             welche Art von Symbol 
             definiert werden soll.  Diese Zahl bezeichnen wir als \emph{Symbol-Nummer}.
             Jedem Terminal und jeder syntaktische Variablen entspricht genau Symbol-Nummer. 
@@ -440,45 +440,45 @@ Operatoren zu erkennen.  Abbildung \ref{fig:calc.jflex} auf Seite
             auf Seite \pageref{fig:sym.java} zeigt diese von \textsc{Cup} erzeugte Klasse.
       \item \texttt{public Symbol(int \textsl{symbolID}, Object \textsl{value});}
 
-            Dieser Konstruktor bekommt zusätzlich zur Symbol-Nummer einen \emph{Wert}, der im Symbol
+            Dieser Konstruktor bekommt zus\"atzlich zur Symbol-Nummer einen \emph{Wert}, der im Symbol
             abgespeichert wird. Dieser Wert hat den Typ \texttt{Object}, wodurch der Typ so
-            allgemein wie möglich ist.  Dieser
+            allgemein wie m\"oglich ist.  Dieser
             Konstruktor wird benutzt, wenn Terminale, die einen Wert haben, wie beispielsweise
-            Zahlen, vom Scanner an den Parser zurück gegeben werden sollen.
+            Zahlen, vom Scanner an den Parser zur\"uck gegeben werden sollen.
       \item \texttt{public Symbol(int \textsl{symbolID}, int \textsl{start}, int \textsl{end})}
 
-            Dieser Konstruktor hat zusätzlich zur Symbol-Nummer die Argumente \texttt{start}  und
+            Dieser Konstruktor hat zus\"atzlich zur Symbol-Nummer die Argumente \texttt{start}  und
             \texttt{stop}, die den Anfang und das Ende des erkannten Terminals festlegen.  Die Variable
-            \texttt{start} gibt die Position des ersten Zeichens im Text an, während \texttt{end}
-            die Position des letzten Zeichens des Tokens angibt.  Diese Information ist nützlich,
-            um später im Parser Syntax-Fehler besser lokalisieren zu können.
+            \texttt{start} gibt die Position des ersten Zeichens im Text an, w\"ahrend \texttt{end}
+            die Position des letzten Zeichens des Tokens angibt.  Diese Information ist n\"utzlich,
+            um sp\"ater im Parser Syntax-Fehler besser lokalisieren zu k\"onnen.
       \item \texttt{public Symbol(int \textsl{symbolID}, int  \textsl{start}, int \textsl{end},
                     Objekt \textsl{value})}
 
-            Dieser Konstruktor erhält zusätzlich zur Symbol-Nummer und Position des gelesenen Tokens noch
+            Dieser Konstruktor erh\"alt zus\"atzlich zur Symbol-Nummer und Position des gelesenen Tokens noch
             den Wert, der diesem Token zugeordnet ist.
       \end{enumerate}
       Bei der Implementierung der beiden Hilfs-Methoden mit dem Namen $\texttt{symbol}()$ verwenden
-      wir die Funktion $\texttt{yylength}()$.  Diese Funktion wird von \textsl{jflex} zur Verfügung
-      gestellt und gibt die Länge des Strings zurück, der dem zuletzt erkannten Tokens entspricht.
+      wir die Funktion $\texttt{yylength}()$.  Diese Funktion wird von \textsl{jflex} zur Verf\"ugung
+      gestellt und gibt die L\"ange des Strings zur\"uck, der dem zuletzt erkannten Tokens entspricht.
 \item In den Zeilen 28 bis 35 erkennen wir die arithmetischen Operatoren und die Klammer-Symbole.
-      Zur Spezifikation des zurückgegebenen Token verwenden wir dabei die in der Klasse \texttt{ExprParserSym}
+      Zur Spezifikation des zur\"uckgegebenen Token verwenden wir dabei die in der Klasse \texttt{ExprParserSym}
       definierten Konstanten \texttt{SEMI}, \texttt{PLUS}, etc. 
-\item In Zeile 37 erkennen wir mit dem regulären Ausdruck ``\texttt{0|[1-9][0-9]*}'' eine natürliche
+\item In Zeile 37 erkennen wir mit dem regul\"aren Ausdruck ``\texttt{0|[1-9][0-9]*}'' eine nat\"urliche
       Zahl.  Diese wandeln wir durch den Konstruktor-Aufruf 
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{new Integer(yytext())}
       \\[0.2cm]
       in ein Objekt vom Typ \texttt{Integer} um, wobei der String, der in eine Zahl umgewandelt wird, von der
-      Funktion $\texttt{yytext}()$ geliefert wird.  Anschließend geben wir ein Objekt der Klasse \texttt{Symbol} zurück,
+      Funktion $\texttt{yytext}()$ geliefert wird.  Anschlie{\ss}end geben wir ein Objekt der Klasse \texttt{Symbol} zur\"uck,
       in dem diese Zahl als mit dem Symbol assoziierter Wert abgespeichert wird.
-\item In Zeile 39 überlesen wir Leerzeichen, Tabulatoren und Zeilen-Umbrüche.
-      Das Überlesen geschieht dadurch, dass wir in diesem Fall kein Symbol an den Parser zurück
-      geben, denn die semantische Aktion enthält keinen \texttt{return}-Befehl.
+\item In Zeile 39 \"uberlesen wir Leerzeichen, Tabulatoren und Zeilen-Umbr\"uche.
+      Das \"Uberlesen geschieht dadurch, dass wir in diesem Fall kein Symbol an den Parser zur\"uck
+      geben, denn die semantische Aktion enth\"alt keinen \texttt{return}-Befehl.
 \item Falls ein beliebiges anderes Zeichen gelesen wird, geben wir mit der Regel, die in Zeile 41 
       beginnt, eine Fehlermeldung aus.  Dabei greifen wir auf die Variablen 
-      \texttt{yyline} und \texttt{yycolumn} zurück, damit der Fehler lokalisiert werden kann.
+      \texttt{yyline} und \texttt{yycolumn} zur\"uck, damit der Fehler lokalisiert werden kann.
 \end{enumerate}
 Durch den Aufruf
 \\[0.2cm]
@@ -522,12 +522,12 @@ Wir hatten in Abbildung
           ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{\textsc{Cup}-Spezifikation eines Parsers für arithmetische Ausdrücke}
+\caption{\textsc{Cup}-Spezifikation eines Parsers f\"ur arithmetische Ausdr\"ucke}
 \label{fig:calc-ambiguous.cup}
 \end{figure}
 
 Wir betrachten nun ein weiteres Beispiel.  Abbildung \ref{fig:calc-ambiguous.cup} zeigt eine 
-\textsc{Cup}-Spezifikation einer Grammatik, die offenbar mehrdeutig ist, da die Präzedenzen der
+\textsc{Cup}-Spezifikation einer Grammatik, die offenbar mehrdeutig ist, da die Pr\"azedenzen der
 arithmetischen Operatoren durch diese Grammatik nicht festgelegt werden.
   Mit dieser Grammatik ist beispielsweise nicht klar, ob der String
 \\[0.2cm]
@@ -537,13 +537,13 @@ arithmetischen Operatoren durch diese Grammatik nicht festgelegt werden.
 interpretiert werden soll.   Wir hatten im letzten Kapitel schon gesehen, dass es in einer
 mehrdeutigen Grammatik immer Shift/Reduce- oder Reduce/Reduce-Konflikte geben muss, denn jede
 LALR-Grammatik ist eindeutig.  Wenn wir versuchen, die Grammatik aus Abbildung
-\ref{fig:calc-ambiguous.cup} mit \textsc{Cup} zu übersetzen und wenn wir dabei zusätzlich die Option 
+\ref{fig:calc-ambiguous.cup} mit \textsc{Cup} zu \"ubersetzen und wenn wir dabei zus\"atzlich die Option 
 ``\texttt{-dump}'' angeben, der Aufruf von \textsc{Cup} hat dann die Form
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{cup -dump calc.cup}
 \\[0.2cm]
-so erhalten wir eine große Zahl von Shift/Reduce-Konflikten angezeigt.
+so erhalten wir eine gro{\ss}e Zahl von Shift/Reduce-Konflikten angezeigt.
 Beispielsweise erhalten wir die folgende Fehlermeldung:
 \begin{verbatim}
     Warning : *** Shift/Reduce conflict found in state #12
@@ -579,7 +579,7 @@ worden ist.  Der Zustand mit der Nummer 12 hat folgende Form:
       [expr ::= expr MINUS expr (*) ,  {EOF PLUS MINUS TIMES DIVIDE MOD RPAREN }]
     }
 \end{verbatim}
-Damit können wir jetzt den
+Damit k\"onnen wir jetzt den
 Shift/Reduce-Konflikt interpretieren: Im Zustand 12 ist der Parser entweder dabei, die
 Eingabe mit der Regel 
 \\[0.2cm]
@@ -591,22 +591,22 @@ zu reduzieren, oder der Parser ist gerade dabei, die rechte Seite der Regel
 \hspace*{1.3cm}
 $\textsl{expr} \rightarrow \textsl{expr} \quoted{+} \textsl{expr}$
 \\[0.2cm]
-zu erkennen, wobei er bereits eine \textsl{expr} erkannt hat und nun als nächstes das
+zu erkennen, wobei er bereits eine \textsl{expr} erkannt hat und nun als n\"achstes das
 Token ``\texttt{+}'' erwartet wird.  Da das Token ``\texttt{+}'' auch in der Follow-Menge der
 erweiterten markierten Regel $R_1$ liegen kann, ist an dieser Stelle unklar, ob das Token
 ``\texttt{+}'' auf den 
 Stack geschoben werden soll, oder ob stattdessen mit der Regel $R_1$ reduziert werden
 muss.  Bei einem Shift/Reduce-Konflikt entscheidet sich der von \textsc{Cup} erzeugte
-Parser immer dafür, das Token auf den Stack zu schieben.
+Parser immer daf\"ur, das Token auf den Stack zu schieben.
 
 
-\section{Operator-Präzendenzen \label{section:operator-precedence}}
-Es ist mit   \textsc{Cup} möglich, Shift/Reduce-Konflikte durch die Angabe von
-\emph{Operator-Präzedenzen} 
-aufzulösen.  Abbildung \ref{fig:calc-precedence.cup} zeigt die Spezifikation einer Grammatik zur
-Erkennung arithmetischer Ausdrücke, die aus Zahlen und den binären Operatoren ``\texttt{+}'',
+\section{Operator-Pr\"azendenzen \label{section:operator-precedence}}
+Es ist mit   \textsc{Cup} m\"oglich, Shift/Reduce-Konflikte durch die Angabe von
+\emph{Operator-Pr\"azedenzen} 
+aufzul\"osen.  Abbildung \ref{fig:calc-precedence.cup} zeigt die Spezifikation einer Grammatik zur
+Erkennung arithmetischer Ausdr\"ucke, die aus Zahlen und den bin\"aren Operatoren ``\texttt{+}'',
 ``\texttt{-}'', ``\texttt{*}'', ``\texttt{/}'' und ``\texttt{\symbol{94}}'' aufgebaut sind.   Mit
-Hilfe der Schlüsselwörter 
+Hilfe der Schl\"usselw\"orter 
 \\[0.2cm]
 \hspace*{1.3cm}
 ``\texttt{precedence left}'' \quad und \quad ``\texttt{precedence right}'' 
@@ -617,7 +617,7 @@ haben wir festgelegt, dass die Operatoren ``\texttt{+}'', ``\texttt{-}'', ``\tex
 \hspace*{1.3cm}
 $3 - 2 - 1$ \quad wird also als \quad $(3 - 2) - 1$ \quad und nicht als \quad $3 - (2-1)$
 \\[0.2cm]
-gelesen.  Demgegenüber ist der Operator ``\texttt{\symbol{94}}'', der in der \textsc{Cup}-Grammatik
+gelesen.  Demgegen\"uber ist der Operator ``\texttt{\symbol{94}}'', der in der \textsc{Cup}-Grammatik
 mit ``\texttt{POW}'' bezeichnet wird und die Potenzbildung bezeichnet,
 \emph{rechts-assoziativ}, der Ausdruck 
 \\[0.2cm]
@@ -625,17 +625,17 @@ mit ``\texttt{POW}'' bezeichnet wird und die Potenzbildung bezeichnet,
 $4 \texttt{\symbol{94}} 3 \texttt{\symbol{94}} 2$ \quad wird daher als \quad
 $4^{\mbox{(}3^2\mbox{)}}$ \quad  und nicht als \quad $\bigl(4^3\bigr)^2$
 \\[0.2cm]
-interpretiert.   Die Reihenfolge, in der die Assoziativität der Operatoren spezifiziert werden, legt die
-\emph{Präzedenzen}, die auch als \emph{Bindungsstärken} bezeichnet werden, fest.  Dabei ist die
-Bindungsstärke umso größer, je später der Operator spezifiziert wird.  In unserem konkreten Beispiel bindet
-der Exponentiations-Operator ``\texttt{\symbol{94}}'' also am stärksten, während die Operatoren ``\texttt{+}'' und
-``\texttt{-}'' am schwächsten binden.  Bei der in Abbildung \ref{fig:calc-precedence.cup} gezeigten Grammatik
-ordnet \textsc{Cup} den Operatoren die Bindungsstärke nach der folgenden Tabelle zu:
+interpretiert.   Die Reihenfolge, in der die Assoziativit\"at der Operatoren spezifiziert werden, legt die
+\emph{Pr\"azedenzen}, die auch als \emph{Bindungsst\"arken} bezeichnet werden, fest.  Dabei ist die
+Bindungsst\"arke umso gr\"o{\ss}er, je sp\"ater der Operator spezifiziert wird.  In unserem konkreten Beispiel bindet
+der Exponentiations-Operator ``\texttt{\symbol{94}}'' also am st\"arksten, w\"ahrend die Operatoren ``\texttt{+}'' und
+``\texttt{-}'' am schw\"achsten binden.  Bei der in Abbildung \ref{fig:calc-precedence.cup} gezeigten Grammatik
+ordnet \textsc{Cup} den Operatoren die Bindungsst\"arke nach der folgenden Tabelle zu:
 
 \begin{center}
 \begin{tabular}[t]{|c|c|c|}
 \hline
-Operator       & Bindungsstärke & Assoziativität \\
+Operator       & Bindungsst\"arke & Assoziativit\"at \\
 \hline
 \hline
 ``\texttt{+}''  & 1             &  links         \\
@@ -699,23 +699,23 @@ Operator       & Bindungsstärke & Assoziativität \\
 \end{Verbatim}
 %$
 \vspace*{-0.3cm}
-\caption{Auflösung der Shift/Reduce-Konflikte durch Operator-Präzedenzen.}
+\caption{Aufl\"osung der Shift/Reduce-Konflikte durch Operator-Pr\"azedenzen.}
 \label{fig:calc-precedence.cup}
 \end{figure}
 
-Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Konflikte aufzulösen.
-\textsc{Cup} geht folgendermaßen vor:
+Wie erl\"autern nun, wie diese Bindungsst\"arken benutzt werden, um Shift/Reduce-Konflikte aufzul\"osen.
+\textsc{Cup} geht folgenderma{\ss}en vor:
 \begin{enumerate}
-\item Zunächst wird jeder Grammatik-Regel eine \emph{Präzedenz} zugeordnet.
-      Die Präzedenz ist dabei die Bindungsstärke des letzten in der Regel auftretenden Operators.
-      Für den Fall, dass eine Regel mehrere Operatoren enthält, für die eine Bindungsstärke spezifiziert
-      wurde, wird zur Festlegung der Bindungsstärke also der Operator herangezogen, der in
+\item Zun\"achst wird jeder Grammatik-Regel eine \emph{Pr\"azedenz} zugeordnet.
+      Die Pr\"azedenz ist dabei die Bindungsst\"arke des letzten in der Regel auftretenden Operators.
+      F\"ur den Fall, dass eine Regel mehrere Operatoren enth\"alt, f\"ur die eine Bindungsst\"arke spezifiziert
+      wurde, wird zur Festlegung der Bindungsst\"arke also der Operator herangezogen, der in
       der Regel am weitesten 
-      rechts steht.  In unserem Beispiel haben die einzelnen Regeln damit die folgenden Präzedenzen:
+      rechts steht.  In unserem Beispiel haben die einzelnen Regeln damit die folgenden Pr\"azedenzen:
       \begin{center}
         \begin{tabular}[t]{|l|c|}
           \hline
-          Regel                          & Präzedenz  \\
+          Regel                          & Pr\"azedenz  \\
           \hline
           \hline
           $E \rightarrow E \quoted{+} E$ & 1          \\
@@ -734,8 +734,8 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
           \hline
         \end{tabular}
       \end{center}
-      Für die Regeln, die keinen Operator enthalten, für den eine Bindungsstärke spezifiziert ist,
-      bleibt die Präzedenz unspezifiziert.
+      F\"ur die Regeln, die keinen Operator enthalten, f\"ur den eine Bindungsst\"arke spezifiziert ist,
+      bleibt die Pr\"azedenz unspezifiziert.
 \item Ist $s$ ein Zustand, in dem zwei Regeln $r_1$ und $r_2$ der Form
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -747,13 +747,13 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
       \hspace*{1.3cm}
       $\textsl{action}(s, o)$
       \\[0.2cm]
-      zunächst einen Shift/Reduce-Konflikt.  Falls dem Operator $o$ die Präzedenz $p(o)$
-      zugeordnet worden ist und wenn außerdem die Regel $r_2$, mit der reduziert werden würde, die
-      Präzedenz  $p(r_2)$ hat, so wird der Shift/Reduce-Konflikt in Abhängigkeit von der relativen
-      Größe   der beiden Zahlen $p(o)$ und $p(r_2)$ aufgelöst.  Hier werden fünf Fälle unterschieden:
+      zun\"achst einen Shift/Reduce-Konflikt.  Falls dem Operator $o$ die Pr\"azedenz $p(o)$
+      zugeordnet worden ist und wenn au{\ss}erdem die Regel $r_2$, mit der reduziert werden w\"urde, die
+      Pr\"azedenz  $p(r_2)$ hat, so wird der Shift/Reduce-Konflikt in Abh\"angigkeit von der relativen
+      Gr\"o{\ss}e   der beiden Zahlen $p(o)$ und $p(r_2)$ aufgel\"ost.  Hier werden f\"unf F\"alle unterschieden:
       \begin{enumerate}
       \item $p(o) > p(c \rightarrow \gamma)$: 
-            In diesem Fall bindet der Operator $o$ stärker.  Daher wird das Token $o$  
+            In diesem Fall bindet der Operator $o$ st\"arker.  Daher wird das Token $o$  
             in diesem Fall auf den Stack geschoben:
             \hspace*{1.3cm}
             \\[0.2cm]
@@ -770,7 +770,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             $E \rightarrow E \quoted{+} E \mid E \quoted{*} E \mid \textsc{Number}$
             \\[0.2cm]
             parsen.  Betrachten wir die Situation, bei der der Teilstring ``\texttt{1+2}''
-            bereits gelesen wurde und nun als nächstes das Token ``\texttt{*}''
+            bereits gelesen wurde und nun als n\"achstes das Token ``\texttt{*}''
             verarbeitet werden soll.  Der LALR-Parser ist dann in dem folgenden Zustand:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -786,14 +786,14 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             \end{array}
             $
             \\[0.2cm]
-            Wenn in diesem Zustand als nächstes Zeichen ein ``\texttt{*}'' gelesen wird, so darf der
+            Wenn in diesem Zustand als n\"achstes Zeichen ein ``\texttt{*}'' gelesen wird, so darf der
             bisher gelesene String ``\texttt{1+2}'' nicht mit der Regel 
-            $E \rightarrow E \squoted{+} E$ reduziert werden, denn wir wollen die 2 ja zunächst mit 3 
+            $E \rightarrow E \squoted{+} E$ reduziert werden, denn wir wollen die 2 ja zun\"achst mit 3 
             multiplizieren.  Statt dessen muss also das Zeichen 
             ``\texttt{*}'' auf den Stack geschoben werden.
       \item $p(o) < p(c \rightarrow \gamma)$: 
-            Jetzt bindet der Operator, der in der Regel $r_2$ auftritt, stärker als der
-            Operator $o$.  Daher wird in diesem Fall zunächst mit der Regel $r_2$ reduziert, wir haben 
+            Jetzt bindet der Operator, der in der Regel $r_2$ auftritt, st\"arker als der
+            Operator $o$.  Daher wird in diesem Fall zun\"achst mit der Regel $r_2$ reduziert, wir haben 
             also 
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -810,7 +810,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             $E \rightarrow E \quoted{+} E \mid E \quoted{*} E \mid \textsc{Number}$
             \\[0.2cm]
             parsen.  Betrachten wir die Situation, bei der der Teilstring ``\texttt{1*2}''
-            bereits gelesen wurde und nun als nächstes das Token ``\texttt{+}''
+            bereits gelesen wurde und nun als n\"achstes das Token ``\texttt{+}''
             verarbeitet werden soll.  Der LALR-Parser ist dann in dem folgenden Zustand:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -826,12 +826,12 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             \end{array}
             $
             \\[0.2cm]
-            Wenn in diesem Zustand als nächstes Zeichen ein ``\texttt{+}'' gelesen wird, so soll
+            Wenn in diesem Zustand als n\"achstes Zeichen ein ``\texttt{+}'' gelesen wird, so soll
             der bisher gelesene String ``\texttt{1*2}''  mit der Regel 
-            $E \rightarrow E \squoted{*} E$ reduziert werden, denn wir wollen die 1 ja zunächst mit 2 
+            $E \rightarrow E \squoted{*} E$ reduziert werden, denn wir wollen die 1 ja zun\"achst mit 2 
             multiplizieren.  
       \item $p(o) = p(c \rightarrow \gamma)$ und der Operator $o$ ist links-assoziativ:
-            Dann wird zunächst mit der Regel $r_2$ reduziert, wir haben
+            Dann wird zun\"achst mit der Regel $r_2$ reduziert, wir haben
             also 
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -848,7 +848,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             $E \rightarrow E \quoted{+} E \mid E \quoted{-} E \mid \textsc{Number}$
             \\[0.2cm]
             parsen.  Betrachten wir die Situation, bei der der Teilstring ``\texttt{1-2}''
-            bereits gelesen wurde und nun als nächstes das Token ``\texttt{-}''
+            bereits gelesen wurde und nun als n\"achstes das Token ``\texttt{-}''
             verarbeitet werden soll.  Der LALR-Parser ist dann in dem folgenden Zustand:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -864,10 +864,10 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             \end{array}
             $
             \\[0.2cm]
-            Wenn in diesem Zustand als nächstes Zeichen ein ``\texttt{-}'' gelesen wird, so soll
+            Wenn in diesem Zustand als n\"achstes Zeichen ein ``\texttt{-}'' gelesen wird, so soll
             der bisher gelesene String ``\texttt{1-2}'' mit der Regel 
             $E \rightarrow E \squoted{-} E$ reduziert werden, denn wir wollen von der Zahl 1 ja
-            zunächst die Zahl 2 subtrahieren.  
+            zun\"achst die Zahl 2 subtrahieren.  
       \item $p(o) = p(c \rightarrow \gamma)$ und der Operator $o$ ist rechts--assoziativ:
             In diesem Fall wird $o$ auf den
             Stack geschoben:
@@ -886,7 +886,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             $E \rightarrow E \,\texttt{\symbol{94}}\, E \mid \textsc{Number}$
             \\[0.2cm]
             zu parsen und die Situation zu betrachten, bei der der Teilstring
-            ``\texttt{1\symbol{94}2}'' bereits verarbeitet wurde und als nächstes Zeichen nun
+            ``\texttt{1\symbol{94}2}'' bereits verarbeitet wurde und als n\"achstes Zeichen nun
             der Operator ``\texttt{\symbol{94}}'' gelesen wird.
             Der LALR-Parser ist dann in dem folgenden Zustand:
             \\[0.2cm]
@@ -898,9 +898,9 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             \bigr\}.
             $
             \\[0.2cm]
-            Hier muss als nächstes das Token \quoted{\texttt{\symbol{94}}} auf den Stack geschoben
-            werden, denn wir wollen ja zunächst den Ausdruck ``$3 \texttt{\symbol{94}} 4$'' berechnen.
-      \item $p(o) = p(c \rightarrow \gamma)$ und der Operator $o$ hat keine Assoziativität:
+            Hier muss als n\"achstes das Token \quoted{\texttt{\symbol{94}}} auf den Stack geschoben
+            werden, denn wir wollen ja zun\"achst den Ausdruck ``$3 \texttt{\symbol{94}} 4$'' berechnen.
+      \item $p(o) = p(c \rightarrow \gamma)$ und der Operator $o$ hat keine Assoziativit\"at:
             In diesem Fall liegt ein Syntax-Fehler vor:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -918,14 +918,14 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             \\[0.2cm]
             %$
             zu parsen.  In dem Moment, in dem Sie den Teilstring ``\texttt{1 < 1}'' gelesen haben
-            und nun das nächste Token das Zeichen ``\texttt{<}'' ist, erkennen Sie, 
+            und nun das n\"achste Token das Zeichen ``\texttt{<}'' ist, erkennen Sie, 
             dass es ein Problem gibt.  
 
             \remark
-            Beachten Sie, dass auch in diesem Fall der Shift/Reduce-Konflikt aufgelöst
-            wird, denn den Syntax-Fehler erhalten Sie erst beim Parsen,  während die
+            Beachten Sie, dass auch in diesem Fall der Shift/Reduce-Konflikt aufgel\"ost
+            wird, denn den Syntax-Fehler erhalten Sie erst beim Parsen,  w\"ahrend die
             Erstellung des Parsers selber fehlerfrei (sprich: ohne verbleibende Konflikte)
-            verläuft.
+            verl\"auft.
 
             Um in \textsc{Cup} einen Operator $o$ als nicht-assoziativ zu deklarieren, 
             schreiben Sie:
@@ -941,17 +941,17 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift/Reduce-Kon
             \hspace*{1.3cm}
             \texttt{-expect} $n$
             \\[0.2cm]
-            beim Aufruf von \textsc{Cup} unterdrückt wird.  Bei dieser Option ist $n$ die Anzahl der
+            beim Aufruf von \textsc{Cup} unterdr\"uckt wird.  Bei dieser Option ist $n$ die Anzahl der
             vom Benutzer erwarteten Konflikte. In diesem Fall wird der Konflikt dann per Default
-            dadurch aufgelöst,  dass das betreffende Token auf den Stack geschoben wird. 
-            Wir werden dieses Verhalten im nächsten Abschnitt anhand eines Beispiels im Detail 
+            dadurch aufgel\"ost,  dass das betreffende Token auf den Stack geschoben wird. 
+            Wir werden dieses Verhalten im n\"achsten Abschnitt anhand eines Beispiels im Detail 
             diskutieren. 
       \end{enumerate}
 
 \end{enumerate}
 Die von \textsc{Cup} mit der Option ``\texttt{-dump}'' erzeugte Ausgabe zeigt im Detail, wie die
-Shift/Reduce-Konflikt Konflikte aufgelöst worden sind.  Wir betrachten exemplarisch zwei Zustände in
-der Datei, die für die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Grammatik erzeugt wird.
+Shift/Reduce-Konflikt Konflikte aufgel\"ost worden sind.  Wir betrachten exemplarisch zwei Zust\"ande in
+der Datei, die f\"ur die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Grammatik erzeugt wird.
 \begin{enumerate}
 \item Der Zustand Nummer 14 hat die in Abbildung \ref{fig:state14} gezeigte Form.
       Hier gibt es unter anderem einen Shift/Reduce-Konflikt zwischen den beiden markierten Regeln
@@ -960,12 +960,12 @@ der Datei, die für die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Gramm
       $E \rightarrow E \bullet \quoted{+} E$ \quad und \quad
       $E \rightarrow E \quoted{*} E \bullet$, 
       \\[0.2cm]
-      denn die erste Regel verlangt nach einem Shift, während die zweite Regel eine Reduktion fordert.
-      Da die Regel $E \rightarrow E \quoted{*} E$ dieselbe Präzedenz wie der Operator ``\texttt{*}''
-      und dieser eine höhere Präzedenz als $\quoted{+}$ hat, wird beispielsweise beim Lesen des Zeichens
+      denn die erste Regel verlangt nach einem Shift, w\"ahrend die zweite Regel eine Reduktion fordert.
+      Da die Regel $E \rightarrow E \quoted{*} E$ dieselbe Pr\"azedenz wie der Operator ``\texttt{*}''
+      und dieser eine h\"ohere Pr\"azedenz als $\quoted{+}$ hat, wird beispielsweise beim Lesen des Zeichens
       ``\texttt{+}'' mit der Regel $E \rightarrow E \quoted{*} E$ reduziert.
       Wird hingegen das Zeichen ``\texttt{\^}'' gelesen, so wird dieses geshiftet, denn
-      dieses Zeichen hat eine höhere Priorität als die Regel
+      dieses Zeichen hat eine h\"ohere Priorit\"at als die Regel
        $E \rightarrow E \quoted{*} E$.
     \begin{figure}[!ht]
     \centering
@@ -1004,20 +1004,20 @@ der Datei, die für die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Gramm
       $E \rightarrow E \bullet \quoted{*} E$ \quad und \quad
       $E \rightarrow E \quoted{*} E \bullet$.
       \\[0.2cm]
-      Hier haben beide Regeln die gleiche Präzedenz.  Daher entscheidet die  Assoziativität.
+      Hier haben beide Regeln die gleiche Pr\"azedenz.  Daher entscheidet die  Assoziativit\"at.
       Da der Operator ``\texttt{*}'' links-assoziativ ist, wird mit der Regel
-      $E \rightarrow E \quoted{*} E$ reduziert, falls das nächste Zeichen ein Multiplikations-Operator
+      $E \rightarrow E \quoted{*} E$ reduziert, falls das n\"achste Zeichen ein Multiplikations-Operator
       ``\texttt{*}'' ist.
 \item Der Zustand Nummer 18 hat die in Abbildung \ref{fig:state18} gezeigte Form.
-      Zunächst gibt es hier einen Shift/Reduce-Konflikt zwischen den Regeln
+      Zun\"achst gibt es hier einen Shift/Reduce-Konflikt zwischen den Regeln
       \\[0.2cm]
       \hspace*{1.3cm}
       $E \rightarrow E \bullet \quoted{\symbol{94}} E$ \quad und \quad
       $E \rightarrow E \quoted{\symbol{94}} E  \bullet$,
       \\[0.2cm]
-      wenn das nächste Token der Operator ``\texttt{\symbol{94}}'' ist.  Da der Operator 
-      dieselbe Präzedenz 
-      hat wie die Regel, entscheidet die Assoziativität.  Nun ist der Operator
+      wenn das n\"achste Token der Operator ``\texttt{\symbol{94}}'' ist.  Da der Operator 
+      dieselbe Pr\"azedenz 
+      hat wie die Regel, entscheidet die Assoziativit\"at.  Nun ist der Operator
       ``\texttt{\symbol{94}}'' rechts-assoziativ, daher wird in diesem Fall geshiftet.
 
     \begin{figure}[!ht]
@@ -1059,16 +1059,16 @@ der Datei, die für die in Abbildung \ref{fig:calc-precedence.cup} gezeigte Gramm
       $E \rightarrow E \bullet \quoted{+} E$ \quad und \quad
       $E \rightarrow E \quoted{\symbol{94}} E  \bullet$,
       \\[0.2cm]
-      der auftritt, wenn das nächste Token ein ``\texttt{+}'' ist.  Da die Regel 
-      $E \rightarrow E \quoted{\symbol{94}} E$ die Präzedenz 3 hat, die größer ist als die Präzedenz 1 des
-      Operators ``\texttt{+}'' wird dieser Konflikt dadurch aufgelöst, dass mit der Regel 
+      der auftritt, wenn das n\"achste Token ein ``\texttt{+}'' ist.  Da die Regel 
+      $E \rightarrow E \quoted{\symbol{94}} E$ die Pr\"azedenz 3 hat, die gr\"o{\ss}er ist als die Pr\"azedenz 1 des
+      Operators ``\texttt{+}'' wird dieser Konflikt dadurch aufgel\"ost, dass mit der Regel 
       $E \rightarrow E \quoted{\symbol{94}} E$ reduziert wird. 
 \end{enumerate}    
 \vspace*{\fill} \pagebreak
 
 \exercise
 Implementieren Sie einen \textsc{Cup}-Parser, der in der Lage ist, eine
-\textsc{Cup}-Grammatik zu lesen und zusätzlich die folgenden Anforderungen erfüllt:
+\textsc{Cup}-Grammatik zu lesen und zus\"atzlich die folgenden Anforderungen erf\"ullt:
 \begin{enumerate}
 \item Die Grammatik soll intern in Form eines abstrakten Syntax-Baums abgespeichert werden.  
       In dem Verzeichnis 
@@ -1078,17 +1078,17 @@ Implementieren Sie einen \textsc{Cup}-Parser, der in der Lage ist, eine
 \texttt{Exercises/Grammar2HTML-Cup/}}
       \\[0.2cm]
       finden Sie verschiedene \textsl{Java}-Klassen, mit denen Sie einen solchen Syntax-Baum
-      darstellen können.  Diese Klassen implementieren eine Methode \texttt{toString()}, mit deren
-      Hilfe sich der Syntax-Baum bequem im \textsc{Html}-Format ausgeben lässt.  Außerdem enthält
+      darstellen k\"onnen.  Diese Klassen implementieren eine Methode \texttt{toString()}, mit deren
+      Hilfe sich der Syntax-Baum bequem im \textsc{Html}-Format ausgeben l\"asst.  Au{\ss}erdem enth\"alt
       das Verzeichnis auch die Datei 
       \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Exercises/Grammar2HTML-Cup/Grammatik.java}{\texttt{Grammatik.java}},
       welche die Klasse \texttt{Grammatik}
-      implementiert.  Diese Klasse enthält eine Methode \texttt{main}, mit der Sie Ihren Parser
-      testen können.
-\item Die semantischen Aktionen der gelesenen Grammatik sollen unterdrückt werden.
+      implementiert.  Diese Klasse enth\"alt eine Methode \texttt{main}, mit der Sie Ihren Parser
+      testen k\"onnen.
+\item Die semantischen Aktionen der gelesenen Grammatik sollen unterdr\"uckt werden.
 \item Testen Sie Ihr Programm, indem Sie es sowohl auf sich selbst als auch auf die im Unterricht
-      vorgestellte Grammatik für arithmetische Ausdrücke anwenden.
-      Zusätzlich können Sie es auch auf die \texttt{C}-Grammatik, die Sie unter
+      vorgestellte Grammatik f\"ur arithmetische Ausdr\"ucke anwenden.
+      Zus\"atzlich k\"onnen Sie es auch auf die \texttt{C}-Grammatik, die Sie unter
       \\[0.2cm]
       \hspace*{1.3cm}
       \href{https://github.com/karlstroetmann/Formal-Languages/blob/master/Cup/Grammars/c-grammar.cup}{https://github.com/karlstroetmann/Formal-Languages/blob/master/Cup/Grammars/c-grammar.cup}
@@ -1133,7 +1133,7 @@ Implementieren Sie einen \textsc{Cup}-Parser, der in der Lage ist, eine
            ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Fragment einer Grammatik für die Sprache \texttt{C}}
+\caption{Fragment einer Grammatik f\"ur die Sprache \texttt{C}}
 \label{fig:dangling-else.y}
 \end{figure}
 
@@ -1143,10 +1143,10 @@ von \emph{if-then-else} Konstrukten ein Shift/Reduce-Konflikt auf, den wir jetzt
 Abbildung \ref{fig:dangling-else.y} zeigt die Grammatik 
 \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/DanglingElse/dangling.cup}{\texttt{dangling.cup}},
 die einen Teil der Syntax von Befehlen der Sprache \texttt{C} beschreibt.  Um uns auf das
-Wesentliche konzentrieren zu können, sind dort die Ausdrücke nur Gleichungen und Variablen.  Das
-Token ``\texttt{ID}'' (Abkürzung für \textsl{Identifier}) steht für eine Variable, die Grammatik
+Wesentliche konzentrieren zu k\"onnen, sind dort die Ausdr\"ucke nur Gleichungen und Variablen.  Das
+Token ``\texttt{ID}'' (Abk\"urzung f\"ur \textsl{Identifier}) steht f\"ur eine Variable, die Grammatik
 beschreibt also Befehle, die aus Zuweisungen, \emph{If-Abfragen}, \emph{If-Else-Abfragen} und
-\emph{While-Schleifen} aufgebaut sind.  Übersetzen wir diese Grammatik mit \textsc{Cup}, so erhalten
+\emph{While-Schleifen} aufgebaut sind.  \"Ubersetzen wir diese Grammatik mit \textsc{Cup}, so erhalten
 wir den in Abbildung \ref{fig:dangling-else.output} ausschnittsweise gezeigten 
 Shift/Reduce-Konflikt. 
 
@@ -1211,8 +1211,8 @@ kann auf die folgenden beiden Arten gelesen werden:
       \end{verbatim}
       \vspace*{-0.7cm}
 \item Die zweite Interpretation, die nach der in Abbildung
-      \ref{fig:dangling-else.y} gezeigten Grammatik ebenfalls zulässig wäre,
-      würde den Befehl in der folgenden Form interpretieren:
+      \ref{fig:dangling-else.y} gezeigten Grammatik ebenfalls zul\"assig w\"are,
+      w\"urde den Befehl in der folgenden Form interpretieren:
       \begin{verbatim}
       if (a == b) {
           if (c == d) {
@@ -1224,49 +1224,49 @@ kann auf die folgenden beiden Arten gelesen werden:
       \end{verbatim}
       \vspace*{-0.5cm}
 
-      Hier wird das ``\texttt{else}'' dem äußeren ``\texttt{if}'' zugeordnet, was nicht der
+      Hier wird das ``\texttt{else}'' dem \"au{\ss}eren ``\texttt{if}'' zugeordnet, was nicht der
       Spezifikation der Sprache \texttt{C} entspricht. 
 \end{enumerate}
-Es gibt vier Möglichkeiten, das Problem zu lösen.
+Es gibt vier M\"oglichkeiten, das Problem zu l\"osen.
 \begin{enumerate}
-\item Tritt ein Shift/Reduce-Konflikt auf, der nicht durch Operator-Präzedenzen gelöst wird,
-      so ist der Default, dass das nächste Token auf den Stack geschoben wird.  In dem konkreten
+\item Tritt ein Shift/Reduce-Konflikt auf, der nicht durch Operator-Pr\"azedenzen gel\"ost wird,
+      so ist der Default, dass das n\"achste Token auf den Stack geschoben wird.  In dem konkreten
       Fall ist dies genau das, was wir wollen, weil dadurch das ``\texttt{else}'' immer mit dem letzten
       ``\texttt{if}'' assoziert wird.  Um die normalerweise bei Konfliken von \textsc{Cup}
-      ausgelöste Fehlermeldung zu unterdrücken, müssen wir \textsc{Cup} mit der Option
+      ausgel\"oste Fehlermeldung zu unterdr\"ucken, m\"ussen wir \textsc{Cup} mit der Option
       ``\texttt{-expect}'' wie folgt aufrufen:
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{cup -expect 1 -dump dangling.cup}
       \\[0.2cm]
       Die Zahl \texttt{1} gibt hier die Anzahl der Konflikte an, die wir erwarten.
-      So lange die spezifizierte Zahl der Konflikte mit der tatsächlich gefundenen Zahl übereinstimmt,
+      So lange die spezifizierte Zahl der Konflikte mit der tats\"achlich gefundenen Zahl \"ubereinstimmt,
       wird von \textsc{Cup} nur eine Warnung und keine Fehlermeldung ausgegeben. Insbesondere wird
       in diesem Fall ein Parser erzeugt.
-\item Die zweite Möglichkeit besteht darin, die Grammatik so umzuschreiben, dass die Mehrdeutigkeit
-      verschwindet.   Die grundsätzliche Idee ist hier, zwischen zwei Arten von Befehlen zu
+\item Die zweite M\"oglichkeit besteht darin, die Grammatik so umzuschreiben, dass die Mehrdeutigkeit
+      verschwindet.   Die grunds\"atzliche Idee ist hier, zwischen zwei Arten von Befehlen zu
       unterscheiden.
       \begin{enumerate}
       \item[(a)] Einerseits gibt es Befehle, bei denen jedem ``\texttt{if}'' auch ein ``\texttt{else}''
-            zugeordnet ist.  Zwischen einem ``\texttt{if}'' und einem ``\texttt{else}'' dürfen nur
+            zugeordnet ist.  Zwischen einem ``\texttt{if}'' und einem ``\texttt{else}'' d\"urfen nur
             solche Befehle auftreten.
 
             Wir bezeichnen Befehle dieser Form als \emph{geschlossene Befehle}.  Die Idee bei dieser
-            Sprechweise besteht darin, dass ``\texttt{if}'' als öffnende Klammer zu interpretieren,
-            während das ``\texttt{else}'' einer schließenden Klammer entspricht.  Bei einem
-            geschlossenen Befehl entspricht jeder öffnenden Klammer eine schließende Klammer.
+            Sprechweise besteht darin, dass ``\texttt{if}'' als \"offnende Klammer zu interpretieren,
+            w\"ahrend das ``\texttt{else}'' einer schlie{\ss}enden Klammer entspricht.  Bei einem
+            geschlossenen Befehl entspricht jeder \"offnenden Klammer eine schlie{\ss}ende Klammer.
      \item[(b)] Andererseits gibt es Befehle, bei denen dem letzten ``\texttt{if}'' kein
             ``\texttt{else}'' zugeordnet ist.  Solche Befehle bezeichnen wir als \emph{offene Befehle}.
-            Offene Befehle dürfen nicht zwischen einem ``\texttt{if}'' und einem ``\texttt{else}''
-            auftreten, denn dann müsste das ``\texttt{else}'' dem ``\texttt{if}'' des offenen
-            Befehls zugeordnet werden und der offene Befehl wäre in Wahrheit geschlossen.
+            Offene Befehle d\"urfen nicht zwischen einem ``\texttt{if}'' und einem ``\texttt{else}''
+            auftreten, denn dann m\"usste das ``\texttt{else}'' dem ``\texttt{if}'' des offenen
+            Befehls zugeordnet werden und der offene Befehl w\"are in Wahrheit geschlossen.
      \end{enumerate}
       Abbildung \ref{fig:dangling-else-correct.cup} zeigt die Grammatik
       \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/DanglingMatched/dangling.cup}{\texttt{dangling.cup}},
       die diese Idee umsetzt.  In der Abbildung sind nur noch die Grammatik-Regeln gezeigt, denn die
-      Deklaration der Terminale und syntaktischen Variablen hat sich gegenüber der ursprünglichen
-      Grammatik nicht verändert. Die syntaktische Kategorie \textsl{matchedStmnt} beschreibt dabei
-      die Befehle, bei denen jedem ``\texttt{if}'' ein ``\texttt{else}'' zugeordnet ist, während die
+      Deklaration der Terminale und syntaktischen Variablen hat sich gegen\"uber der urspr\"unglichen
+      Grammatik nicht ver\"andert. Die syntaktische Kategorie \textsl{matchedStmnt} beschreibt dabei
+      die Befehle, bei denen jedem ``\texttt{if}'' ein ``\texttt{else}'' zugeordnet ist, w\"ahrend die
       Kategorie \textsl{unMatchedStmnt} die restlichen Befehle erfasst.
 
 \begin{figure}[!ht]
@@ -1303,7 +1303,7 @@ Es gibt vier Möglichkeiten, das Problem zu lösen.
            ;
     \end{Verbatim}
     \vspace*{-0.3cm}
-    \caption{Eine eindeutige Grammatik für \texttt{C}-Befehle.}
+    \caption{Eine eindeutige Grammatik f\"ur \texttt{C}-Befehle.}
     \label{fig:dangling-else-correct.cup}
 \end{figure}
 
@@ -1311,16 +1311,16 @@ Es gibt vier Möglichkeiten, das Problem zu lösen.
       Aus diesem Grund haben die Entwickler der Sprache \textsl{Java} \cite{gosling:96} bei der
       \href{http://titanium.cs.berkeley.edu/doc/java-langspec-1.0/14.doc.html#5991}{Spezifikation}
       der Syntax den oben skizzierten Weg beschritten.   
-      Der Nachteil ist allerdings, dass bei diesem Vorgehen die Grammatik aufgebläht wird. 
-\item Die nächste Möglichkeit um das \emph{Dangling-Else}-Problem zu lösen, besteht darin, dass
-      wir ``\texttt{if}'' und ``\texttt{else}'' als Operatoren auffassen, denen wir eine Präzedenz
+      Der Nachteil ist allerdings, dass bei diesem Vorgehen die Grammatik aufgebl\"aht wird. 
+\item Die n\"achste M\"oglichkeit um das \emph{Dangling-Else}-Problem zu l\"osen, besteht darin, dass
+      wir ``\texttt{if}'' und ``\texttt{else}'' als Operatoren auffassen, denen wir eine Pr\"azedenz
       zuordenen.  Abbildung \ref{fig:dangling-else-precedence.cup} zeigt die Grammatik
       \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/DanglingOperator/dangling.cup}{\texttt{dangling.cup}},
       bei der dieser Weg beschritten wurde.
       \begin{enumerate}
-      \item[(a)] Zunächst haben wir in den Zeilen 1 und 2 die Terminale ``\texttt{IF}'' und
+      \item[(a)] Zun\"achst haben wir in den Zeilen 1 und 2 die Terminale ``\texttt{IF}'' und
             ``\texttt{ELSE}''  als
-            nicht-assoziative Operatoren deklariert, wobei ``\texttt{ELSE}'' die höhere Präzedenz
+            nicht-assoziative Operatoren deklariert, wobei ``\texttt{ELSE}'' die h\"ohere Pr\"azedenz
             hat.  Dadurch erreichen wir, dass ein ``\texttt{ELSE}'' auf den Stack geschoben wird,
             wenn der Parser in dem in Abbildung \ref{fig:dangling-else.output} gezeigten Zustand ist.
       \item[(b)] In Zeile 6 haben wir der Regel
@@ -1333,18 +1333,18 @@ Es gibt vier Möglichkeiten, das Problem zu lösen.
             \hspace*{1.3cm}
             \texttt{\symbol{37}prec IF}
             \\[0.2cm]
-            die Präzedenz des Operators ``\texttt{IF}'' zugewiesen.  Dies ist notwendig, weil 
-            der letzte Operator, der in dieser Regel auftritt, die schließende runde Klammer
-            ``\texttt{RPAREN}'' ist, der wir keine Priorität zugewiesen haben.  Der Klammer eine Priorität
-            zuzuweisen wäre einerseits kontraintuitiv, andererseits problematisch, da die Klammer ja
-            auch noch an anderen Stellen verwendet werden könnte.  Mit Hilfe der
-            ``\texttt{\symbol{37}prec}''-Deklaration können wir einer Regel unmittelbar die Präzedenz
+            die Pr\"azedenz des Operators ``\texttt{IF}'' zugewiesen.  Dies ist notwendig, weil 
+            der letzte Operator, der in dieser Regel auftritt, die schlie{\ss}ende runde Klammer
+            ``\texttt{RPAREN}'' ist, der wir keine Priorit\"at zugewiesen haben.  Der Klammer eine Priorit\"at
+            zuzuweisen w\"are einerseits kontraintuitiv, andererseits problematisch, da die Klammer ja
+            auch noch an anderen Stellen verwendet werden k\"onnte.  Mit Hilfe der
+            ``\texttt{\symbol{37}prec}''-Deklaration k\"onnen wir einer Regel unmittelbar die Pr\"azedenz
             eines Operators zuweisen und so das Problem umgehen.
 
-            In dem vorliegenden Fall ist die Präzedenz des Operators ``\texttt{ELSE}''
-            höher als die Präzedenz von ``\texttt{IF}'', so dass der Shift/Reduce-Konflikt
-            dadurch aufgelöst wird, dass das Token ``\texttt{ELSE}'' auf den Stack
-            geschoben wird, wodurch eine ``\texttt{else}''-Klausel tatsächlich mit der unmittelbar davor stehenden
+            In dem vorliegenden Fall ist die Pr\"azedenz des Operators ``\texttt{ELSE}''
+            h\"oher als die Pr\"azedenz von ``\texttt{IF}'', so dass der Shift/Reduce-Konflikt
+            dadurch aufgel\"ost wird, dass das Token ``\texttt{ELSE}'' auf den Stack
+            geschoben wird, wodurch eine ``\texttt{else}''-Klausel tats\"achlich mit der unmittelbar davor stehenden
             ``\texttt{if}''-Klausel verbunden wird, wie es die Definition der Sprache \texttt{C} fordert.
       \end{enumerate}
 
@@ -1380,18 +1380,18 @@ Es gibt vier Möglichkeiten, das Problem zu lösen.
            ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Auflösung des Shift/Reduce-Konflikts mit Hilfe von Operator-Präzedenzen.}
+\caption{Aufl\"osung des Shift/Reduce-Konflikts mit Hilfe von Operator-Pr\"azedenzen.}
 \label{fig:dangling-else-precedence.cup}
 \end{figure}
 
-      Operator-Präzedenzen sind ein mächtiges Mittel um eine Grammatik zu strukturieren.  Sie
+      Operator-Pr\"azedenzen sind ein m\"achtiges Mittel um eine Grammatik zu strukturieren.  Sie
       sollten allerdings mit Vorsicht eingesetzt werden, denn Sprachen wie die
-      Programmier-Sprache \texttt{C}, bei der es 15 verschiedene Operator-Präzendenzen gibt, überfordern
+      Programmier-Sprache \texttt{C}, bei der es 15 verschiedene Operator-Pr\"azendenzen gibt, \"uberfordern
       die meisten Benutzer.
-\item Die letzte Möglichkeit, das \emph{Dangling-Else}-Problem zu lösen, besteht darin, dass wir
+\item Die letzte M\"oglichkeit, das \emph{Dangling-Else}-Problem zu l\"osen, besteht darin, dass wir
       fordern, dass die Befehle, die in einem ``\texttt{if}''-Befehl verwendet werden, immer in den geschweiften
       Klammern ``\texttt{\{}'' und ``\texttt{\}}'' eingeschlossen werden.  Dies ist allerdings nur
-      dann eine Option, wenn wir die Syntax der Sprache selber definieren können.  Bei der Sprache
+      dann eine Option, wenn wir die Syntax der Sprache selber definieren k\"onnen.  Bei der Sprache
       \href{http://randoom.org/Software/SetlX}{\textsc{SetlX}}
       wurde dieser Weg beschritten.  Abbildung \ref{fig:dangling-else-brace.cup} auf Seite
       \pageref{fig:dangling-else-brace.cup} zeigt die Grammatik
@@ -1437,33 +1437,33 @@ Es gibt vier Möglichkeiten, das Problem zu lösen.
  
 
 
-\section{Auflösung von Reduce/Reduce-Konflikten}
-Im Gegensatz zu Shift/Reduce-Konflikten können Reduce/Reduce-Konflikte nicht durch Operator-Präzedenzen
-aufgelöst werden.  Wir diskutieren in diesem Abschnitt die Möglichkeiten, die wir haben um
-Reduce/Reduce-Konflikte aufzulösen.  Wir beginnen unsere Diskussion damit, dass wir die
+\section{Aufl\"osung von Reduce/Reduce-Konflikten}
+Im Gegensatz zu Shift/Reduce-Konflikten k\"onnen Reduce/Reduce-Konflikte nicht durch Operator-Pr\"azedenzen
+aufgel\"ost werden.  Wir diskutieren in diesem Abschnitt die M\"oglichkeiten, die wir haben um
+Reduce/Reduce-Konflikte aufzul\"osen.  Wir beginnen unsere Diskussion damit, dass wir die
 Reduce/Reduce-Konflikte in verschiedene Kategorien einteilen. 
 \begin{enumerate}
 \item \emph{Mehrdeutigkeits-Konflikte} sind Reduce/Reduce-Konflikte, die ihre Ursache in einer Mehrdeutigkeit
-      der zu Grunde liegenden Grammatik haben.  Solche Konflikte weisen damit auf ein tatsächliches
-      Problem der Grammatik hin.  Wir hatten ein Beispiel für solche Konflikte gesehen, als wir in
+      der zu Grunde liegenden Grammatik haben.  Solche Konflikte weisen damit auf ein tats\"achliches
+      Problem der Grammatik hin.  Wir hatten ein Beispiel f\"ur solche Konflikte gesehen, als wir in
       Abbildung \ref{fig:calc-ambiguous.cup} in der Grammatik
       \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/Calculator-Ambiguous/calc.cup}{\texttt{calc.cup}} 
-      versucht hatten, die Syntax arithmetischer Ausdrücke ohne die syntaktischen
+      versucht hatten, die Syntax arithmetischer Ausdr\"ucke ohne die syntaktischen
       Kategorien \textsl{product} und \textsl{factor} zu beschreiben.
 
-      Wir hatten damals bereits gesehen, dass wir das Problem durch die Einführung von
-      Operator-Präzedenzen lösen können.  Falls dies nicht möglich ist, dann bleibt nur das
+      Wir hatten damals bereits gesehen, dass wir das Problem durch die Einf\"uhrung von
+      Operator-Pr\"azedenzen l\"osen k\"onnen.  Falls dies nicht m\"oglich ist, dann bleibt nur das
       Umschreiben der Grammatik.
 \item \emph{Look-Ahead-Konflikte} sind Reduce/Reduce-Konflikte, bei denen die Grammatik zwar
-      einerseits eindeutig ist, für die aber andererseits
-      ein Look-Ahead von einem Token aber nicht ausreichend ist um den Konflikt zu lösen.
-\item \emph{Mysteriöse Konflikte} entstehen erst beim Übergang von den LR-Zuständen zu den LALR-Zuständen 
-      durch das Zusammenfassen von Zuständen mit dem gleichen Kern.  Diese Konflikte treten also
+      einerseits eindeutig ist, f\"ur die aber andererseits
+      ein Look-Ahead von einem Token aber nicht ausreichend ist um den Konflikt zu l\"osen.
+\item \emph{Mysteri\"ose Konflikte} entstehen erst beim \"Ubergang von den LR-Zust\"anden zu den LALR-Zust\"anden 
+      durch das Zusammenfassen von Zust\"anden mit dem gleichen Kern.  Diese Konflikte treten also
       genau dann auf, wenn das Konzept einer LALR-Grammatik nicht ausreichend ist um die Syntax der
       zu parsenden Sprache zu beschreiben.
 \end{enumerate}
-Wir betrachten die letzten beiden Fälle nun im Detail und zeigen Wege auf, wie die Konflikte gelöst
-werden können.
+Wir betrachten die letzten beiden F\"alle nun im Detail und zeigen Wege auf, wie die Konflikte gel\"ost
+werden k\"onnen.
 
 \subsection{Look-Ahead-Konflikte}
 Ein Look-Ahead-Konflikt liegt dann vor, wenn die Grammatik zwar eindeutig ist, aber ein Look-Ahead von einem
@@ -1506,13 +1506,13 @@ die zwar eindeutig ist, aber nicht die LR(1)-Eigenschaft hat.
 \end{figure}
 
 
-Berechnen wir die LR-Zustände dieser Grammatik,
+Berechnen wir die LR-Zust\"ande dieser Grammatik,
 so finden wir unter anderem den folgenden Zustand:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\{ b \rightarrow \;\squoted{X} \bullet: \squoted{U},\; c \rightarrow \;\squoted{X} \bullet: \squoted{U} \}$.
 \\[0.2cm]
-Da die Menge der Folge-Token für beide Regeln gleich sind, haben wir hier einen Reduce/Reduce-Konflikt.
+Da die Menge der Folge-Token f\"ur beide Regeln gleich sind, haben wir hier einen Reduce/Reduce-Konflikt.
 Dieser Konflikt hat seine Ursache darin, dass der Parser mit einem Look-Ahead von nur einem Token nicht
 entscheiden kann, ob ein $\squoted{X}$ als ein $b$ oder als ein $c$ zu interpretieren ist, denn dies
 entscheidet sich erst, wenn das auf $\squoted{U}$ folgende Zeichen gelesen wird:  Handelt es sich hierbei
@@ -1550,15 +1550,15 @@ und folglich ist das $\quoted{X}$ als  $c$ zu lesen.
        ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Eine zu \ref{fig:lr-conflict.g} äquivalente LR(1)-Grammatik.}
+\caption{Eine zu \ref{fig:lr-conflict.g} \"aquivalente LR(1)-Grammatik.}
 \label{fig:lr-conflict-resolved.g}
 \end{figure}
 
-Das Problem bei dieser Grammatik ist, dass sie versucht, abhängig vom Kontext ein $\squoted{X}$ wahlweise
-als ein $b$ oder als ein $c$ zu interpretieren.  Es ist offensichtlich, wie das Problem gelöst werden
+Das Problem bei dieser Grammatik ist, dass sie versucht, abh\"angig vom Kontext ein $\squoted{X}$ wahlweise
+als ein $b$ oder als ein $c$ zu interpretieren.  Es ist offensichtlich, wie das Problem gel\"ost werden
 kann:  Wenn der Kontext ``\texttt{U}'', der sowohl auf $b$ als auch auf $c$ folgt, mit in
-die Regeln für $b$ und $c$ aufgenommen wird, dann verschwindet der Konflikt, denn dann hat der
-Zustand, in dem früher der Konflikt auftrat, die Form
+die Regeln f\"ur $b$ und $c$ aufgenommen wird, dann verschwindet der Konflikt, denn dann hat der
+Zustand, in dem fr\"uher der Konflikt auftrat, die Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\{ b \rightarrow \;\squoted{X} \squoted{U}\bullet: \squoted{V},\; 
@@ -1566,13 +1566,13 @@ $\{ b \rightarrow \;\squoted{X} \squoted{U}\bullet: \squoted{V},\;
 \}
 $.
 \\[0.2cm]  
-Hier entscheidet sich nun anhand des nächsten Tokens, mit welcher Regel wir in diesem Zustand
-reduzieren müssen:  Ist das nächste Token ein $\squoted{V}$, so reduzieren wir mit der Regel
+Hier entscheidet sich nun anhand des n\"achsten Tokens, mit welcher Regel wir in diesem Zustand
+reduzieren m\"ussen:  Ist das n\"achste Token ein $\squoted{V}$, so reduzieren wir mit der Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $b \rightarrow \;\squoted{X} \squoted{U}$,
 \\[0.2cm]
-ist das nächste Token hingegen der Buchstabe $\squoted{W}$, so nehmen wir statt dessen die Regel
+ist das n\"achste Token hingegen der Buchstabe $\squoted{W}$, so nehmen wir statt dessen die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $c \rightarrow \;\squoted{X} \squoted{U}\bullet: \squoted{W}$.
@@ -1581,9 +1581,9 @@ Abbildung
 \ref{fig:lr-conflict-resolved.g} zeigt die entsprechend modifizierte Grammatik
 \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/LookAheadConflict/solved.cup}{\texttt{solved.cup}},
 
-\subsection{Mysteriöse Reduce/Reduce-Konflikte}
-Wir sprechen dann von einem \emph{mysteriösen Reduce/Reduce-Konflikt}, wenn die gegebene Grammatik eine
-LR(1)-Grammatik ist, sich aber beim Übergang von den LR-Zuständen zu den LALR-Zuständen Reduce/Reduce-Konflikte
+\subsection{Mysteri\"ose Reduce/Reduce-Konflikte}
+Wir sprechen dann von einem \emph{mysteri\"osen Reduce/Reduce-Konflikt}, wenn die gegebene Grammatik eine
+LR(1)-Grammatik ist, sich aber beim \"Ubergang von den LR-Zust\"anden zu den LALR-Zust\"anden Reduce/Reduce-Konflikte
 ergeben.  Die in Abbildung \ref{fig:mysterious.cup} gezeigte Grammatik 
 \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/MysteriousConflict/mysterious.cup}{\texttt{mysterious.cup}}
 habe ich dem 
@@ -1627,12 +1627,12 @@ habe ich dem
          ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Eine \textsc{Cup}-Grammatik mit einem mysteriösen Reduce/Reduce-Konflikt.}
+\caption{Eine \textsc{Cup}-Grammatik mit einem mysteri\"osen Reduce/Reduce-Konflikt.}
 \label{fig:mysterious.cup}
 \end{figure}
 \vspace*{0.3cm}
 
-Übersetzen wir diese Grammatik mit \textsc{Cup}, so erhalten wir unter anderem den folgenden Zustand:
+\"Ubersetzen wir diese Grammatik mit \textsc{Cup}, so erhalten wir unter anderem den folgenden Zustand:
 \begin{verbatim}
     lalr_state [1]: {
       [name ::= ID (*) , {COMMA COLON }]
@@ -1640,10 +1640,10 @@ habe ich dem
     }
 \end{verbatim}
 Da in beiden Mengen von Folgetoken das Token \texttt{COMMA} auftritt, gibt es hier offensichtlich einen
-Reduce/Reduce-Konflikt.   Um diesen Konflikt besser zu verstehen, berechnen wir zunächst die Zustände
-eines kanonischen LR-Parsers für diese Grammatik.
-Wir erhalten dann eine Menge von Zuständen, von denen die für den späteren Konflikt ursächlichen 
-Zuständen in Abbildung \ref{fig:mysterious.txt} gezeigt sind.
+Reduce/Reduce-Konflikt.   Um diesen Konflikt besser zu verstehen, berechnen wir zun\"achst die Zust\"ande
+eines kanonischen LR-Parsers f\"ur diese Grammatik.
+Wir erhalten dann eine Menge von Zust\"anden, von denen die f\"ur den sp\"ateren Konflikt urs\"achlichen 
+Zust\"anden in Abbildung \ref{fig:mysterious.txt} gezeigt sind.
 
 \begin{figure}[!ht]
 \centering
@@ -1679,19 +1679,19 @@ Zuständen in Abbildung \ref{fig:mysterious.txt} gezeigt sind.
          }
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{LR-Zustände der in Abbildung \ref{fig:mysterious.cup} gezeigten Grammatik.}
+\caption{LR-Zust\"ande der in Abbildung \ref{fig:mysterious.cup} gezeigten Grammatik.}
 \label{fig:mysterious.txt}
 \end{figure} %\$
 
-Analysieren wir die Zustände, so stellen wir fest, dass beim Übergang von LR-Zuständen zu den
-LALR-Zuständen die beiden Zustände $s_7$ und $s_8$ zu einem Zustand zusammengefasst werden, denn diese
-beiden Zustände haben den selben Kern.  Bei der Zusammenfassung entsteht der Zustand, der von
-\textsc{Cup} als ``\texttt{lalr\_state [1]}'' bezeichnet hat.  Die Zustände $s_7$ und $s_8$ selber haben
+Analysieren wir die Zust\"ande, so stellen wir fest, dass beim \"Ubergang von LR-Zust\"anden zu den
+LALR-Zust\"anden die beiden Zust\"ande $s_7$ und $s_8$ zu einem Zustand zusammengefasst werden, denn diese
+beiden Zust\"ande haben den selben Kern.  Bei der Zusammenfassung entsteht der Zustand, der von
+\textsc{Cup} als ``\texttt{lalr\_state [1]}'' bezeichnet hat.  Die Zust\"ande $s_7$ und $s_8$ selber haben
 noch keinen Konflikt, weil dort die Mengen der Folgetoken disjunkt sind.  Der Konflikt tritt erst durch
-die Vereinigung dieser beiden Mengen auf, denn dadurch ist das Token ``$\texttt{,}$'' als Folgetoken für
-beide in dem Zustand enthaltenen Regeln zulässig.   Um den Konflikt aufzulösen müssen wir verhindern, dass
-die beiden Zustände $s_7$ und $s_8$ zusammengefasst werden.  Dazu analysieren wir zunächst, wo diese
-Zustände herkommen.
+die Vereinigung dieser beiden Mengen auf, denn dadurch ist das Token ``$\texttt{,}$'' als Folgetoken f\"ur
+beide in dem Zustand enthaltenen Regeln zul\"assig.   Um den Konflikt aufzul\"osen m\"ussen wir verhindern, dass
+die beiden Zust\"ande $s_7$ und $s_8$ zusammengefasst werden.  Dazu analysieren wir zun\"achst, wo diese
+Zust\"ande herkommen.
 \begin{enumerate}
 \item Den Zustand $s_7$ erhalten wir, wenn wir im Zustand $s_0$ das Token \texttt{ID} lesen, denn
       es gilt 
@@ -1703,27 +1703,27 @@ Zustände herkommen.
       \hspace*{1.3cm}
       $s_8 = \textsl{goto}(s_2, \mathtt{ID})$.
 \end{enumerate}
-Die Idee zur Auflösung des Konflikts ist, dass wir den Zustand $s_2$ so ändern, dass die Kerne von
+Die Idee zur Aufl\"osung des Konflikts ist, dass wir den Zustand $s_2$ so \"andern, dass die Kerne von
 $s_7 = \textsl{goto}(s_0, \mathtt{ID})$ und $s_8 = \textsl{goto}(s_0, \mathtt{ID})$ unterschiedlich werden.  
-Die erweiterten markierten Regeln in den Zuständen $s_0$ und $s_2$, die letztlich für den Konflikt verantwortlich
-sind, sind die Grammatik-Regeln für die syntaktische Variablen \textsl{param\_spec} und
-\textsl{return\_spec}, denn von diesen Regeln werden die  Zustände $s_7$ und $s_8$ abgeleitet.
-Um zu verhindern, dass diese Zustände zusammengefasst werde, ändern wir die Regeln für die
+Die erweiterten markierten Regeln in den Zust\"anden $s_0$ und $s_2$, die letztlich f\"ur den Konflikt verantwortlich
+sind, sind die Grammatik-Regeln f\"ur die syntaktische Variablen \textsl{param\_spec} und
+\textsl{return\_spec}, denn von diesen Regeln werden die  Zust\"ande $s_7$ und $s_8$ abgeleitet.
+Um zu verhindern, dass diese Zust\"ande zusammengefasst werde, \"andern wir die Regeln f\"ur die
 syntaktische Variable \textsl{return\_spec} wie in der in Abbildung \ref{fig:myst-solved.g}
 gezeigten Grammatik
 \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/MysteriousConflict/mysterious-solved.cup}{\texttt{mysterious-solved.cup}}
  ab,
-indem wir eine zusätzliche Grammatik-Regel 
+indem wir eine zus\"atzliche Grammatik-Regel 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{return\_spec} \rightarrow \mathtt{ID}\;\, \mathtt{BOGUS}$
 \\[0.2cm]
-einführen.  Wenn das Terminal \texttt{BOGUS} nie vom Scanner erzeugt werden kann, dann ändert sich durch
-die Hinzunahme dieser Regel die von der Grammatik erzeugte Sprache nicht.  Allerdings ändern sich nun die
-LR-Zustände.  Abbildung \ref{fig:myst-solved.txt} zeigt, wie sich die entsprechenden Zustände ändern.
-Insbesondere sehen wir, dass der Zustand $s_8$ nun eine weitere markierte Regel enthält, zu der es in dem
-Zustand $s_7$ kein äquivalent gibt.  Die Konsequenz ist, dass diese Zustände beim Übergang von den
-LR-Zuständen zu den LALR-Zuständen nicht mehr zusammengefasst werden können, da sie unterschiedliche
+einf\"uhren.  Wenn das Terminal \texttt{BOGUS} nie vom Scanner erzeugt werden kann, dann \"andert sich durch
+die Hinzunahme dieser Regel die von der Grammatik erzeugte Sprache nicht.  Allerdings \"andern sich nun die
+LR-Zust\"ande.  Abbildung \ref{fig:myst-solved.txt} zeigt, wie sich die entsprechenden Zust\"ande \"andern.
+Insbesondere sehen wir, dass der Zustand $s_8$ nun eine weitere markierte Regel enth\"alt, zu der es in dem
+Zustand $s_7$ kein \"aquivalent gibt.  Die Konsequenz ist, dass diese Zust\"ande beim \"Ubergang von den
+LR-Zust\"anden zu den LALR-Zust\"anden nicht mehr zusammengefasst werden k\"onnen, da sie unterschiedliche
 Kerne haben.  Daher gibt es dann auch keinen Konflikt mehr. 
 
 \begin{figure}[!ht]
@@ -1758,7 +1758,7 @@ Kerne haben.  Daher gibt es dann auch keinen Konflikt mehr.
         ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Auflösung des mysteriösen Reduce/Reduce-Konflikts.}
+\caption{Aufl\"osung des mysteri\"osen Reduce/Reduce-Konflikts.}
 \label{fig:myst-solved.g}
 \end{figure}
 
@@ -1798,50 +1798,50 @@ Kerne haben.  Daher gibt es dann auch keinen Konflikt mehr.
          }
 \end{Verbatim}
 \vspace*{-0.3cm} %\$
-\caption{Einige Zustände der in Abbildung \ref{fig:myst-solved.g} gezeigten Grammatik.}
+\caption{Einige Zust\"ande der in Abbildung \ref{fig:myst-solved.g} gezeigten Grammatik.}
 \label{fig:myst-solved.txt}
 \end{figure}
 
-\section{Auflösung von Shift/Reduce-Konflikten}
+\section{Aufl\"osung von Shift/Reduce-Konflikten}
 Es gibt im wesentlichen zwei Arten von Shift/Reduce-Konflikten:
 \begin{enumerate}
-\item Konflikte, die auf eine Mehrdeutigkeit der Grammatik zurückzuführen sind.
+\item Konflikte, die auf eine Mehrdeutigkeit der Grammatik zur\"uckzuf\"uhren sind.
 
-      Solche Mehrdeutigkeits-Konflikte hatten wir beispielsweise in der Grammatik für arithmetische
-      Ausdrücke, die in Abbildung \ref{fig:shift-reduce-conflict.grammar} auf Seite
+      Solche Mehrdeutigkeits-Konflikte hatten wir beispielsweise in der Grammatik f\"ur arithmetische
+      Ausdr\"ucke, die in Abbildung \ref{fig:shift-reduce-conflict.grammar} auf Seite
       \pageref{fig:shift-reduce-conflict.grammar} gezeigt ist, diskutiert.  In dem Beispiel waren
-      diese Konflikte darauf zurückzuführen, dass durch die Grammatik keine Präzedenzen für die
+      diese Konflikte darauf zur\"uckzuf\"uhren, dass durch die Grammatik keine Pr\"azedenzen f\"ur die
       arithmetischen Operatoren festgelegt wurde, so dass am Ende nicht klar war, ob ein Ausdruck
       der Form ``\texttt{1+2*3}'' als ``\texttt{1+(2*3)}'' oder als ``\texttt{(1+2)*3}'' zu
       interpretieren ist.
 
-      Wir haben bereits früher in Abschnitt \ref{section:operator-precedence} besprochen, wie solche
-      Konflikte durch die Spezifikation von Operator-Präzedenzen aufgelöst werden können.
+      Wir haben bereits fr\"uher in Abschnitt \ref{section:operator-precedence} besprochen, wie solche
+      Konflikte durch die Spezifikation von Operator-Pr\"azedenzen aufgel\"ost werden k\"onnen.
 \item Konflikte, die entstehen, weil ein Look-Ahead von einem Token nicht ausreichend ist um zu
-      entscheiden, ob das nächste Token der Eingabe auf den Stack geschoben werden soll, oder 
+      entscheiden, ob das n\"achste Token der Eingabe auf den Stack geschoben werden soll, oder 
       ob statt dessen der Stack durch Anwendung einer Grammatik-Regel reduziert werden muss.
       Solche \emph{Look-Ahead}-Konflikte   werden wir in diesem Abschnitt diskutieren.
 \end{enumerate}
-Als Beispiel für einen Look-Ahead-Konflikt betrachten wir die in Abbildung \ref{fig:lambda.g}
+Als Beispiel f\"ur einen Look-Ahead-Konflikt betrachten wir die in Abbildung \ref{fig:lambda.g}
 gezeigte Grammatik
 \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/LambdaExpr/lambda.cup}{\texttt{lambda.cup}}.  
-Diese Grammatik beschreibt drei Arten von Ausdrücken:
+Diese Grammatik beschreibt drei Arten von Ausdr\"ucken:
 \begin{enumerate}
-\item $\lambda$-Ausdrücke haben syntaktisch die Form
+\item $\lambda$-Ausdr\"ucke haben syntaktisch die Form
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{[$x_1$, $\cdots$, $x_n$] |-> $e$}.
       \\[0.2cm]
-      Ein solcher Ausdruck steht für eine Funktion, die $n$ Argumente $x_1$, $\cdots$, $x_n$
-      verarbeitet und als Ergebnis den Ausdruck $e$ zurück liefert, wobei der Ausdruck $e$ im
-      Allgemeinen von den Parametern $x_1$, $\cdots$, $x_n$ abhängen wird.   Ein konkretes Beispiel
-      wäre etwa der $\lambda$-Ausdruck
+      Ein solcher Ausdruck steht f\"ur eine Funktion, die $n$ Argumente $x_1$, $\cdots$, $x_n$
+      verarbeitet und als Ergebnis den Ausdruck $e$ zur\"uck liefert, wobei der Ausdruck $e$ im
+      Allgemeinen von den Parametern $x_1$, $\cdots$, $x_n$ abh\"angen wird.   Ein konkretes Beispiel
+      w\"are etwa der $\lambda$-Ausdruck
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{[x, y] |-> [x, y, x]}.
-\item Zusätzlich sind als Ausdrücke Variablen-Namen zugelassen.
-\item Außerdem sind auch Listen von Ausdrücken möglich, wobei diese Listen in eckigen Klammern
-      eingefasst werden.  Diese Listen können dabei beliebig geschachtelt sein.
+\item Zus\"atzlich sind als Ausdr\"ucke Variablen-Namen zugelassen.
+\item Au{\ss}erdem sind auch Listen von Ausdr\"ucken m\"oglich, wobei diese Listen in eckigen Klammern
+      eingefasst werden.  Diese Listen k\"onnen dabei beliebig geschachtelt sein.
 \end{enumerate}
 
 \begin{figure}[!ht]
@@ -1876,11 +1876,11 @@ Diese Grammatik beschreibt drei Arten von Ausdrücken:
           ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Eine \textsc{Cup}-Grammatik für $\lambda$-Ausdrücke.}
+\caption{Eine \textsc{Cup}-Grammatik f\"ur $\lambda$-Ausdr\"ucke.}
 \label{fig:lambda.g}
 \end{figure}
 
-Versuchen wir mit \textsc{Cup} einen Parser für diese Grammatik zu erzeugen, so erhalten wir
+Versuchen wir mit \textsc{Cup} einen Parser f\"ur diese Grammatik zu erzeugen, so erhalten wir
 verschiedene Shift/Reduce-Konflikte.  Diese Konflikte entstehen in dem Zustand Nummer 6, der in
 Abbildung \ref{fig:lambda.g:state6} gezeigt ist.  Da auf eine \textsl{expr} ein ``\texttt{,}''
 folgen kann, dieses aber in dem Zustand gleichzeitig auch auf den Stack geschoben werden kann, ist
@@ -1890,16 +1890,16 @@ nicht klar, ob mit der Regel
 $\textsl{expr} \rightarrow \mathtt{IDENTIFIER}$
 \\[0.2cm]
 reduziert werden darf, wenn das Look-Ahead-Token ein Komma ist.  Um zu entscheiden, ob der Parser
-versucht eine Liste von \texttt{IDENTIFIER}n zu parsen, müsste der Parser bis zu dem Token
-\texttt{MAPSTO} schauen können.  Wenn später ein solches Token noch kommt, dann würde der Parser im
+versucht eine Liste von \texttt{IDENTIFIER}n zu parsen, m\"usste der Parser bis zu dem Token
+\texttt{MAPSTO} schauen k\"onnen.  Wenn sp\"ater ein solches Token noch kommt, dann w\"urde der Parser im
 Zustand 6 versuchen, eine \texttt{identifierList} zu parsen und das Komma sollte auf den Stack
-geschoben werden.  Andernfalls könnte mit der Regel 
+geschoben werden.  Andernfalls k\"onnte mit der Regel 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{expr} \rightarrow \mathtt{IDENTIFIER}$
 \\[0.2cm]
-reduziert werden. Leider lässt ein LR-Parser-Generator nicht zu, dass wir den noch ungelesenen Teil
-der Eingabe inspizieren.  Wir müssen daher eine andere Lösung suchen.
+reduziert werden. Leider l\"asst ein LR-Parser-Generator nicht zu, dass wir den noch ungelesenen Teil
+der Eingabe inspizieren.  Wir m\"ussen daher eine andere L\"osung suchen.
 
 \begin{figure}[!ht]
 \centering
@@ -1923,15 +1923,15 @@ der Eingabe inspizieren.  Wir müssen daher eine andere Lösung suchen.
 \label{fig:lambda.g:state6}
 \end{figure}
 
-Wir können den Shift/Reduce-Konflikt lösen, indem wir die Grammatik wie in der in Abbildung
+Wir k\"onnen den Shift/Reduce-Konflikt l\"osen, indem wir die Grammatik wie in der in Abbildung
 \ref{fig:lambda-generalized.cup} gezeigten Grammatik
 \href{https://github.com/karlstroetmann/Formal-Languages/tree/master/Cup/LambdaExpr/lambda-generalized.cup}{\texttt{lambda-generalized.cup}}
- \textbf{verallgemeinern}.  Diese Grammatik lässt auch
-Ausdrücke zu, bei denen in der Argument-Liste nicht nur Variablen-Namen enthält, sondern Ausdrücke
-beliebiger Komplexität.  Damit beschreibt diese Grammatik eine Sprache, die eigentlich zu allgemein
-ist.  Es ist aber ein leichtes, später den resultierenden Syntax-Baum drauf hin zu untersuchen, ob
-in der Parameter-Liste tatsächlich nur Variablen stehen oder nicht.  Daher bietet eine solche
-Verallgemeinerung der Grammatik eine praktische Möglichkeit um Shift/Reduce-Konflikte zu lösen.
+ \textbf{verallgemeinern}.  Diese Grammatik l\"asst auch
+Ausdr\"ucke zu, bei denen in der Argument-Liste nicht nur Variablen-Namen enth\"alt, sondern Ausdr\"ucke
+beliebiger Komplexit\"at.  Damit beschreibt diese Grammatik eine Sprache, die eigentlich zu allgemein
+ist.  Es ist aber ein leichtes, sp\"ater den resultierenden Syntax-Baum drauf hin zu untersuchen, ob
+in der Parameter-Liste tats\"achlich nur Variablen stehen oder nicht.  Daher bietet eine solche
+Verallgemeinerung der Grammatik eine praktische M\"oglichkeit um Shift/Reduce-Konflikte zu l\"osen.
 
 \begin{figure}[!ht]
 \centering
@@ -1963,7 +1963,7 @@ Verallgemeinerung der Grammatik eine praktische Möglichkeit um Shift/Reduce-Konf
           ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Die verallgemeinerte Grammatik für $\lambda$-Ausdrücke.}
+\caption{Die verallgemeinerte Grammatik f\"ur $\lambda$-Ausdr\"ucke.}
 \label{fig:lambda-generalized.cup}
 \end{figure}
 \vspace*{\fill}

--- a/Lecture-Notes/earley-parser.tex
+++ b/Lecture-Notes/earley-parser.tex
@@ -1,5 +1,5 @@
 \chapter{Earley-Parser$^*$}
-In diesem Kapitel stellen wir ein effizientes Verfahren vor, mit dem es möglich ist, für eine
+In diesem Kapitel stellen wir ein effizientes Verfahren vor, mit dem es m\"oglich ist, f\"ur eine
 \underline{beliebi}g\underline{e} vorgegebene kontextfreie Grammatik
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -9,25 +9,25 @@ zu entscheiden, ob $s$ ein Element der Sprache $L(G)$ ist, ob also $s \in L(G)$ 
 Der Algorithmus, denn wir gleich diskutieren werden, wurde 1970 von Jay Earley publiziert
 \cite{earley:70}.  Neben dem Algorithmus von Earley gibt es noch den
 Cocke-Younger-Kasami-Algorithmus, in der Literatur auch als \textsc{Cyk}-Algorithmus bekannt,
-der unabhängig von John Cocke \cite{cocke:1970}, Daniel
+der unabh\"angig von John Cocke \cite{cocke:1970}, Daniel
 H.~Younger \cite{younger:1967} und Tadao Kasami \cite{kasami:1965} entdeckt wurde.
-Der \textsc{Cyk}-Algorithmus hat allerdings eine Laufzeit von $\mathcal{O}(n^3)$ und ist außerdem nur anwendbar, wenn
+Der \textsc{Cyk}-Algorithmus hat allerdings eine Laufzeit von $\mathcal{O}(n^3)$ und ist au{\ss}erdem nur anwendbar, wenn
 die Grammatik in Chomsky-Normalform vorliegt.  Da es sehr aufwendig ist, eine Grammatik in
 Chomsky-Normalform zu transformieren, wird der \textsc{Cyk}-Algorithmus in der
 Praxis nicht eingesetzt.  
-Demgegenüber kann der von Earley angegebene Algorithmus auf beliebige kontextfreie Grammatiken
-angewendet werden.  Im allgemeinen Fall hat dieser Algorithmus ebenfalls die Komplexität
-$\mathcal{O}(n^3)$, aber falls die vorgegebene Grammatik eindeutig ist, dann ist die Komplexität
+Demgegen\"uber kann der von Earley angegebene Algorithmus auf beliebige kontextfreie Grammatiken
+angewendet werden.  Im allgemeinen Fall hat dieser Algorithmus ebenfalls die Komplexit\"at
+$\mathcal{O}(n^3)$, aber falls die vorgegebene Grammatik eindeutig ist, dann ist die Komplexit\"at
 lediglich $\mathcal{O}(n^2)$,
 Geschickte Implementierungen von Earley's Algorithmus
-erreichen für viele praktisch relevante Grammatiken sogar eine lineare Laufzeit.  Dies ist
-beispielsweise sowohl für $LL(k)$-Grammatiken als auch für $LR(1)$-Grammatiken, die wir in einem späteren Kapitel analysieren werden, der Fall.
+erreichen f\"ur viele praktisch relevante Grammatiken sogar eine lineare Laufzeit.  Dies ist
+beispielsweise sowohl f\"ur $LL(k)$-Grammatiken als auch f\"ur $LR(1)$-Grammatiken, die wir in einem sp\"ateren Kapitel analysieren werden, der Fall.
 Dieses Kapitel gliedert sich in die folgenden Abschnitte.
 \begin{enumerate}
-\item Zunächst skizzieren wir die Theorie, die Earley's Algorithmus zu Grunde liegt.
+\item Zun\"achst skizzieren wir die Theorie, die Earley's Algorithmus zu Grunde liegt.
 \item Danach geben wir eine einfache Implementierung des Algorithmus in \textsc{SetlX} an.
-\item Anschließend beweisen wir die Korrektheit und Vollständigkeit des Algorithmus.
-\item Zum Abschluss des Kapitels untersuchen wir die Komplexität.
+\item Anschlie{\ss}end beweisen wir die Korrektheit und Vollst\"andigkeit des Algorithmus.
+\item Zum Abschluss des Kapitels untersuchen wir die Komplexit\"at.
 \end{enumerate}
 
 \section{Der Algorithmus von Earley}
@@ -36,7 +36,7 @@ das wie folgt definiert ist.
 
 \begin{Definition}[Earley-Objekt]
   Gegeben sei eine kontextfreie Grammatik $G = \langle V, \Sigma, R, S \rangle$ und ein String
-  $s = x_1x_2 \cdots x_n \in \Sigma^*$ der Länge $n$.  Wir bezeichnen ein Paar der Form
+  $s = x_1x_2 \cdots x_n \in \Sigma^*$ der L\"ange $n$.  Wir bezeichnen ein Paar der Form
   \\[0.2cm]
   \hspace*{1.3cm}
   $\langle A \rightarrow \alpha \bullet \beta, k \rangle$
@@ -49,7 +49,7 @@ das wie folgt definiert ist.
 \end{Definition}
 
 \noindent
-\textbf{Erklärung}: 
+\textbf{Erkl\"arung}: 
 Ein Earley-Objekt beschreibt einen Zustand, in dem ein Parser sich befinden kann.  
 Ein Earley-Parser, der einen String $x_1 \cdots x_n$ parsen soll,
 verwaltet $n+1$ Mengen von Earley-Objekten.  Diese Mengen bezeichnen wir mit
@@ -74,22 +74,22 @@ ist dann wie folgt:
 \item Folglich versucht der Parser am Anfang des Teilstrings $x_{j+1} \cdots x_n$ ein
       $\beta$ erkennen.
 \end{enumerate}
-Der Algorithmus von Earley verwaltet für $j=0,1,\cdots,n$  Mengen $Q_j$ von
+Der Algorithmus von Earley verwaltet f\"ur $j=0,1,\cdots,n$  Mengen $Q_j$ von
 Earley-Objekten, die den Zustand beschreiben, in dem der Parser ist, wenn der Teilstring
 $x_1 \cdots x_j$ verarbeitet ist.  Zu Beginn des Algorithmus wird der Grammatik ein neues Start-Symbol $\widehat{S}$ 
-sowie die Regel $\widehat{S} \rightarrow S$ hinzugefügt.  Die Menge $Q_0$ wird definiert als
+sowie die Regel $\widehat{S} \rightarrow S$ hinzugef\"ugt.  Die Menge $Q_0$ wird definiert als
 \\[0.2cm]
 \hspace*{1.3cm}
 $Q_0 := \bigl\{ \pair(\widehat{S} \rightarrow \bullet S, 0) \bigr\}$,
 \\[0.2cm]
 denn der Parser soll ja das Start-Symbol $S$ am Anfang des Strings $x_1 \cdots x_n$ erkennen.
-Die restlichen Mengen $Q_j$ sind für $j=1,\cdots,n$ zunächst leer.  Die Mengen $Q_j$ werden nun durch die
-folgende drei Operationen so lange wie möglich erweitert: 
+Die restlichen Mengen $Q_j$ sind f\"ur $j=1,\cdots,n$ zun\"achst leer.  Die Mengen $Q_j$ werden nun durch die
+folgende drei Operationen so lange wie m\"oglich erweitert: 
 \begin{enumerate}
 \item \emph{Lese-Operation}
 
       Falls der Zustand $Q_j$ ein Earley-Objekt der Form 
-      $\pair(A \rightarrow \beta \bullet a \gamma, k)$ enthält, wobei $a$ ein
+      $\pair(A \rightarrow \beta \bullet a \gamma, k)$ enth\"alt, wobei $a$ ein
       Terminal ist, so versucht der Parser, die rechte Seite der Regel
       $A \rightarrow \beta a \gamma$ zu erkennen und hat bis zur Position $j$ bereits den Teil $\beta$ erkannt.
       Folgt auf dieses $\beta$ nun, wie in der Regel $A \rightarrow \beta a \gamma$
@@ -100,7 +100,7 @@ folgende drei Operationen so lange wie möglich erweitert:
       \hspace*{1.3cm}
       $\pair(A \rightarrow \beta a \bullet \gamma, k)$
       \\[0.2cm]
-      dem Zustand $Q_{j+1}$ hinzugefügt:
+      dem Zustand $Q_{j+1}$ hinzugef\"ugt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(A \rightarrow \beta \bullet a \gamma, k) \in Q_j \wedge x_{j+1} = a
@@ -109,9 +109,9 @@ folgende drei Operationen so lange wie möglich erweitert:
 \item \emph{Vorhersage-Operation}
 
       Falls der Zustand $Q_j$ ein Earley-Objekt der Form $\pair(A \rightarrow \beta \bullet C \delta, k)$
-      enthält, wobei $C$ eine syntaktische Variable ist, so versucht der Parser im Zustand
+      enth\"alt, wobei $C$ eine syntaktische Variable ist, so versucht der Parser im Zustand
       $Q_j$ den Teilstring $C\delta$ zu erkennen.  Dazu muss der Parser an diesem Punkt ein $C$ erkennen.  
-      Wir fügen daher für jede Regel $C \rightarrow \gamma$ der Grammatik das Earley-Objekt 
+      Wir f\"ugen daher f\"ur jede Regel $C \rightarrow \gamma$ der Grammatik das Earley-Objekt 
       $\pair(C \rightarrow \bullet \gamma, j)$ zu der Menge $Q_j$ hinzu:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -119,13 +119,13 @@ folgende drei Operationen so lange wie möglich erweitert:
        \wedge (C \rightarrow \gamma) \in R 
        \;\Rightarrow\;
        Q_j := Q_j \cup\bigl\{ \pair(C \rightarrow \bullet\gamma, j)\bigr\}$.
-\item \emph{Vervollständigungs-Operation}
+\item \emph{Vervollst\"andigungs-Operation}
 
       Falls der Zustand $Q_i$ ein Earley-Objekt der Form $\pair(C \rightarrow \gamma \bullet, j)$
-      enthält und weiter der Zustand $Q_j$ ein Earley-Objekt der Form 
-      $\pair(A \rightarrow \beta \bullet C \delta,k)$ enthält, dann hat der Parser im Zustand $Q_j$
+      enth\"alt und weiter der Zustand $Q_j$ ein Earley-Objekt der Form 
+      $\pair(A \rightarrow \beta \bullet C \delta,k)$ enth\"alt, dann hat der Parser im Zustand $Q_j$
       versucht, ein $C$ zu parsen und das $C$ ist im Zustand $Q_i$ erkannt worden.  
-      Daher fügen wir dem Zustand
+      Daher f\"ugen wir dem Zustand
       $Q_i$ nun das Earley-Objekt $\pair(A \rightarrow \beta C \bullet \delta,k)$ hinzu:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -136,40 +136,40 @@ folgende drei Operationen so lange wie möglich erweitert:
 \end{enumerate}
 Der Algorithmus von Earley um einen String der Form $s = x_1 \cdots x_n$ zu parsen funktioniert so:
 \begin{enumerate}
-\item Wir initialisieren die Zustände $Q_i$ wie folgt:
+\item Wir initialisieren die Zust\"ande $Q_i$ wie folgt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $Q_0 := \bigl\{ \pair(\widehat{S} \rightarrow \bullet S, 0) \bigr\}$,
       \\[0.2cm]
       \hspace*{1.3cm}
-      $Q_i := \bigl\{ \bigr\}$ \quad für $i=1,\cdots,n$.
-\item Anschließend lassen wir in einer Schleife $i$ von $0$ bis $n$ laufen und führen die folgenden 
+      $Q_i := \bigl\{ \bigr\}$ \quad f\"ur $i=1,\cdots,n$.
+\item Anschlie{\ss}end lassen wir in einer Schleife $i$ von $0$ bis $n$ laufen und f\"uhren die folgenden 
       Schritte durch:
       \begin{enumerate}
-      \item Wir vergrößern $Q_i$ mit der Vervollständigungs-Operation so lange, bis mit dieser Operation
-            keine neuen Earley-Objekte mehr gefunden werden können.
-      \item Anschließend vergrößern wir $Q_i$ mit Hilfe der Vorhersage-Operation.  Diese Operation
-            wird ebenfalls so lange durchgeführt, wie neue Earley-Objekte gefunden werden.
+      \item Wir vergr\"o{\ss}ern $Q_i$ mit der Vervollst\"andigungs-Operation so lange, bis mit dieser Operation
+            keine neuen Earley-Objekte mehr gefunden werden k\"onnen.
+      \item Anschlie{\ss}end vergr\"o{\ss}ern wir $Q_i$ mit Hilfe der Vorhersage-Operation.  Diese Operation
+            wird ebenfalls so lange durchgef\"uhrt, wie neue Earley-Objekte gefunden werden.
       \item Falls $i < n$ ist, wenden wir die Lese-Operation auf $Q_i$ an und initialisierend damit
             $Q_{i+1}$. 
       \end{enumerate}
-      Falls die betrachtete Grammatik $G$ auch $\varepsilon$-Regeln enthält, also Regeln der Form
+      Falls die betrachtete Grammatik $G$ auch $\varepsilon$-Regeln enth\"alt, also Regeln der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $C \rightarrow \varepsilon$,
       \\[0.2cm]
       dann kann es passieren, dass durch die Anwendung einer Vorhersage-Operation eine neue Anwendung
-      der Vervollständigungs-Operation möglich wird.  In diesem Fall müssen Vorhersage-Operation und
-      Vervollständigungs-Operation so lange iteriert werden, bis durch Anwendung dieser beiden
-      Operationen keine neuen Earley-Objekte mehr erzeugt werden können.
+      der Vervollst\"andigungs-Operation m\"oglich wird.  In diesem Fall m\"ussen Vorhersage-Operation und
+      Vervollst\"andigungs-Operation so lange iteriert werden, bis durch Anwendung dieser beiden
+      Operationen keine neuen Earley-Objekte mehr erzeugt werden k\"onnen.
 \item Falls nach Beendigung des Algorithmus die Menge $Q_n$ das Earley-Objekt 
-      $\pair(\widehat{S} \rightarrow S \bullet,0)$ enthält, dann war das Parsen erfolgreich und 
+      $\pair(\widehat{S} \rightarrow S \bullet,0)$ enth\"alt, dann war das Parsen erfolgreich und 
       der String $x_1 \cdots x_n$ liegt in der von der Grammatik erzeugten Sprache.
 \end{enumerate}
   
 \example
-Abbildung \ref{fig:expr-small} zeigt eine vereinfachte Grammatik für arithmetische
-Ausdrücke, die nur aus den Zahlen ``1'', ``2'' und ``3'' und den beiden Operator-Symbolen
+Abbildung \ref{fig:expr-small} zeigt eine vereinfachte Grammatik f\"ur arithmetische
+Ausdr\"ucke, die nur aus den Zahlen ``1'', ``2'' und ``3'' und den beiden Operator-Symbolen
 ``\texttt{+}'' und ``\texttt{*}'' aufgebaut sind.  Die Menge $T$ der Terminale dieser
 Grammatik ist also durch
 \\[0.2cm]
@@ -178,10 +178,10 @@ Grammatik ist also durch
 \\[0.2cm]
 gegeben.
 Wie zeigen, wie sich der String
-``\texttt{1+2*3}'' mit dieser Grammatik und dem Algorithmus von Earley parsen lässt.
+``\texttt{1+2*3}'' mit dieser Grammatik und dem Algorithmus von Earley parsen l\"asst.
 In der folgenden Darstellung werden wir die syntaktische Variable \texttt{expr} mit
-dem Buchstaben $E$ abkürzen, für \texttt{prod} schreiben wir $P$ und für \texttt{fact} verwenden wir die
-Abkürzung $F$.
+dem Buchstaben $E$ abk\"urzen, f\"ur \texttt{prod} schreiben wir $P$ und f\"ur \texttt{fact} verwenden wir die
+Abk\"urzung $F$.
 
 
 \begin{figure}[!ht]
@@ -208,7 +208,7 @@ Abkürzung $F$.
          ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-  \caption{Eine vereinfachte Grammatik für arithmetische Ausdrücke.}
+  \caption{Eine vereinfachte Grammatik f\"ur arithmetische Ausdr\"ucke.}
   \label{fig:expr-small} 
 \end{figure}
 
@@ -219,21 +219,21 @@ Abkürzung $F$.
       \hspace*{1.3cm}
       $Q_0 = \{ \pair(\widehat{S} \rightarrow \bullet\, E, 0) \}$. 
       \\[0.2cm]
-      Die Mengen $Q_1$, $Q_2$, $Q_3$, $Q_4$ und $Q_5$ sind zunächst alle leer.
-      Wenden wir die Vervollständigungs-Operation auf $Q_0$ an, so finden wir keine neuen
+      Die Mengen $Q_1$, $Q_2$, $Q_3$, $Q_4$ und $Q_5$ sind zun\"achst alle leer.
+      Wenden wir die Vervollst\"andigungs-Operation auf $Q_0$ an, so finden wir keine neuen
       Earley-Objekte.
 
-      Anschließend wenden wir die Vorhersage-Operation auf das Earley-Objekt 
+      Anschlie{\ss}end wenden wir die Vorhersage-Operation auf das Earley-Objekt 
       $\pair(\widehat{S} \rightarrow \bullet\, E, 0)$ an.  Dadurch werden der Menge $Q_0$ 
-      zunächst die beiden Earley-Objekte 
+      zun\"achst die beiden Earley-Objekte 
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(E \rightarrow \bullet\; E \squoted{+} P, 0)$ 
       \quad und \quad
       $\pair(E \rightarrow \bullet\; P, 0)$ 
       \\[0.2cm]
-      hinzugefügt.  Auf das Earley-Objekt $\pair(E \rightarrow \bullet\, P, 0)$ 
-      können wir die Vorhersage-Operation ein weiteres Mal anwenden und erhalten dann die beiden
+      hinzugef\"ugt.  Auf das Earley-Objekt $\pair(E \rightarrow \bullet\, P, 0)$ 
+      k\"onnen wir die Vorhersage-Operation ein weiteres Mal anwenden und erhalten dann die beiden
       neuen Earley-Objekte
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -242,14 +242,14 @@ Abkürzung $F$.
       $\pair(P \rightarrow \bullet\; F, 0)$. 
       \\[0.2cm]
       Wenden wir auf das Earley-Objekt $\pair(P \rightarrow \bullet\; F, 0)$
-      die Vorhersage-Operation an, so erhalten wir schießlich noch die folgenden Earley-Objekte in $Q_0$:
+      die Vorhersage-Operation an, so erhalten wir schie{\ss}lich noch die folgenden Earley-Objekte in $Q_0$:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(F \rightarrow \bullet \squoted{1}, 0)$, \quad 
       $\pair(F \rightarrow \bullet \squoted{2}, 0)$, \quad und \quad
       $\pair(F \rightarrow \bullet \squoted{3}, 0)$. 
       \\[0.2cm]
-      Insgesamt enthält $Q_0$ nun die folgenden Earley-Objekte:
+      Insgesamt enth\"alt $Q_0$ nun die folgenden Earley-Objekte:
       \begin{enumerate}
       \item $\pair(\widehat{S} \rightarrow \bullet\; E, 0)$,
       \item $\pair(E \rightarrow \bullet\; E \squoted{+} P, 0)$
@@ -266,20 +266,20 @@ Abkürzung $F$.
       \\[0.2cm]
       \hspace*{1.3cm}
       $Q_1 = \bigl\{ \pair(F \rightarrow \squoted{1} \bullet, 0) \bigr\}$.
-\item Nun setzen wir $i= 1$ und wenden zunächst auf $Q_1$ die Vervollständigungs-Operation an.
+\item Nun setzen wir $i= 1$ und wenden zun\"achst auf $Q_1$ die Vervollst\"andigungs-Operation an.
       Aufgrund des Earley-Objekts $\pair(F \rightarrow \squoted{1} \bullet, 0) $ in $Q_1$
       suchen wie in $Q_0$ ein Earley-Objekt, bei dem die Markierung ``$\bullet$'' vor der Variablen
       $F$ steht.  Wir finden das Earley-Objekt
-      $\pair(P \rightarrow \bullet\; F, 0)$.  Daher fügen wir nun
+      $\pair(P \rightarrow \bullet\; F, 0)$.  Daher f\"ugen wir nun
       $Q_1$ das Earley-Objekt
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(P \rightarrow F \;\bullet, 0)$ 
       \\[0.2cm]
-      hinzu.  Hierauf können wir wieder die
-      Vervollständigungs-Operation anwenden und finden (nach mehrmaliger Anwendung der
-      Vervollständigungs-Operation) für $Q_1$ insgesamt die folgenden Earley-Objekte durch
-      Vervollständigung:
+      hinzu.  Hierauf k\"onnen wir wieder die
+      Vervollst\"andigungs-Operation anwenden und finden (nach mehrmaliger Anwendung der
+      Vervollst\"andigungs-Operation) f\"ur $Q_1$ insgesamt die folgenden Earley-Objekte durch
+      Vervollst\"andigung:
       \begin{enumerate}
       \item $\pair(P \rightarrow F \;\bullet, 0)$, 
       \item $\pair(P \rightarrow  P\;\bullet \squoted{*} F, 0)$, 
@@ -288,7 +288,7 @@ Abkürzung $F$.
       \item $\pair(\widehat{S} \rightarrow  E\;\bullet, 0)$.
       \end{enumerate}
       
-      Als nächstes wenden wir auf diese Earley-Objekte die Vorhersage-Operation an.  Da das
+      Als n\"achstes wenden wir auf diese Earley-Objekte die Vorhersage-Operation an.  Da das
       Markierungs-Zeichen ``$\bullet$'' aber in keinem der in $Q_i$ auftretenden Earley-Objekte vor einer 
       Variablen steht, ergeben sich hierbei keine neuen Earley-Objekte.
 
@@ -298,24 +298,24 @@ Abkürzung $F$.
       \hspace*{1.3cm}
       $\pair(E \rightarrow E\;\bullet \squoted{+} P, 0)$
       \\[0.2cm]
-      enthält, fügen wir in $Q_2$  das Earley-Objekt
+      enth\"alt, f\"ugen wir in $Q_2$  das Earley-Objekt
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(E \rightarrow E \squoted{+}\bullet\; P, 0)$
       \\[0.2cm]
       ein.
-\item Nun setzen wir $i= 2$ und wenden zunächst auf $Q_2$ die Vervollständigungs-Operation
+\item Nun setzen wir $i= 2$ und wenden zun\"achst auf $Q_2$ die Vervollst\"andigungs-Operation
       an.  Zu diesem Zeitpunkt gilt
       \\[0.2cm]
       \hspace*{1.3cm}
       $Q_2 = \{ \pair(E \rightarrow E \squoted{+}\bullet\; P, 0) \}$.
       \\[0.2cm]
       Da in dem einzigen Earley-Objekt, das hier auftritt, das Markierungs-Zeichen ``$\bullet$''
-      nicht am Ende der Grammatik-Regel steht, finden wir durch die Vervollständigungs-Operation in
+      nicht am Ende der Grammatik-Regel steht, finden wir durch die Vervollst\"andigungs-Operation in
       diesem Schritt keine       neuen Earley-Objekte. 
 
-      Als nächstes wenden wir auf $Q_2$ die Vorhersage-Operation an.  Da das Markierungs-Zeichen
-      vor der Variablen $P$ steht, finden wir zunächst die beiden Earley-Objekte
+      Als n\"achstes wenden wir auf $Q_2$ die Vorhersage-Operation an.  Da das Markierungs-Zeichen
+      vor der Variablen $P$ steht, finden wir zun\"achst die beiden Earley-Objekte
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(P \rightarrow \bullet\; F, 2)$ \quad und \quad
@@ -335,14 +335,14 @@ Abkürzung $F$.
       \\[0.2cm]
       \hspace*{1.3cm}
       $Q_3 = \{ \pair(F \rightarrow \squoted{2}\bullet, 2) \}$.
-\item Wir setzen $i = 3$ und wenden auf $Q_3$ die Vervollständigungs-Operation an.
-      Dadurch fügen wir 
+\item Wir setzen $i = 3$ und wenden auf $Q_3$ die Vervollst\"andigungs-Operation an.
+      Dadurch f\"ugen wir 
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(P \rightarrow F \;\bullet, 2)$ 
       \\[0.2cm]
-      in $Q_3$ ein.  Hier können wir eine weiteres Mal die Vervollständigungs-Operation anwenden. 
-      Durch iterierte Anwendung der Vervollständigungs-Operation erhalten wir zusätzlich die folgenden 
+      in $Q_3$ ein.  Hier k\"onnen wir eine weiteres Mal die Vervollst\"andigungs-Operation anwenden. 
+      Durch iterierte Anwendung der Vervollst\"andigungs-Operation erhalten wir zus\"atzlich die folgenden 
       Earley-Objekte:
       \begin{enumerate}
       \item $\pair(P \rightarrow P \bullet \squoted{*} F, 2)$,
@@ -350,23 +350,23 @@ Abkürzung $F$.
       \item $\pair(E \rightarrow E\;\bullet \squoted{+} P, 0)$
       \item $\pair(\widehat{S} \rightarrow E\bullet, 0)$.
       \end{enumerate}
-      Als letztes wenden wir die Lese-Operation an.  Da der nächste zu lesende Buchstabe das Zeichen
+      Als letztes wenden wir die Lese-Operation an.  Da der n\"achste zu lesende Buchstabe das Zeichen
       ``\texttt{*}'' ist, erhalten wir
       \\[0.2cm]
       \hspace*{1.3cm}
       $Q_4 = \{ \pair(P \rightarrow P \squoted{*} \bullet\, F, 2) \}$.
-\item Wir setzen $i= 4$.  Die Vervollständigungs-Operation liefert keine neuen Earley-Objekte.
+\item Wir setzen $i= 4$.  Die Vervollst\"andigungs-Operation liefert keine neuen Earley-Objekte.
       Die Vorhersage-Operation liefert folgende Earley-Objekte:
       \begin{enumerate}
       \item $\pair(F \rightarrow \bullet \squoted{1}, 4)$, 
       \item $\pair(F \rightarrow \bullet \squoted{2}, 4)$,
       \item $\pair(F \rightarrow \bullet \squoted{3}, 4)$.
       \end{enumerate}
-      Da das nächste Zeichen die Ziffer ``3'' ist, liefert die Lese-Operation für $Q_5$:
+      Da das n\"achste Zeichen die Ziffer ``3'' ist, liefert die Lese-Operation f\"ur $Q_5$:
       \\[0.2cm]
       \hspace*{1.3cm}
       $Q_5 = \pair(F \rightarrow \squoted{3}\bullet, 4) \}$.
-\item Wir setzen $i=5$.  Die Vervollständigungs-Operation liefert nacheinander die folgenden
+\item Wir setzen $i=5$.  Die Vervollst\"andigungs-Operation liefert nacheinander die folgenden
       Earley-Objekte:
       \begin{enumerate}
       \item $\pair(P \rightarrow P \squoted{*} F\;\bullet, 2)$,
@@ -376,8 +376,8 @@ Abkürzung $F$.
       \item $\pair(\widehat{S} \rightarrow  E\;\bullet, 0)$.
       \end{enumerate}
 \end{enumerate}
-Da die Menge $Q_5$ das Earley-Objekt $\pair(\widehat{S} \rightarrow  E\;\bullet, 0)$ enthält,
-können wir schließen, dass der String ``\texttt{1+2*3}'' tatsächlich in der von der Grammatik erzeugten
+Da die Menge $Q_5$ das Earley-Objekt $\pair(\widehat{S} \rightarrow  E\;\bullet, 0)$ enth\"alt,
+k\"onnen wir schlie{\ss}en, dass der String ``\texttt{1+2*3}'' tats\"achlich in der von der Grammatik erzeugten
 Sprache liegt.
 \vspace*{0.3cm}
 
@@ -983,22 +983,22 @@ grammar from Figure \ref{fig:expr-small}.
 \end{figure}
 
 
-\section{Korrektheit und Vollständigkeit}
+\section{Korrektheit und Vollst\"andigkeit}
 In diesem Kapitel beweisen wir zwei Eigenschaften des von Earley angegebenen Algorithmus.
-Zunächst zeigen wir, dass immer dann, wenn wir den Algorithmus auf einen String $s = x_1 x_2 \cdots x_n$
+Zun\"achst zeigen wir, dass immer dann, wenn wir den Algorithmus auf einen String $s = x_1 x_2 \cdots x_n$
 anwenden und nach Beendigung des Algorithmus das Earley-Objekt 
 $\pair(\widehat{S} \rightarrow S \,\bullet, 0)$ in der Menge $Q_n$ enthalten ist, wir
-schließen können, dass der String $s$ sich von dem Start-Symbol $S$ ableiten lässt.
+schlie{\ss}en k\"onnen, dass der String $s$ sich von dem Start-Symbol $S$ ableiten l\"asst.
 Diese Eigenschaft
-bezeichnen wir als die Korrektheit des Algorithmus.  Außerdem beweisen wir, dass auch die
+bezeichnen wir als die Korrektheit des Algorithmus.  Au{\ss}erdem beweisen wir, dass auch die
 Umkehrung gilt:  Falls der String $s$ in der von der Variablen $S$ erzeugten Sprache
 liegt, dann ist das Earley-Objekt 
 $\pair(\widehat{S} \rightarrow S \,\bullet, 0)$ nach Beendigung des Algorithmus ein Element der Menge
-$Q_n$.  Diese Eigenschaft bezeichnen wir als die Vollständigkeit des Algorithmus.
+$Q_n$.  Diese Eigenschaft bezeichnen wir als die Vollst\"andigkeit des Algorithmus.
 Bei allen folgenden Betrachtungen gehen wir davon aus, dass $G = \pair(V, T, S, R)$ die 
 verwendete kontextfreie Grammatik bezeichnet.
 
-Das nachfolgende Lemma wird später benötigt, um die Korrektheit zu zeigen.  Es formalisiert die Idee, die
+Das nachfolgende Lemma wird sp\"ater ben\"otigt, um die Korrektheit zu zeigen.  Es formalisiert die Idee, die
 der Definition eines Earley-Objekts zu Grunde liegt.
 \begin{Lemma}
   Es sei $s = x_1 x_2 \cdots x_n \in T^*$ der String, auf den wir den Algorithmus von Earley anwenden.
@@ -1014,16 +1014,16 @@ der Definition eines Earley-Objekts zu Grunde liegt.
 \end{Lemma}
 
 \noindent
-\textbf{Beweis}: Wir führen den Beweis durch Induktion über die Anzahl $l$ der Berechnungs-Schritte, die
-der Algorithmus durchgeführt hat, um $\pair(A \rightarrow \alpha \bullet \beta, k) \in Q_i$ nachzuweisen.
+\textbf{Beweis}: Wir f\"uhren den Beweis durch Induktion \"uber die Anzahl $l$ der Berechnungs-Schritte, die
+der Algorithmus durchgef\"uhrt hat, um $\pair(A \rightarrow \alpha \bullet \beta, k) \in Q_i$ nachzuweisen.
 \begin{enumerate}
-\item[I.A.:] $l=0$.  Zu Beginn enthält die Menge $Q_0$ nur das Earley-Objekt
+\item[I.A.:] $l=0$.  Zu Beginn enth\"alt die Menge $Q_0$ nur das Earley-Objekt
             \\[0.2cm]
             \hspace*{1.3cm}
             $\pair( \widehat{S} \rightarrow \bullet\,S, 0)$
             \\[0.2cm]
-            und alle anderen Mengen $Q_i$ sind leer.  Damit müssen wir die Behauptung nur für dieses
-            eine Earley-Objekt nachweisen.  Für dieses Earley-Objekt haben die Variablen $A$, $\alpha$,
+            und alle anderen Mengen $Q_i$ sind leer.  Damit m\"ussen wir die Behauptung nur f\"ur dieses
+            eine Earley-Objekt nachweisen.  F\"ur dieses Earley-Objekt haben die Variablen $A$, $\alpha$,
             $\beta$ und $k$ folgende Werte: 
             \begin{enumerate}
             \item $A = \widehat{S}$,
@@ -1032,18 +1032,18 @@ der Algorithmus durchgeführt hat, um $\pair(A \rightarrow \alpha \bullet \beta, 
             \item $i = 0$,
             \item $k = 0$.
             \end{enumerate}
-            Wir müssen dann zeigen, dass 
+            Wir m\"ussen dann zeigen, dass 
             \\[0.2cm]
             \hspace*{1.3cm}
             $\varepsilon \Rightarrow^* x_1 \cdots x_0$ 
             \\[0.2cm]
             gilt. Diese Behauptung folgt aus $x_1 \cdots x_0 = \varepsilon$.
-\item[I.S.:] $0,\cdots,l \mapsto l+1$.  Wir müssen eine Fallunterscheidung nach der Art der Operation
-            durchführen, mit der das Earley-Objekt $E = \pair(A \rightarrow \alpha \bullet \beta, k)$
+\item[I.S.:] $0,\cdots,l \mapsto l+1$.  Wir m\"ussen eine Fallunterscheidung nach der Art der Operation
+            durchf\"uhren, mit der das Earley-Objekt $E = \pair(A \rightarrow \alpha \bullet \beta, k)$
             erzeugt worden ist.
             \begin{enumerate}
-            \item $E$ ist durch eine Vorhersage-Operation in $Q_i$ eingefügt worden. 
-                  Daher enthält $Q_i$ ein Earley-Objekt der Form
+            \item $E$ ist durch eine Vorhersage-Operation in $Q_i$ eingef\"ugt worden. 
+                  Daher enth\"alt $Q_i$ ein Earley-Objekt der Form
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $F = \pair(A' \rightarrow \alpha' \bullet A\, \delta, k')$.
@@ -1061,7 +1061,7 @@ der Algorithmus durchgeführt hat, um $\pair(A \rightarrow \alpha \bullet \beta, 
                   $\varepsilon \Rightarrow^* x_{i+1} \cdots x_i$ 
                   \\[0.2cm]
                   gilt. Wegen $x_{i+1} \cdots x_i = \varepsilon$ ist das trivial.
-            \item $E$ ist durch eine Lese-Operation in $Q_i$ eingefügt worden.
+            \item $E$ ist durch eine Lese-Operation in $Q_i$ eingef\"ugt worden.
                   Dann gibt es ein Earley-Objekt der Form 
                   $\pair(A \rightarrow \alpha' \bullet x_i \beta, k) \in Q_{i-1}$, es gilt 
                   $\alpha = \alpha' x_i$ und nach
@@ -1070,7 +1070,7 @@ der Algorithmus durchgeführt hat, um $\pair(A \rightarrow \alpha \bullet \beta, 
                   \hspace*{1.3cm}
                   $\alpha' \Rightarrow^* x_{k+1} \cdots x_{i-1}$
                   \\[0.2cm]
-                  Wir müssen zeigen, dass
+                  Wir m\"ussen zeigen, dass
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $\alpha \Rightarrow^* x_{k+1} \cdots x_{i}$ 
@@ -1079,7 +1079,7 @@ der Algorithmus durchgeführt hat, um $\pair(A \rightarrow \alpha \bullet \beta, 
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $\alpha = \alpha' x_i \Rightarrow^* x_{k+1} \cdots x_{i-1} x_i = x_{k+1} \cdots x_i$.
-            \item $E$ ist durch eine Vervollständigungs-Operation in $Q_i$ eingefügt worden.
+            \item $E$ ist durch eine Vervollst\"andigungs-Operation in $Q_i$ eingef\"ugt worden.
                   Dann hat $E$ die Form
                   \\[0.2cm]
                   \hspace*{1.3cm}
@@ -1144,9 +1144,9 @@ Das Korollar zeigt:  Produziert der Algorithmus von Earley das Earley-Objekt
 $\pair(\widehat{S} \rightarrow S \bullet, 0) \in Q_n$,
 \\[0.2cm] 
  so liegt der String, auf den wir den
-Algorithmus angewendet haben, tatsächlich in der von der Grammatik erzeugten Sprache.  Wir wollen
+Algorithmus angewendet haben, tats\"achlich in der von der Grammatik erzeugten Sprache.  Wir wollen
 aber auch die Umkehrung dieser Aussage nachweisen:  Falls ein String $s$ von der Grammatik erzeugt
-wird, so wird der Algorithmus von Earley dies auch erkennen.  Dazu zeigen wir zunächst das folgende
+wird, so wird der Algorithmus von Earley dies auch erkennen.  Dazu zeigen wir zun\"achst das folgende
 Lemma.
 
 
@@ -1163,10 +1163,10 @@ Lemma.
 \end{Lemma}
 
 \noindent
-\textbf{Beweis}: Wir führen den Beweis durch Induktion über die Anzahl der Ableitungs-Schritte in
+\textbf{Beweis}: Wir f\"uhren den Beweis durch Induktion \"uber die Anzahl der Ableitungs-Schritte in
 der Ableitung $\beta \Rightarrow^* x_{i+1} \cdots x_l$.  
 \begin{enumerate}
-\item Falls die Ableitung die Länge $0$ hat, gilt offenbar $\beta = x_{i+1} \cdots x_l$.  
+\item Falls die Ableitung die L\"ange $0$ hat, gilt offenbar $\beta = x_{i+1} \cdots x_l$.  
       Damit hat die Voraussetzung
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -1182,18 +1182,18 @@ der Ableitung $\beta \Rightarrow^* x_{i+1} \cdots x_l$.
       \hspace*{1.3cm}
       $\pair(A \rightarrow \alpha x_{i+1} \cdots x_l \bullet \gamma, k) \in Q_l$
       \\[0.2cm]
-      und wegen  $\beta = x_{i+1} \cdots x_l$ ist das äquivalent zu
+      und wegen  $\beta = x_{i+1} \cdots x_l$ ist das \"aquivalent zu
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(A \rightarrow \alpha \beta \bullet \gamma, k) \in Q_l$.
       \\[0.2cm]
       Das ist aber gerade die Behauptung.
-\item Wir führen nun den Induktions-Schritt
-      durch, wobei die Ableitung $\beta \Rightarrow^* x_{i+1} \cdots x_l$ eine Länge größer als 0
+\item Wir f\"uhren nun den Induktions-Schritt
+      durch, wobei die Ableitung $\beta \Rightarrow^* x_{i+1} \cdots x_l$ eine L\"ange gr\"o{\ss}er als 0
       hat und nehmen an, dass  die erste Regel, die bei
       dieser Ableitung angewendet worden ist, die Form
       $D \rightarrow \delta$
-      hat.   Zur Vereinfachung nehmen wir außerdem an, dass die Ableitungs-Schritte so durchgeführt
+      hat.   Zur Vereinfachung nehmen wir au{\ss}erdem an, dass die Ableitungs-Schritte so durchgef\"uhrt
       werden, dass immer die linkeste Variable ersetzt wird.  
       Die Ableitung hat dann insgesamt die Form
       \\[0.2cm]
@@ -1210,8 +1210,8 @@ der Ableitung $\beta \Rightarrow^* x_{i+1} \cdots x_l$.
         \label{earley:1b}
         \mu    \Rightarrow^* x_{h+1} \cdots x_l    
       \end{equation}
-      für ein geeignetes $h \in \{j, \cdots, l+1\}$.
-      Also  können wir zunächst auf das Earley-Objekt
+      f\"ur ein geeignetes $h \in \{j, \cdots, l+1\}$.
+      Also  k\"onnen wir zun\"achst auf das Earley-Objekt
       \\[0.2cm]
       \hspace*{1.3cm}
       $\pair(A \rightarrow \alpha \bullet \beta \gamma, k) \in Q_i$
@@ -1231,7 +1231,7 @@ der Ableitung $\beta \Rightarrow^* x_{i+1} \cdots x_l$.
         \label{earley:4}
         \pair(D \rightarrow \delta\, \bullet, j) \in Q_h.
       \end{equation}
-      Aus (\ref{earley:2}) und (\ref{earley:4}) folgt mit der Vervollständigungs-Operation
+      Aus (\ref{earley:2}) und (\ref{earley:4}) folgt mit der Vervollst\"andigungs-Operation
       \begin{equation}
         \label{earley:5}
         \pair(A \rightarrow \alpha x_{i+1} \cdots x_j D \bullet \mu \gamma, k) \in Q_{h}.  
@@ -1249,7 +1249,7 @@ der Ableitung $\beta \Rightarrow^* x_{i+1} \cdots x_l$.
       gezeigt und das ist gerade die Behauptung. \qed
 \end{enumerate}
 
-\begin{Korollar}[Vollständigkeit] \hspace*{\fill} \\
+\begin{Korollar}[Vollst\"andigkeit] \hspace*{\fill} \\
 Falls $s = x_1 \cdots x_n \in L(G)$ ist, dann gilt $\pair(\widehat{S} \rightarrow S \bullet, 0) \in Q_n$.
 \end{Korollar}
 
@@ -1260,107 +1260,107 @@ Der Algorithmus von Earley initialisiert die Menge $Q_0$ mit dem Earley-Objekt
 \hspace*{1.3cm}
 $\pair(\widehat{S} \rightarrow \bullet S, 0)$.  
 \\[0.2cm]
-Die Voraussetzung $x_1 \cdots x_n \in L(G)$ heißt gerade
+Die Voraussetzung $x_1 \cdots x_n \in L(G)$ hei{\ss}t gerade
 $S \Rightarrow^* x_1 \cdots x_n$.  Also folgt die Behauptung aus dem eben bewiesenen Lemma,
 wenn wir dort $\alpha := \varepsilon$, $\beta := S$, $\gamma := \varepsilon$, $i := 0$,
 $k:= 0$ und $l:= n$ setzen.
 \qed
 
-\section{Analyse der Komplexität}
+\section{Analyse der Komplexit\"at}
 Wir zeigen, dass sich die Anzahl der Schritte, die der Algorithmus von Earley bei einem String der
-Länge $n$ durch $\mathcal{O}(n^3)$ nach oben abschätzen lässt.  Falls die Grammatik eindeutig ist,
+L\"ange $n$ durch $\mathcal{O}(n^3)$ nach oben absch\"atzen l\"asst.  Falls die Grammatik eindeutig ist,
 wenn es also zu jedem String nur einen Parse-Baum gibt, kann dies zu $\mathcal{O}(n^2)$ verbessert
 werden.  
-Zusätzlich hat Jay Earley in seiner Doktorarbeit \cite{earley:68} gezeigt, dass der
-Algorithmus in vielen praktisch relevanten Fällen eine lineare Komplexität hat.
+Zus\"atzlich hat Jay Earley in seiner Doktorarbeit \cite{earley:68} gezeigt, dass der
+Algorithmus in vielen praktisch relevanten F\"allen eine lineare Komplexit\"at hat.
 
-Der Schlüssel bei der Berechnung der Komplexität des Algorithmus von Earley ist die
+Der Schl\"ussel bei der Berechnung der Komplexit\"at des Algorithmus von Earley ist die
 Betrachtung der Anzahl der Elemente der Menge $Q_i$.  Es gilt offenbar:
 \\[0.2cm]
 \hspace*{1.3cm}
 Wenn $\pair(A \rightarrow \alpha \bullet \beta, k) \in Q_{i}$, dann $k \in \{0,\cdots,i\}$.  
 \\[0.2cm]
-Die Komponente $A \rightarrow \alpha \bullet \beta$ hängt nur von der Grammatik und nicht
-von dem zu parsenden String ab, während der Index $i$ von der Länge des zu parsenden
-Strings abhängig ist, es gilt 
+Die Komponente $A \rightarrow \alpha \bullet \beta$ h\"angt nur von der Grammatik und nicht
+von dem zu parsenden String ab, w\"ahrend der Index $i$ von der L\"ange des zu parsenden
+Strings abh\"angig ist, es gilt 
 \\[0.2cm]
 \hspace*{1.3cm}
 $i \in \{0,\cdots,n\}$.
 \\[0.2cm]
-Interessiert nur das Wachstum der Mengen $Q_i$ in Abhängigkeit von der Länge des zu
+Interessiert nur das Wachstum der Mengen $Q_i$ in Abh\"angigkeit von der L\"ange des zu
 parsenden Strings, so kann daher die Anzahl der Elemente der Menge $Q_i$ durch
-$\mathcal{O}(n)$ abgeschätzt werden.  Wir analysieren nun die Anzahl der Rechenschritte,
-die bei den einzelnen Operationen durchgeführt werden.
+$\mathcal{O}(n)$ abgesch\"atzt werden.  Wir analysieren nun die Anzahl der Rechenschritte,
+die bei den einzelnen Operationen durchgef\"uhrt werden.
 \begin{enumerate}
 \item Bei der Implementierung der Vorhersage-Operation in der Methode $\textsl{predict}()$
       (Abbildung \ref{fig:earleyParser.stlx:predict}) haben wir drei Schleifen.
       \begin{enumerate}
-      \item Für die äußere \texttt{do}-\texttt{while}-Schleife finden wir, dass diese
+      \item F\"ur die \"au{\ss}ere \texttt{do}-\texttt{while}-Schleife finden wir, dass diese
             maximal so oft durchlaufen wird, wie neue Earley-Objekte in die Menge
-            $Q_i$ eingefügt werden.  
-            Alle mit der Vorhersage-Operation neu eingefügten Objekte haben aber die Form
+            $Q_i$ eingef\"ugt werden.  
+            Alle mit der Vorhersage-Operation neu eingef\"ugten Objekte haben aber die Form
             \\[0.2cm]
             \hspace*{1.3cm}
             $\langle A \rightarrow \bullet \gamma, i \rangle$,
             \\[0.2cm]
             der Index hat hier also immer den Wert $i$.
             Die Anzahl solcher Objekte ist nur von der Grammatik und nicht von dem
-            Eingabe-String abhängig.  Damit kann die Anzahl dieser Schleifen-Durchläufe 
-            durch $\mathcal{O}(1)$ abgeschätzt werden.
-      \item Die äußere \texttt{for}-Schleife läuft über alle Earley-Objekte der Menge
+            Eingabe-String abh\"angig.  Damit kann die Anzahl dieser Schleifen-Durchl\"aufe 
+            durch $\mathcal{O}(1)$ abgesch\"atzt werden.
+      \item Die \"au{\ss}ere \texttt{for}-Schleife l\"auft \"uber alle Earley-Objekte der Menge
             $Q_i$ und wird daher maximal $\mathcal{O}(n)$-mal durchlaufen.
-      \item Die innere \texttt{for}-Schleife läuft über alle Grammatik-Regeln und ist von
-            der Länge des zu parsenden Strings unabhängig.  Diese Schleife liefert also 
-            nur einen Beitrag, der durch $\mathcal{O}(1)$ abgeschätzt werden kann.
+      \item Die innere \texttt{for}-Schleife l\"auft \"uber alle Grammatik-Regeln und ist von
+            der L\"ange des zu parsenden Strings unabh\"angig.  Diese Schleife liefert also 
+            nur einen Beitrag, der durch $\mathcal{O}(1)$ abgesch\"atzt werden kann.
       \end{enumerate}
-      Insgesamt hat ein Aufruf der Methode $\texttt{predict}()$ daher die Komplexität 
+      Insgesamt hat ein Aufruf der Methode $\texttt{predict}()$ daher die Komplexit\"at 
       $\mathcal{O}(1) \cdot {O}(n) \cdot \mathcal{O}(1) = \mathcal{O}(n)$.
 \item Bei der Implementierung der Lese-Operation, die in Abbildung \ref{fig:earleyParser.stlx:scan}
       gezeigt ist, haben wir eine \texttt{for}-Schleife,
-      die über alle Elemente der Menge $Q_i$ iteriert.  Da diese Menge $\mathcal{O}(n)$
-      Elemente enthält, hat die Lese-Operation ebenfalls die Komplexität $\mathcal{O}(n)$.
+      die \"uber alle Elemente der Menge $Q_i$ iteriert.  Da diese Menge $\mathcal{O}(n)$
+      Elemente enth\"alt, hat die Lese-Operation ebenfalls die Komplexit\"at $\mathcal{O}(n)$.
 \item Die von uns in Abbildung \ref{fig:earleyParser.stlx:complete} auf Seite
       \pageref{fig:earleyParser.stlx:complete} gezeigte Implementierung der
-      Vervollständigungs-Operation in der Methode $\mathtt{complete}()$ 
-      ist ineffizient, weil wir in der äußeren
-      \texttt{for}-Schleife immer über alle Elemente der Menge $Q_i$ iterieren.
-      Effizienter wäre es, wenn wir nur über die beim letzten Schleifen-Durchlauf neu
-      hinzu gekommenen Elemente iterieren würden.  Dann würde
-      im schlimmsten Falle für jedes Elemente der Menge $Q_i$ einmal die innere
-      \texttt{for}-Schleife, die über alle Elemente der Menge $Q_j$ iteriert, ausgeführt.
+      Vervollst\"andigungs-Operation in der Methode $\mathtt{complete}()$ 
+      ist ineffizient, weil wir in der \"au{\ss}eren
+      \texttt{for}-Schleife immer \"uber alle Elemente der Menge $Q_i$ iterieren.
+      Effizienter w\"are es, wenn wir nur \"uber die beim letzten Schleifen-Durchlauf neu
+      hinzu gekommenen Elemente iterieren w\"urden.  Dann w\"urde
+      im schlimmsten Falle f\"ur jedes Elemente der Menge $Q_i$ einmal die innere
+      \texttt{for}-Schleife, die \"uber alle Elemente der Menge $Q_j$ iteriert, ausgef\"uhrt.
       Da die Anzahl der Elemente von $Q_i$ und $Q_j$ jeweils durch $\mathcal{O}(n)$
-      abgeschätzt werden können, kann die Komplexität der Vervollständigungs-Operation
-      insgesamt mit $\mathcal{O}(n^2)$ abgeschätzt werden.
+      abgesch\"atzt werden k\"onnen, kann die Komplexit\"at der Vervollst\"andigungs-Operation
+      insgesamt mit $\mathcal{O}(n^2)$ abgesch\"atzt werden.
 \end{enumerate}
-Da die einzelnen Operationen für alle Mengen $Q_i$ für $i = 0, \cdots, n$ durchgeführt
-werden müssen, hat der Algorithmus insgesamt die Komplexität $\mathcal{O}(n^3)$.  Damit
-diese Komplexität auch tatsächlich erreicht wird, müssten wir die Implementierung der Methoden so umändern,
+Da die einzelnen Operationen f\"ur alle Mengen $Q_i$ f\"ur $i = 0, \cdots, n$ durchgef\"uhrt
+werden m\"ussen, hat der Algorithmus insgesamt die Komplexit\"at $\mathcal{O}(n^3)$.  Damit
+diese Komplexit\"at auch tats\"achlich erreicht wird, m\"ussten wir die Implementierung der Methoden so um\"andern,
 dass kein Element der Menge $Q_i$ mehrfach betrachtet wird.  Da eine solche
-Implementierung schwerer zu verstehen wäre, haben wir uns aus didaktischen Gründen
-mit einer ineffizienteren Implementierung begnügt.
+Implementierung schwerer zu verstehen w\"are, haben wir uns aus didaktischen Gr\"unden
+mit einer ineffizienteren Implementierung begn\"ugt.
 
-Der Nachweis, dass der Algorithmus bei einer eindeutigen Grammatik die Komplexität 
+Der Nachweis, dass der Algorithmus bei einer eindeutigen Grammatik die Komplexit\"at 
 $\mathcal{O}\bigl(n^2\bigr)$ hat, geht
-über den Rahmen der Vorlesung hinaus und kann in dem Artikel von Earley \cite{earley:70}
-nachgelesen werden.   In seiner Doktorarbeit hat Jay Earley \cite{earley:68} zusätzlich
-gezeigt, dass der Algorithmus in vielen praktisch relevanten Fällen nur eine lineare
-Komplexität hat.  Es gibt daher eine Reihe von Parser-Generatoren, die den Algorithmus von
+\"uber den Rahmen der Vorlesung hinaus und kann in dem Artikel von Earley \cite{earley:70}
+nachgelesen werden.   In seiner Doktorarbeit hat Jay Earley \cite{earley:68} zus\"atzlich
+gezeigt, dass der Algorithmus in vielen praktisch relevanten F\"allen nur eine lineare
+Komplexit\"at hat.  Es gibt daher eine Reihe von Parser-Generatoren, die den Algorithmus von
 Earley umsetzen, z.~B.~das System \textsl{Accent}
 \\[0.2cm]
 \hspace*{1.3cm}
 \href{http://accent.compilertools.net}{\texttt{http://accent.compilertools.net}},
 \\[0.2cm]
-mit dessen Hilfe sich \texttt{C}-Parser für beliebige Grammatiken erzeugen lassen.
+mit dessen Hilfe sich \texttt{C}-Parser f\"ur beliebige Grammatiken erzeugen lassen.
 Ein Problem bei der Verwendung solcher Systeme besteht in der Praxis darin, dass die
 Frage, ob eine Grammatik eindeutig ist, unentscheidbar ist.  Bei der Definition einer
 neuen Grammatik kann es leicht passieren, dass die Grammatik aufgrund eines Design-Fehlers nicht 
-eindeutig ist.  Bei der Verwendung eines Earley-Parser-Generators können solche Fehler
+eindeutig ist.  Bei der Verwendung eines Earley-Parser-Generators k\"onnen solche Fehler
 erst zur Laufzeit des erzeugten Parsers bemerkt werden.  Bei Systemen wie \textsl{Antlr}
-oder \textsl{Bison}, die mit einer eingeschränkteren Klasse von Grammatiken arbeiten,
-tritt dieses Problem nicht auf, denn die Grammatiken, für die sich mit einem solchen
-System ein Parser erzeugen lässt, sind nach Konstruktion eindeutig.  Ist also eine
+oder \textsl{Bison}, die mit einer eingeschr\"ankteren Klasse von Grammatiken arbeiten,
+tritt dieses Problem nicht auf, denn die Grammatiken, f\"ur die sich mit einem solchen
+System ein Parser erzeugen l\"asst, sind nach Konstruktion eindeutig.  Ist also eine
 Grammatik aufgrund eines Design-Fehlers nicht eindeutig, so liegt Sie erst recht nicht in
-der eingeschränkten Klasse von LR(1)-Grammatiken, die sich beispielsweise mit
+der eingeschr\"ankten Klasse von LR(1)-Grammatiken, die sich beispielsweise mit
 \textsl{Bison} bearbeiten lassen und der Fehler wird bereits bei der Erstellung des
 Parsers bemerkt.
 

--- a/Lecture-Notes/entscheidbarkeit-kontextfrei.tex
+++ b/Lecture-Notes/entscheidbarkeit-kontextfrei.tex
@@ -1,12 +1,12 @@
 \chapter{Entscheibarkeit kontextfreier Sprachen}
-In diesem Kapitel zeigen wir, dass für eine gegebene kontextfreie Grammatik $G = \langle V, T, R, S \rangle$
+In diesem Kapitel zeigen wir, dass f\"ur eine gegebene kontextfreie Grammatik $G = \langle V, T, R, S \rangle$
 und ein Wort $w$ die Frage, ob 
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \Rightarrow_G^* w$
 \\[0.2cm]
 gilt, entscheidbar ist.   Wir werden einen konkreten Algorithmus angeben, mit dem sich
-diese Frage für ein gegebenes Wort $w$ beantworten lässt. 
+diese Frage f\"ur ein gegebenes Wort $w$ beantworten l\"asst. 
 
 %%% Local Variables: 
 %%% mode: latex

--- a/Lecture-Notes/ep.tex
+++ b/Lecture-Notes/ep.tex
@@ -2,13 +2,13 @@
 \section{Exkurs: Der Klassen-Generator \texttt{EP}}
 Die meisten Parser haben die Aufgabe, einen Parse-Baum zu erstellen.  In diesem Parsebaum wird jeder
 Knoten durch ein Objekt einer Klasse dargestellt.  Die Klassen dieser Objekte orientieren sich
-typischerweise an den Symbolen der Grammatik, so dass in der Regel für jedes Symbol auch eine Klasse
-existiert.  Das führt dazu, dass wir bei der Entwicklung eines solchen Parses eine große Zahl von
-\textsl{Java}-Klassen definieren müssen.  Das ist zwar nicht weiter schwer, aber doch mit einem
-hohen Schreibaufwand verbunden.  Um hier die Arbeit abzukürzen, können wir einen
-\emph{Klassen-Generator} einsetzen, die die benötigten Klassen aus einer Spezifikation erzeugt.  Da
-diese Spezifikation meist wesentlich kürzer ist als die \textsl{Java}-Klassen, können wir dadurch 
-einiges an Schreibarbeit einsparen.  In diesem Abschnitt möchte ich Ihnen ein solches System
+typischerweise an den Symbolen der Grammatik, so dass in der Regel f\"ur jedes Symbol auch eine Klasse
+existiert.  Das f\"uhrt dazu, dass wir bei der Entwicklung eines solchen Parses eine gro{\ss}e Zahl von
+\textsl{Java}-Klassen definieren m\"ussen.  Das ist zwar nicht weiter schwer, aber doch mit einem
+hohen Schreibaufwand verbunden.  Um hier die Arbeit abzuk\"urzen, k\"onnen wir einen
+\emph{Klassen-Generator} einsetzen, die die ben\"otigten Klassen aus einer Spezifikation erzeugt.  Da
+diese Spezifikation meist wesentlich k\"urzer ist als die \textsl{Java}-Klassen, k\"onnen wir dadurch 
+einiges an Schreibarbeit einsparen.  In diesem Abschnitt m\"ochte ich Ihnen ein solches System
 vorstellen.  Es handelt sich um das System EP, dass Sie unter der Adresse
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -17,12 +17,12 @@ vorstellen.  Es handelt sich um das System EP, dass Sie unter der Adresse
 im Netz finden.
 
 \subsection{Installation}
-Wir beschreiben zunächst die Installation dieses Systems.  Die nachfolgende Anleitung geht
+Wir beschreiben zun\"achst die Installation dieses Systems.  Die nachfolgende Anleitung geht
 von einem Linux oder Unix-System aus.  Wir nehmen an, dass der Klassen-Generator in
 dem Ordner \texttt{Software}, der sich im Home-Verzeichnis des Benutzers befindet, installiert
 werden soll.  Die Installation besteht dann aus folgenden Schritten:
 \begin{enumerate}
-\item Zunächst schieben wir die Datei ``\texttt{ep.tar.gz}'' 
+\item Zun\"achst schieben wir die Datei ``\texttt{ep.tar.gz}'' 
       in das Verzeichnis \texttt{\symbol{126}/Software}: \\[0.2cm]
       \hspace*{1.3cm} \texttt{mv ep.tar.gz \symbol{126}/Software}
 \item Nun wechseln wir in dieses Verzeichnis: \\[0.2cm]
@@ -33,28 +33,28 @@ werden soll.  Die Installation besteht dann aus folgenden Schritten:
 \item Die Datei \texttt{ep.tar} wird nun entpackt: \\[0.2cm]
       \hspace*{1.3cm} \texttt{untar xf ep.tar} \\[0.2cm]
       Durch diesen Befehl wird im Verzeichnis \texttt{Software} ein Unterverzeichnis mit dem Namen 
-       \texttt{EP} angelegt.  Dieses Unterverzeichnis enthält drei Verzeichnisse:
+       \texttt{EP} angelegt.  Dieses Unterverzeichnis enth\"alt drei Verzeichnisse:
       \begin{enumerate}
-      \item \texttt{src} enthält die \textsl{Java}-Quellen zusammen mit den Klassen-Dateien.
-            Falls die Version Ihrer \textsl{Java}-Umgebung nicht mit der Version übereinstimmt,
-            für die die Klassen-Dateien erzeugt wurden, müssen Sie in diesem Verzeichnis mit dem Befehl
+      \item \texttt{src} enth\"alt die \textsl{Java}-Quellen zusammen mit den Klassen-Dateien.
+            Falls die Version Ihrer \textsl{Java}-Umgebung nicht mit der Version \"ubereinstimmt,
+            f\"ur die die Klassen-Dateien erzeugt wurden, m\"ussen Sie in diesem Verzeichnis mit dem Befehl
             \\[0.2cm]
             \hspace*{1.3cm}
             \texttt{javac *.java}
             \\[0.2cm]
-            alle \textsl{Java}-Quelldateien neu übersetzen.
-      \item \texttt{doc} enthält die Dokumentation.
-      \item \texttt{examples} enthält die Beispiel-Datei ``\texttt{expr.ep}''.
-            In dieser Datei werden Klassen spezifiziert, die arithmetische Ausdrücke beschreiben.
+            alle \textsl{Java}-Quelldateien neu \"ubersetzen.
+      \item \texttt{doc} enth\"alt die Dokumentation.
+      \item \texttt{examples} enth\"alt die Beispiel-Datei ``\texttt{expr.ep}''.
+            In dieser Datei werden Klassen spezifiziert, die arithmetische Ausdr\"ucke beschreiben.
       \end{enumerate}
-      Zusätzlich enthält das Verzeichnis \texttt{EP} noch die Datei \texttt{antlr-2.7.5.jar}.
+      Zus\"atzlich enth\"alt das Verzeichnis \texttt{EP} noch die Datei \texttt{antlr-2.7.5.jar}.
       Hierbei handelt es sich um die Version des Parser-Generator \textsc{Antlr}
       \cite{parr95antlr},
       die ich bei der Erstellung des Parsers verwendet habe.
-\item Um EP verwenden zu können, müssen Sie die Datei \texttt{antlr-2.7.5.jar} und das
+\item Um EP verwenden zu k\"onnen, m\"ussen Sie die Datei \texttt{antlr-2.7.5.jar} und das
       Verzeichnis \texttt{src} in den \texttt{CLASSPATH} aufnehmen.  Das geht in einem
       \textsl{Unix}-basiertem Betriebssystem beispielsweise,
-      indem Sie in der Datei \texttt{\symbol{126}/.bashrc} folgende Zeile hinzufügen:
+      indem Sie in der Datei \texttt{\symbol{126}/.bashrc} folgende Zeile hinzuf\"ugen:
       \\[0.2cm]
       \texttt{export
         CLASSPATH=\symbol{36}CLASSPATH:\symbol{126}/Software/EP/antlr-2.7.5.jar:\symbol{126}/Software/EP/src} 
@@ -63,21 +63,21 @@ werden soll.  Die Installation besteht dann aus folgenden Schritten:
       \\[0.2cm]
       \hspace*{1.3cm} \texttt{java EP expr} 
       \\[0.2cm]
-      ausführen.  
+      ausf\"uhren.  
       Dieses Kommando sollte eine Reihe von \textsl{Java}-Dateien erzeugen, die dann durch den Befehl
       \\[0.2cm]
       \hspace*{1.3cm} \texttt{javac *.java} \\[0.2cm]
-      übersetzt werden können.
-      Anschließend können wir das Kommando \\[0.2cm]
+      \"ubersetzt werden k\"onnen.
+      Anschlie{\ss}end k\"onnen wir das Kommando \\[0.2cm]
       \hspace*{1.3cm} \texttt{java Main} \\[0.2cm]
-      ausführen.  Dieses Kommando sollte das folgende Ergebnis produzieren: \\[0.2cm]
+      ausf\"uhren.  Dieses Kommando sollte das folgende Ergebnis produzieren: \\[0.2cm]
       \hspace*{1.3cm} \texttt{Product(Variable(x), Variable(x))/dx = } \\
       \hspace*{2.3cm} \texttt{Sum(Product(Number(1.0), Variable(x)),} \\
       \hspace*{3.04cm}     \texttt{Product(Variable(x), Number(1.0)))}. 
 \end{enumerate}
 
 \section{Eine Beispiel-Datei}
-Abbildung \ref{fig:expr.ep} zeigt eine EP-Spezifikation für Klassen, die arithmetische Ausdrücke
+Abbildung \ref{fig:expr.ep} zeigt eine EP-Spezifikation f\"ur Klassen, die arithmetische Ausdr\"ucke
 spezifizieren.   Die eigentliche Spezifikation der Klassen findet sich in den Zeilen 1 -- 6.
 Hier wird eine abstrakte Klasse \texttt{Expr} definiert, von der insgesamt 6 Klassen abgeleitet
 werden.  Als ein Beispiel betrachten wir die Klasse \texttt{Sum}.  Der Ausdruck
@@ -85,11 +85,11 @@ werden.  Als ein Beispiel betrachten wir die Klasse \texttt{Sum}.  Der Ausdruck
 \hspace*{1.3cm}
 \texttt{Sum(Expr lhs, Expr rhs)}
 \\[0.2cm]
-spezifiziert, dass die Klasse \texttt{Sum} zwei Member-Variablen enthält, die beide den Typ
+spezifiziert, dass die Klasse \texttt{Sum} zwei Member-Variablen enth\"alt, die beide den Typ
 \texttt{Expr} haben.  Weiterhin werden die Namen dieser Member-Variablen definiert.  Der Name der
-ersten Member-Variable ist später \texttt{mLhs}, die zweite Member-Variable heißt \texttt{mRhs}.
+ersten Member-Variable ist sp\"ater \texttt{mLhs}, die zweite Member-Variable hei{\ss}t \texttt{mRhs}.
 Dem in der Spezifikation angegebenen Namen wird also ein ``\texttt{m}'' vorangestellt und der darauf
-folgende Buchstabe wird groß geschrieben.
+folgende Buchstabe wird gro{\ss} geschrieben.
 
 \begin{figure}[thb]
   \centering
@@ -124,7 +124,7 @@ folgende Buchstabe wird groß geschrieben.
                   Product(r, r) );
 \end{Verbatim} 
 \vspace*{-0.3cm}
-  \caption{Die Spezifikation arithmetischer Ausdrücke.}
+  \caption{Die Spezifikation arithmetischer Ausdr\"ucke.}
   \label{fig:expr.ep}
 \end{figure} %\$
 
@@ -178,7 +178,7 @@ folgende Buchstabe wird groß geschrieben.
   \label{fig:Sum.java.ep}
 \end{figure} %\$
 
-Neben der Spezifikation der Klassen enthält die in Abbildung \ref{fig:expr.ep} gezeigte Datei noch
+Neben der Spezifikation der Klassen enth\"alt die in Abbildung \ref{fig:expr.ep} gezeigte Datei noch
 die Spezifikation der Signatur einer Methode: In Zeile 8 wird die Methode \texttt{diff}
 spezifiziert.  Das implizite Argument dieser Methode ist vom Typ \texttt{Expr}, denn es handelt sich
 ja um eine Methode der Klasse \texttt{Expr}, das erste Argument ist vom Type \texttt{String} und das Ergebnis
@@ -194,15 +194,15 @@ Wir diskutieren den erzeugten \textsl{Java}-Code jetzt im Detail.
 \item In Zeile 5 -- 8 finden wir einen Konstruktor, der die Member-Variablen initialisiert.
 \item In Zeile 9 -- 11 finden wir die Implementierung der Methode $\textsl{diff}$.  Diese Zeile
       setzt die Zeile 15 aus der Abbildung \ref{fig:expr.ep} um.
-\item Des weiteren enthält die Klasse \texttt{Sum} noch eine Methode $\texttt{equals}()$, die
+\item Des weiteren enth\"alt die Klasse \texttt{Sum} noch eine Methode $\texttt{equals}()$, die
       automatisch erzeugt wird.
-\item Außerdem werden noch Getter-Methoden für die Member-Variablen in den Zeilen 25 -- 30
+\item Au{\ss}erdem werden noch Getter-Methoden f\"ur die Member-Variablen in den Zeilen 25 -- 30
       erzeugt.
-\item Schließlich zeigt Zeile 31 -- 33 eine automatisch erzeugte \texttt{toString}-Methode.
+\item Schlie{\ss}lich zeigt Zeile 31 -- 33 eine automatisch erzeugte \texttt{toString}-Methode.
 \end{enumerate}
-Um die von \textsc{EP} erzeugten Klassen zu testen, benötigen wir noch eine Methode
+Um die von \textsc{EP} erzeugten Klassen zu testen, ben\"otigen wir noch eine Methode
 $\texttt{main}()$.  Abbildung \ref{fig:Main.java} zeigt die Klasse \texttt{Main}, die eine
-solche Methode enthält.  Übersetzen wir diese Klasse und führen wir das erzeugte Programm
+solche Methode enth\"alt.  \"Ubersetzen wir diese Klasse und f\"uhren wir das erzeugte Programm
 aus, so erhalten wir die folgende Ausgabe:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -282,32 +282,32 @@ aus, so erhalten wir die folgende Ausgabe:
 \end{figure}
 \noindent
 Wir zeigen nun, wie wir alle  drei Werkzeuge
-\textsl{JFlex}, \textsl{JavaCup} und \textsc{Ep} gemeinsam verwenden können um ein
-Programm zum symbolischen Differenzieren erstellen zu können.  
+\textsl{JFlex}, \textsl{JavaCup} und \textsc{Ep} gemeinsam verwenden k\"onnen um ein
+Programm zum symbolischen Differenzieren erstellen zu k\"onnen.  
 \begin{enumerate}
 \item Abbildung \ref{fig:differentiator.jflex} zeigt die Spezifikation des Scanners.
-      Gegenüber dem in Abbildung \ref{fig:calc.jflex} gezeigten Scanner kommt hier die Zeile 30
+      Gegen\"uber dem in Abbildung \ref{fig:calc.jflex} gezeigten Scanner kommt hier die Zeile 30
       hinzu, in der Variablen erkannt werden.
 \item Abbildung \ref{fig:differentiator.cup} zeigt die Spezifikation der Grammatik.
       Der wesentliche Unterschied zu der in Abbildung \ref{fig:calc.cup} gezeigten Grammatik besteht
       darin, dass mit der syntaktische Variable \textsl{expr} nun nicht mehr ein Objekt vom Typ
       \texttt{Integer} assoziiert ist, sondern statt dessen ein Objekt der Klasse \texttt{Expr}.
-      Dieses Objekt repräsentiert einen Syntax-Baum.
+      Dieses Objekt repr\"asentiert einen Syntax-Baum.
 \item Abbildung \ref{fig:expr.ep} aus dem letzten Abschnitt zeigt die Definition der abstrakten Klasse
       \texttt{Expr} und der davon abgeleiteten Klassen mit Hilfe einer \textsc{Ep}-Spezifikation.
 \item Abbildung \ref{fig:Differentiator.java} zeigt die Definition der Klasse
       Differentiator, in der die Methode $\textsl{main}()$ enthalten ist.
   
-      Hier muss die Zeile 7 näher erläutert werden:
-      Die Methode $\textsl{parse}()$ gibt ein Objekt vom Typ \texttt{Symbol} zurück.  Die
+      Hier muss die Zeile 7 n\"aher erl\"autert werden:
+      Die Methode $\textsl{parse}()$ gibt ein Objekt vom Typ \texttt{Symbol} zur\"uck.  Die
       Klasse \texttt{Symbol} ist in dem Paket 
-      \texttt{java\_cup.runtime} definiert und enthält eine als \texttt{public} deklarierte
-      Member-Variable \texttt{value}.  Diese Variable enthält den Wert, welcher dem von der Methode
+      \texttt{java\_cup.runtime} definiert und enth\"alt eine als \texttt{public} deklarierte
+      Member-Variable \texttt{value}.  Diese Variable enth\"alt den Wert, welcher dem von der Methode
       $\textsl{parse}()$ erkannten Nichtterminal \textsl{expr} zugeordnet ist.  Dieser Wert ist ein
       Element der Klasse \texttt{Expr}, der in der Klasse \texttt{Symbol} aber als \texttt{Object} 
-      deklariert ist.  Daher müssen wir diesen Wert erst durch den Cast in Zeile 8 in den Typ 
-      \texttt{Expr} überführen, damit wird dann in Zeile 9 die Methode $\textsl{diff}()$  Klasse
-      \texttt{Expr} aufrufen dürfen.
+      deklariert ist.  Daher m\"ussen wir diesen Wert erst durch den Cast in Zeile 8 in den Typ 
+      \texttt{Expr} \"uberf\"uhren, damit wird dann in Zeile 9 die Methode $\textsl{diff}()$  Klasse
+      \texttt{Expr} aufrufen d\"urfen.
 \end{enumerate}
 
 
@@ -343,7 +343,7 @@ Programm zum symbolischen Differenzieren erstellen zu können.
              ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Grammatik für symbolische Ausdrücke}
+\caption{Grammatik f\"ur symbolische Ausdr\"ucke}
 \label{fig:differentiator.cup}
 \end{figure}
 

--- a/Lecture-Notes/finite-state-machines.tex
+++ b/Lecture-Notes/finite-state-machines.tex
@@ -538,37 +538,37 @@ Since this simulator is written in \textsl{JavaScript} it is even more convenien
 Specify a \textsc{Fsm} $F$ such that $L(F)$ is the set of those
 strings from the language  $\{a,b\}^*$ that contain the substring ``\texttt{aba}''. \eox
 
-\section{Äquivalenz von \textsc{EA} und \textsc{NEA}}
+\section{\"Aquivalenz von \textsc{EA} und \textsc{NEA}}
 In diesem Abschnitt zeigen wir, wie sich ein nicht-deterministischer endlicher Automat 
 \\[0.2cm]
 \hspace*{1.3cm}
 $A = \langle Q, \Sigma, \delta, q_0, F \rangle$ 
 \\[0.2cm]
-so in einen deterministischen endlichen Automaten $\textsl{det}(A)$ übersetzen lässt, dass die von beiden
+so in einen deterministischen endlichen Automaten $\textsl{det}(A)$ \"ubersetzen l\"asst, dass die von beiden
 Automaten erkannte Sprache gleich ist, dass also 
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(A) = L\bigl(\textsl{det}(A)\bigr)$
 \\[0.2cm]
-gilt.  Die Idee ist, dass der Automat $\textsl{det}(A)$ die Menge aller der Zustände berechnet, in denen sich
-der Automat $A$ befinden \emph{könnte}.  Die Zustände des deterministischen Automaten $\textsl{det}(A)$ sind also
-\textbf{Mengen} von Zuständen des ursprünglichen nicht-deterministischen Automaten $A$.  Eine solche Menge fasst
-alle die Zustände zusammen, in denen der nicht-deterministische Automat $A$ sich befinden kann.
+gilt.  Die Idee ist, dass der Automat $\textsl{det}(A)$ die Menge aller der Zust\"ande berechnet, in denen sich
+der Automat $A$ befinden \emph{k\"onnte}.  Die Zust\"ande des deterministischen Automaten $\textsl{det}(A)$ sind also
+\textbf{Mengen} von Zust\"anden des urspr\"unglichen nicht-deterministischen Automaten $A$.  Eine solche Menge fasst
+alle die Zust\"ande zusammen, in denen der nicht-deterministische Automat $A$ sich befinden kann.
 Folglich ist eine Menge $M$ von
-Zuständen des Automaten $A$ ein akzeptierender Zustand des Automaten
+Zust\"anden des Automaten $A$ ein akzeptierender Zustand des Automaten
 $\textsl{det}(A)$, wenn die Menge $M$ einen akzeptierenden Zustand des Automaten $A$
-enthält.
+enth\"alt.
 
 
-Um diese Konstruktion von $\textsl{det}(A)$ angeben zu können, definieren wir zunächst zwei
+Um diese Konstruktion von $\textsl{det}(A)$ angeben zu k\"onnen, definieren wir zun\"achst zwei
 Hilfs-Funktionen.  Wir beginnen mit dem sogenannten $\varepsilon$-Abschluss
 (Englisch: $\varepsilon$-closure).  Die Funktion
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{ec}: Q \rightarrow 2^Q$
 \\[0.2cm]
-soll für jeden Zustand $q \in Q$ die Menge $\textsl{ec}(q)$ aller der Zustände berechnen, in die der Automat
-ausgehend von dem Zustand $q$ mit Hilfe von $\varepsilon$-Transitionen übergehen kann.
+soll f\"ur jeden Zustand $q \in Q$ die Menge $\textsl{ec}(q)$ aller der Zust\"ande berechnen, in die der Automat
+ausgehend von dem Zustand $q$ mit Hilfe von $\varepsilon$-Transitionen \"ubergehen kann.
 Formal definieren wir die Menge $\textsl{ec}(Q)$ indem wir induktiv festlegen, welche Elemente in 
 der Menge $\textsl{ec}(q)$ enthalten sind.
 \begin{enumerate}
@@ -591,7 +591,7 @@ der Menge $\textsl{ec}(q)$ enthalten sind.
 \example
 Abbildung \ref{fig:ab-or-ba-star.dot} zeigt einen nicht-deterministischen endlichen Automaten mit
 $\varepsilon$-Transitionen.  Die $\varepsilon$-Transitionen sind in der Abbildung die
-Pfeile, die nicht mit einem Buchstaben beschriftet sind. Wir berechnen für alle Zustände
+Pfeile, die nicht mit einem Buchstaben beschriftet sind. Wir berechnen f\"ur alle Zust\"ande
 den $\varepsilon$-Abschluss. 
 \begin{enumerate}
 \item $\textsl{ec}(q_0) = \{ q_0, q_1, q_2 \}$,
@@ -607,66 +607,66 @@ den $\varepsilon$-Abschluss.
 
 \noindent
 Um den am Anfang des Abschnitts angegebenen nicht-deterministischen Automaten $A$ in einen 
-deterministischen Automaten $\textsl{det}(A)$ umwandeln zu können, 
+deterministischen Automaten $\textsl{det}(A)$ umwandeln zu k\"onnen, 
 transformieren wir die Funktion $\delta$ in eine Funktion 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\delta^*: Q \times \Sigma \rightarrow 2^Q$,
 \\[0.2cm]
-wobei die Idee ist, dass $\delta^*(q,c)$ für einen Zustand $q$ und einen Buchstaben $c$ die Menge
-aller der Zustände berechnet, in denen der Automat $A$ sich befinden kann, wenn er im Zustand $q$
-zunächst den Buchstaben $c$ liest und anschließend eventuell noch einen oder auch mehrere
-$\varepsilon$-Transitionen durchführt.   Formal erfolgt die Definition von $\delta^*$ durch die Formel 
+wobei die Idee ist, dass $\delta^*(q,c)$ f\"ur einen Zustand $q$ und einen Buchstaben $c$ die Menge
+aller der Zust\"ande berechnet, in denen der Automat $A$ sich befinden kann, wenn er im Zustand $q$
+zun\"achst den Buchstaben $c$ liest und anschlie{\ss}end eventuell noch einen oder auch mehrere
+$\varepsilon$-Transitionen durchf\"uhrt.   Formal erfolgt die Definition von $\delta^*$ durch die Formel 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\delta^*(q_1, c) := \bigcup \bigl\{ \textsl{ec}(q_2) \bigm| q_2 \in \delta(q_1, c) \bigr \}$.
 \\[0.2cm]
 Diese Formel ist wie folgt zu lesen:
 \begin{enumerate}
-\item Wir berechnen für alle Zustände $q_2 \in Q$, die von dem Zustand $q_1$ durch
-      Lesen des Buchstabens $c$ erreicht werden können, den $\varepsilon$-Abschluss
+\item Wir berechnen f\"ur alle Zust\"ande $q_2 \in Q$, die von dem Zustand $q_1$ durch
+      Lesen des Buchstabens $c$ erreicht werden k\"onnen, den $\varepsilon$-Abschluss
       $\textsl{ec}(q_2)$.
-\item Anschließend vereinigen wir alle diese Mengen $\textsl{ec}(q_2)$.
+\item Anschlie{\ss}end vereinigen wir alle diese Mengen $\textsl{ec}(q_2)$.
 \end{enumerate}
 
 \example
-In Fortführung des obigen Beispiels erhalten wir beispielsweise:
+In Fortf\"uhrung des obigen Beispiels erhalten wir beispielsweise:
 \begin{enumerate}
 \item $\delta^*(q_0, \texttt{a}) = \{\}$,
 
-      denn vom Zustand $q_0$ gibt es keine Übergänge mit dem Buchstaben \texttt{a}.
+      denn vom Zustand $q_0$ gibt es keine \"Uberg\"ange mit dem Buchstaben \texttt{a}.
       Beachten Sie, dass wir bei der oben gegebenen Definition der Funktion $\delta^*$ die 
-      $\varepsilon$-Transitionen erst nach den Buchstaben-Transitionen durchgeführt werden.
+      $\varepsilon$-Transitionen erst nach den Buchstaben-Transitionen durchgef\"uhrt werden.
 \item $\delta^*(q_1, \texttt{b}) = \{q_3\}$,
 
       denn vom Zustand $q_1$ geht der Automat beim Lesen von \texttt{b} in den Zustand
-      $q_3$ über.  Für den Zustand $q_3$ gibt es aber keine $\varepsilon$-Transitionen.
+      $q_3$ \"uber.  F\"ur den Zustand $q_3$ gibt es aber keine $\varepsilon$-Transitionen.
 \item $\delta^*(q_3, \texttt{a}) = \{q_5, q_7, q_0, q_1, q_2\}$,
 
-      denn vom Zustand $q_3$ geht der Automat beim Lesen von \texttt{a} zunächst in den Zustand
-      $q_5$ über.  Von diesem Zustand aus sind dann die Zustände $q_7$, $q_0$, $q_1$ und $q_2$
+      denn vom Zustand $q_3$ geht der Automat beim Lesen von \texttt{a} zun\"achst in den Zustand
+      $q_5$ \"uber.  Von diesem Zustand aus sind dann die Zust\"ande $q_7$, $q_0$, $q_1$ und $q_2$
       durch $\varepsilon$-Transitionen erreichbar. \eox
 \end{enumerate}
 
-Die Funktion $\delta^*$ überführt einen Zustand in eine Menge von Zuständen.  Da der zu entwickelnde
-endliche Automat $\textsl{det}(A)$ mit \emph{Mengen von Zuständen} arbeiten wird, benötigen wir eine Funktion,
-die \emph{Mengen von Zuständen} in \emph{Mengen von Zuständen} überführt.  Wir verallgemeinern daher
+Die Funktion $\delta^*$ \"uberf\"uhrt einen Zustand in eine Menge von Zust\"anden.  Da der zu entwickelnde
+endliche Automat $\textsl{det}(A)$ mit \emph{Mengen von Zust\"anden} arbeiten wird, ben\"otigen wir eine Funktion,
+die \emph{Mengen von Zust\"anden} in \emph{Mengen von Zust\"anden} \"uberf\"uhrt.  Wir verallgemeinern daher
 die Funktion $\delta^*$ zu der Funktion 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\Delta: 2^Q \times \Sigma \rightarrow 2^Q$
 \\[0.2cm]
-so, dass $\Delta(M, c)$ für eine Menge von Zuständen $M$ und einen Buchstaben $c$ die Menge aller
-der Zustände berechnet, in denen der Automat $A$ sich befinden kann, wenn er sich zunächst in
-einem Zustand aus der Menge $M$ befunden hat, dann der Buchstabe $c$ gelesen wurde und anschließend
-eventuell noch $\varepsilon$-Transitionen ausgeführt werden.  Die formale Definition lautet 
+so, dass $\Delta(M, c)$ f\"ur eine Menge von Zust\"anden $M$ und einen Buchstaben $c$ die Menge aller
+der Zust\"ande berechnet, in denen der Automat $A$ sich befinden kann, wenn er sich zun\"achst in
+einem Zustand aus der Menge $M$ befunden hat, dann der Buchstabe $c$ gelesen wurde und anschlie{\ss}end
+eventuell noch $\varepsilon$-Transitionen ausgef\"uhrt werden.  Die formale Definition lautet 
 \[ \Delta(M,c) := \bigcup \bigl\{ \delta^*(q,c) \bigm| q \in M \bigr\}. \]
-Diese Formel ist einfach zu verstehen:  Für jeden Zustand $q \in M$ berechnen wir zunächst die Menge
-aller Zustände, in denen sich der Automat nach Lesen von $c$ und eventuellen
+Diese Formel ist einfach zu verstehen:  F\"ur jeden Zustand $q \in M$ berechnen wir zun\"achst die Menge
+aller Zust\"ande, in denen sich der Automat nach Lesen von $c$ und eventuellen
 $\varepsilon$-Transitionen befinden kann.  Die so erhaltenen Mengen vereinigen wir.
 
 \example
-In Fortführung des obigen Beispiels erhalten wir beispielsweise:
+In Fortf\"uhrung des obigen Beispiels erhalten wir beispielsweise:
 \begin{enumerate}
 \item $\Delta(\{q_0, q_1, q_2\}, \texttt{a}) = \{ q_4 \}$,
 \item $\Delta(\{q_0, q_1, q_2\}, \texttt{b}) = \{ q_3 \}$,
@@ -678,28 +678,28 @@ In Fortführung des obigen Beispiels erhalten wir beispielsweise:
 \end{enumerate}
 
 Wir haben nun alles Material zusammen, um den nicht-deterministischen endlichen Automaten
-$A$ in einen deterministischen endlichen Automaten $\textsl{det}(A)$ überführen zu können.
+$A$ in einen deterministischen endlichen Automaten $\textsl{det}(A)$ \"uberf\"uhren zu k\"onnen.
 Wir definieren 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{det}(A) = \bigl\langle 2^Q, \Sigma, \Delta, \textsl{ec}(q_0), \widehat{F} \bigr\rangle$.
 \begin{enumerate}
-\item Die Menge der Zustände von $\textsl{det}(A)$ besteht aus der Menge aller Teilmengen der Zustände von
+\item Die Menge der Zust\"ande von $\textsl{det}(A)$ besteht aus der Menge aller Teilmengen der Zust\"ande von
       $A$, ist also gleich der Potenz-Menge
       $2^Q$.
 
-      Wir werden später sehen, dass von diesen Teilmengen nicht alle wirklich benötigt werden:
-      Die Teilmengen fassen ja Zustände zusammen, in denen der Automat $A$ sich 
+      Wir werden sp\"ater sehen, dass von diesen Teilmengen nicht alle wirklich ben\"otigt werden:
+      Die Teilmengen fassen ja Zust\"ande zusammen, in denen der Automat $A$ sich 
       ausgehend von dem Start-Zustand nach der Eingabe
-      eines bestimmten Wortes befinden kann.   In der Regel können nicht alle Kombinationen 
-      von Zuständen auch tatsächlich erreicht werden.
-\item An dem Eingabe-Alphabet ändert sich nichts, denn der neue Automat $\textsl{det}(A)$ soll ja dieselbe
+      eines bestimmten Wortes befinden kann.   In der Regel k\"onnen nicht alle Kombinationen 
+      von Zust\"anden auch tats\"achlich erreicht werden.
+\item An dem Eingabe-Alphabet \"andert sich nichts, denn der neue Automat $\textsl{det}(A)$ soll ja dieselbe
       Sprache erkennen wie der Automat $A$.
 \item Die oben definierte Funktion $\Delta$ gibt an, wie sich Zustands-Mengen bei Eingabe eines
-      Zeichens ändern.
-\item Der Start-Zustand des Automaten $\textsl{det}(A)$ ist die Menge aller der Zustände, die von dem
+      Zeichens \"andern.
+\item Der Start-Zustand des Automaten $\textsl{det}(A)$ ist die Menge aller der Zust\"ande, die von dem
       Start-Zustand $q_0$ des Automaten $A$ durch $\varepsilon$-Transitionen erreichbar sind.
-\item Wir definieren die Menge $\widehat{F}$ der akzeptierenden Zustände, als die Menge der
+\item Wir definieren die Menge $\widehat{F}$ der akzeptierenden Zust\"ande, als die Menge der
       Teilmengen von $Q$, die einen akzeptierenden Zustand enthalten, wir setzen also 
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -712,22 +712,22 @@ gezeigten nicht-deterministischen Automat $A$ in einen deterministischen Automat
 $\textsl{det}(A)$.  \eox
 
 \solution
-Wir berechnen zunächst die verschiedenen möglichen Zustands-Mengen:
+Wir berechnen zun\"achst die verschiedenen m\"oglichen Zustands-Mengen:
 \begin{enumerate}
 \item Da $\textsl{ec}(0) = \{0\}$ gilt, besteht der Start-Zustand des
-      deterministischen Automaten aus der Menge, die nur den Knoten $0$ enthält:
+      deterministischen Automaten aus der Menge, die nur den Knoten $0$ enth\"alt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $S_0 := \textsl{ec}(0) = \{ 0 \}$.
       \\[0.2cm]
       Wir bezeichnen den Start-Zustand mit $S_0$.
-\item Von dem Zustand $0$ geht der nicht-deterministische Automat $A$ beim Lesen von \texttt{a} in den Zustand $0$ über.
+\item Von dem Zustand $0$ geht der nicht-deterministische Automat $A$ beim Lesen von \texttt{a} in den Zustand $0$ \"uber.
       Also gilt
       \\[0.2cm]
       \hspace*{1.3cm}
       $\Delta(S_0, \texttt{a}) = \Delta(\{0\}, \texttt{a}) = \{0\} = S_0$.
 \item Von dem Zustand $0$ geht $A$ beim Lesen von \texttt{b} in den Zustand $0$ oder $1$
-      über.  Also gilt
+      \"uber.  Also gilt
       \\[0.2cm]
       \hspace*{1.3cm}
       $S_1 := \Delta(S_0, \texttt{b}) = \Delta(\{0\}, \texttt{b}) = \{ 0, 1 \}$.
@@ -754,20 +754,20 @@ Wir berechnen zunächst die verschiedenen möglichen Zustands-Mengen:
 \item $\Delta(S_7, \texttt{a}) = \Delta(\{ 0, 1, 2, 3 \}, \texttt{a}) = \{ 0, 2, 3 \} = S_6$.
 \item $\Delta(S_7, \texttt{b}) = \Delta(\{ 0, 1, 2, 3 \}, \texttt{b}) = \{ 0, 1, 2, 3 \} = S_7$.
 \end{enumerate}
-Damit haben wir alle Zustände des deterministischen Automaten. Zur besseren Übersicht
-fassen wir die Definitionen der einzelnen Zustände des deterministischen Automaten noch
+Damit haben wir alle Zust\"ande des deterministischen Automaten. Zur besseren \"Ubersicht
+fassen wir die Definitionen der einzelnen Zust\"ande des deterministischen Automaten noch
 einmal zusammen:
 \\[0.2cm]
 \hspace*{1.3cm} $S_0 = \{ 0 \}$, $S_1 = \{ 0, 1 \}$, $S_2 = \{ 0, 2 \}$, $S_3 = \{ 0, 3 \}$, $S_4 = \{ 0, 1, 2 \}$, 
 \\[0.2cm]
 \hspace*{1.3cm} $S_5 = \{ 0, 1, 3 \}$, $S_6 = \{ 0, 2, 3 \}$, $S_7 = \{ 0, 1, 2, 3 \}$
 \\[0.2cm]
-und setzen schließlich 
+und setzen schlie{\ss}lich 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\widehat{Q} := \{ S_0, S_1, S_2, S_3, S_4, S_5, S_6, S_7 \}$.
 \\[0.2cm]
-Wir fassen die Übergangs-Funktion $\Delta$ in einer Tabelle zusammen:
+Wir fassen die \"Ubergangs-Funktion $\Delta$ in einer Tabelle zusammen:
 
 \begin{center}
 \begin{tabular}[t]{|l||c|c|c|c|c|c|c|c|}
@@ -787,23 +787,23 @@ Zustand $3$ enthalten.  Also setzen wir
 \hspace*{1.3cm}
 $\widehat{F} := \{ S_3, S_5, S_6, S_7 \}$.
 \\[0.2cm]
-Damit können wir nun einen deterministischen endlichen Automaten $\textsl{det}(A)$ angeben, der dieselbe 
+Damit k\"onnen wir nun einen deterministischen endlichen Automaten $\textsl{det}(A)$ angeben, der dieselbe 
 Sprache akzeptiert wie der nicht-deterministische Automat $A$:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{det}(A) := \langle \widehat{Q}, \Sigma, \Delta, S_0, \widehat{F}\rangle$.
 \\[0.2cm]
 Abbildung \ref{fig:a2.eps} zeigt den Automaten $\textsl{det}(A)$.
-Wir erkennen, dass dieser Automat 8 verschiedene Zustände besitzt.  Der ursprünglich gegebene
-nicht-deterministische Automat $A$ hat 4 Zustände, für die Zustands-Menge des
+Wir erkennen, dass dieser Automat 8 verschiedene Zust\"ande besitzt.  Der urspr\"unglich gegebene
+nicht-deterministische Automat $A$ hat 4 Zust\"ande, f\"ur die Zustands-Menge des
 nicht-deterministischen Automaten gilt $Q = \{ 0, 1, 2, 3 \}$.  Die Potenz-Menge $2^Q$
 besteht aus 16 Elementen.  Wieso hat dann der Automat $\textsl{det}(A)$ nur 8 und nicht $2^4 = 16$
-Zustände?  Der Grund ist, dass von dem Start-Zustand $0$ nur solche Mengen von Zuständen
+Zust\"ande?  Der Grund ist, dass von dem Start-Zustand $0$ nur solche Mengen von Zust\"anden
 erreichbar sind, die den Zustand $0$ enthalten, denn egal ob \texttt{a} oder \texttt{b}
-eingegeben wird, kann der Automat $A$ von $0$ immer wieder in den Zustand $0$ zurück
-wechseln.  Daher muss jede Menge von Zuständen, die von $0$ erreichbar ist, selbst
-wieder $0$ enthalten.  Damit entfallen als Zustände von $\textsl{det}(A)$ alle Mengen von $2^Q$, die
-$0$ nicht enthalten, wodurch die Zahl der Zustände gegenüber der maximal möglichen
+eingegeben wird, kann der Automat $A$ von $0$ immer wieder in den Zustand $0$ zur\"uck
+wechseln.  Daher muss jede Menge von Zust\"anden, die von $0$ erreichbar ist, selbst
+wieder $0$ enthalten.  Damit entfallen als Zust\"ande von $\textsl{det}(A)$ alle Mengen von $2^Q$, die
+$0$ nicht enthalten, wodurch die Zahl der Zust\"ande gegen\"uber der maximal m\"oglichen
 Anzahl halbiert wird.
 
 
@@ -819,7 +819,7 @@ Anzahl halbiert wird.
 \exercise
 Transformieren Sie den in Abbildung \ref{fig:ab-or-ba-star.dot} auf Seite
 \pageref{fig:ab-or-ba-star.dot} 
-gezeigten endlichen Automaten in einen äquivalenten deterministischen endlichen
+gezeigten endlichen Automaten in einen \"aquivalenten deterministischen endlichen
 Automaten. \eox
 
 \pagebreak
@@ -1018,25 +1018,25 @@ state machine (also known as \textsc{Nfa}, which is short for \underline{n}on-de
       \end{enumerate} 
 \end{enumerate}
 
-\section{Übersetzung regulärer Ausdrücke in \textsc{NEA}}
-In diesem Abschnitt konstruieren wir zu einem gegebenen regulären Ausdruck $r$ einen
+\section{\"Ubersetzung regul\"arer Ausdr\"ucke in \textsc{NEA}}
+In diesem Abschnitt konstruieren wir zu einem gegebenen regul\"aren Ausdruck $r$ einen
 nicht-deterministischen endlichen Automaten $A(r)$, der die durch $r$ spezifizierte
 Sprache akzeptiert:
 \\[0.2cm]
 \hspace*{1.3cm}
 $L\bigl(A(r)\bigr) = L(r)$
 \\[0.2cm]
-Die Konstruktion von $A(r)$ erfolgt durch eine Induktion nach dem Aufbau des regulären
+Die Konstruktion von $A(r)$ erfolgt durch eine Induktion nach dem Aufbau des regul\"aren
 Ausdrucks $r$.  Der konstruierte Automat $A(r)$ wird die folgenden Eigenschaften
 haben, die wir bei der Konstruktion komplexerer Automaten ausnutzen werden:
 \begin{enumerate}
 \item $A(r)$ hat keine Transition in den Start-Zustand.  
 \item $A(r)$ hat genau einen akzeptierenden Zustand, den wir mit
-      $\textsl{accept}\bigl(A(r)\bigr)$ bezeichnen.  Außerdem gibt es keine Übergänge, die
+      $\textsl{accept}\bigl(A(r)\bigr)$ bezeichnen.  Au{\ss}erdem gibt es keine \"Uberg\"ange, die
       von diesem akzeptierenden Zustand ausgehen.
 \end{enumerate}
 Im Folgenden nehmen wir an, dass $\Sigma$ das Alphabet ist, das bei der
-Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie folgt definiert.
+Konstruktion des regul\"aren Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie folgt definiert.
 \begin{enumerate}
 \item Den Automaten $A(\emptyset)$ definieren wir als
       \\[0.2cm]
@@ -1054,8 +1054,8 @@ Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie 
       Abbildung \ref{fig:aLeer.eps} zeigt den Automaten, der die durch $\emptyset$
       spezifizierte Sprache akzeptiert.  Der Automat besteht
       nur aus dem Start-Zustand $q_0$ und dem akzeptierenden Zustand $q_1$.
-      Die Funktion $\delta$ liefert für alle Argumente die leere Menge, der Automat hat
-      also keinerlei Zustands-Übergänge und 
+      Die Funktion $\delta$ liefert f\"ur alle Argumente die leere Menge, der Automat hat
+      also keinerlei Zustands-\"Uberg\"ange und 
       akzeptiert daher nur die leere Sprache.  Damit gilt  $L(\emptyset) = \{\}$. 
 \item Den Automaten $A(\varepsilon)$ definieren wir als
       \\[0.2cm]
@@ -1074,7 +1074,7 @@ Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie 
       nur aus dem Start-Zustand $q_0$ und dem akzeptierenden Zustand $q_1$.
       Von dem Zustand $q_0$ gibt es eine $\varepsilon$-Transition zu dem Zustand $q_1$.
       Damit akzeptiert der Automat das leere Wort und sonst nichts. 
-\item Für einen Buchstaben $c \in \Sigma$ definieren wir den Automaten $A(c)$ durch
+\item F\"ur einen Buchstaben $c \in \Sigma$ definieren wir den Automaten $A(c)$ durch
       \\[0.2cm]
       \hspace*{1.3cm}
       $A(c) = \langle \{ q_0, q_1 \}, \Sigma, 
@@ -1093,17 +1093,17 @@ Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie 
       des Buchstabens $c$ benutzt wird.
       Damit akzeptiert der Automat das Wort, das nur aus dem Buchstaben $c$ besteht und
       sonst nichts.
-\item Um den Automaten $A(r_1 \cdot r_2)$ für die Konkatenation $r_1 \cdot r_2$ definieren
-      zu können, nehmen wir zunächst an, dass die 
-      Zu\-stän\-de der Automaten $A(r_1)$ und $A(r_2)$ verschieden sind.  Dies können
-      wir immer erreichen, indem wir die Zustände des Automaten $A(r_2)$ umbenennen.
+\item Um den Automaten $A(r_1 \cdot r_2)$ f\"ur die Konkatenation $r_1 \cdot r_2$ definieren
+      zu k\"onnen, nehmen wir zun\"achst an, dass die 
+      Zu\-st\"an\-de der Automaten $A(r_1)$ und $A(r_2)$ verschieden sind.  Dies k\"onnen
+      wir immer erreichen, indem wir die Zust\"ande des Automaten $A(r_2)$ umbenennen.
       Wir nehmen nun an, dass $A(r_1)$ und $A(r_2)$ die folgenden Formen haben:
       \begin{enumerate}
       \item $A(r_1) = \langle Q_1, \Sigma, \delta_1, q_1, \{ q_2 \}\rangle$,
       \item $A(r_2) = \langle Q_2, \Sigma, \delta_2, q_3, \{ q_4 \}\rangle$,
       \item $Q_1 \cap Q_2 = \{\}$.
       \end{enumerate}
-      Damit können wir den endlichen Automaten $A(r_1 \cdot r_2)$ aus den beiden Automaten $A(r_1)$ und
+      Damit k\"onnen wir den endlichen Automaten $A(r_1 \cdot r_2)$ aus den beiden Automaten $A(r_1)$ und
       $A(r_2)$ zusammenbauen:  Dieser Automat ist gegeben durch
       \\[0.2cm]
       \hspace*{0.8cm}
@@ -1112,10 +1112,10 @@ Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie 
                    \cup \delta_1 \cup \delta_2, q_1, \{ q_4 \} \rangle$
       \\[0.2cm]
       Die Notation $\{ \pair(q_2,\varepsilon) \mapsto q_3 \} \cup \delta_1 \cup \delta_2$
-      ist so zu verstehen, dass die so spezifizierte Funktion $\delta$ alle Übergänge
-      enthält, die durch die Zustands-Übergangs-Funktionen $\delta_1$ und $\delta_2$
-      spezifiziert sind.  Dazu kommt dann noch der $\varepsilon$-Übergang von $q_2$ nach
-      $q_3$.  Formal könnten wir daher die Funktion $\delta$ auch wie folgt spezifizieren:
+      ist so zu verstehen, dass die so spezifizierte Funktion $\delta$ alle \"Uberg\"ange
+      enth\"alt, die durch die Zustands-\"Ubergangs-Funktionen $\delta_1$ und $\delta_2$
+      spezifiziert sind.  Dazu kommt dann noch der $\varepsilon$-\"Ubergang von $q_2$ nach
+      $q_3$.  Formal k\"onnten wir daher die Funktion $\delta$ auch wie folgt spezifizieren:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\delta(q,c) := \left\{
@@ -1136,21 +1136,21 @@ Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie 
       \end{figure}
       Abbildung \ref{fig:aConcat.eps} zeigt den Automaten $A(r_1 \cdot r_2)$.
 
-      Statt der $\varepsilon$-Transition von $q_2$ nach $q_3$ können wir die beiden
-      Zustände $q_2$ und $q_3$ auch identifizieren.  Das hat den Vorteil, dass der
-      resultierende Automat dann etwas kleiner wird.  Bei den praktischen Übungen werden
-      wir diese Zustände daher identifizieren.  Ich habe die Zustände $q_2$ und $q_3$ bei der obigen
+      Statt der $\varepsilon$-Transition von $q_2$ nach $q_3$ k\"onnen wir die beiden
+      Zust\"ande $q_2$ und $q_3$ auch identifizieren.  Das hat den Vorteil, dass der
+      resultierende Automat dann etwas kleiner wird.  Bei den praktischen \"Ubungen werden
+      wir diese Zust\"ande daher identifizieren.  Ich habe die Zust\"ande $q_2$ und $q_3$ bei der obigen
       Darstellung nur deswegen nicht identifiziert, weil dann sowohl die grafische Darstellung als
       auch die formale Spezifikation schwieriger wird.
-\item Um den Automaten $A(r_1 + r_2)$ definieren zu können, nehmen wir wieder an, dass die
-      Zustände der Automaten $A(r_1)$ und $A(r_2)$ verschieden sind.  
+\item Um den Automaten $A(r_1 + r_2)$ definieren zu k\"onnen, nehmen wir wieder an, dass die
+      Zust\"ande der Automaten $A(r_1)$ und $A(r_2)$ verschieden sind.  
       Wir nehmen weiter an, dass $A(r_1)$ und $A(r_2)$ die folgenden Formen haben:
       \begin{enumerate}
       \item $A(r_1) = \langle Q_1, \Sigma, \delta_1, q_1, \{ q_3 \}\rangle$,
       \item $A(r_2) = \langle Q_2, \Sigma, \delta_2, q_2, \{ q_4 \}\rangle$,
       \item $Q_1 \cap Q_2 = \{\}$.
       \end{enumerate}
-      Damit können wir den Automaten $A(r_1 + r_2)$ aus den beiden Automaten $A(r_1)$ und
+      Damit k\"onnen wir den Automaten $A(r_1 + r_2)$ aus den beiden Automaten $A(r_1)$ und
       $A(r_2)$ zusammenbauen:  Dieser Automat ist gegeben durch
       \\[0.2cm]
       \hspace*{0.8cm}
@@ -1166,34 +1166,34 @@ Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie 
       \label{fig:aPlus.eps}
       \end{figure}
       Abbildung \ref{fig:aPlus.eps} zeigt den Automaten $A(r_1 + r_2)$.
-      Wir sehen, dass zusätzlich zu den Zuständen der beiden Automaten $A(r_1)$ und 
-      $A(r_2)$ noch zwei weitere Zustände hinzukommen:
+      Wir sehen, dass zus\"atzlich zu den Zust\"anden der beiden Automaten $A(r_1)$ und 
+      $A(r_2)$ noch zwei weitere Zust\"ande hinzukommen:
       \begin{enumerate}
       \item $q_0$ ist der Start-Zustand des Automaten $A(r_1 + r_2)$,
       \item $q_5$ ist der einzige akzeptierende Zustand des Automaten $A(r_1 + r_2)$.
       \end{enumerate}
-      Gegenüber den Zustands-Übergängen der Automaten $A(r_1)$ und $A(r_2)$ kommen noch
+      Gegen\"uber den Zustands-\"Uberg\"angen der Automaten $A(r_1)$ und $A(r_2)$ kommen noch
       vier $\varepsilon$-Transitionen hinzu: 
       \begin{enumerate}
       \item Von dem neuen Start-Zustand $q_0$ gibt es jeweils eine
-            $\varepsilon$-Transition zu den Start-Zuständen $q_1$ und $q_2$ der Automaten
+            $\varepsilon$-Transition zu den Start-Zust\"anden $q_1$ und $q_2$ der Automaten
              $A(r_1)$ und $A(r_2)$.
-      \item Von den akzeptierenden Zuständen $q_3$ und $q_4$ der Automaten
+      \item Von den akzeptierenden Zust\"anden $q_3$ und $q_4$ der Automaten
              $A(r_1)$ und $A(r_2)$ gibt es jeweils eine $\varepsilon$-Transition zu dem
              akzeptierenden Zustand $q_5$.
       \end{enumerate}
-      Um den so definierten Automaten zu vereinfachen, \emph{\textcolor{blue}{könnten}} wir einerseits die drei
-      Zustände $q_0$, $q_1$ und $q_2$ und andererseits die drei Zustände 
+      Um den so definierten Automaten zu vereinfachen, \emph{\textcolor{blue}{k\"onnten}} wir einerseits die drei
+      Zust\"ande $q_0$, $q_1$ und $q_2$ und andererseits die drei Zust\"ande 
       $q_3$, $q_4$ und $q_5$ identifizieren.  Dies werden wir aber in den Anwendungen 
       \underline{\textbf{\textcolor{red}{nicht}}} machen, weil die resultierenden Automaten dann
       schwieriger zu verstehen sind. 
-\item Um den Automaten $A(r^*)$ für den Kleene-Abschluss $r^*$ 
-      definieren zu können, schreiben wir $A(r)$ als
+\item Um den Automaten $A(r^*)$ f\"ur den Kleene-Abschluss $r^*$ 
+      definieren zu k\"onnen, schreiben wir $A(r)$ als
       \\[0.2cm]
       \hspace*{1.3cm}
       $A(r) = \langle Q, \Sigma, \delta, q_1, \{ q_2 \} \rangle$,
       \\[0.2cm]
-      Damit können wir  $A(r^*)$ aus dem Automaten $A(r)$ 
+      Damit k\"onnen wir  $A(r^*)$ aus dem Automaten $A(r)$ 
       konstruieren:  Der Automat $A(r^*)$ ist  durch den Ausdruck
       \\[0.2cm]
       \hspace*{0.8cm}
@@ -1211,31 +1211,31 @@ Konstruktion des regulären Ausdrucks $r$ verwendet wurde.  Dann wird $A(r)$ wie 
       \label{fig:aStar.eps}
       \end{figure}
       Abbildung \ref{fig:aStar.eps} zeigt den Automaten $A(r^*)$.
-      Wir sehen, dass zusätzlich zu den Zuständen des  Automaten $A(r)$ 
-      noch zwei weitere Zustände hinzukommen:
+      Wir sehen, dass zus\"atzlich zu den Zust\"anden des  Automaten $A(r)$ 
+      noch zwei weitere Zust\"ande hinzukommen:
       \begin{enumerate}
       \item $q_0$ ist der Start-Zustand des Automaten $A(r^*)$,
       \item $q_3$ ist der einzige akzeptierende Zustand des Automaten $A(r^*)$.
       \end{enumerate}
-      Zu den Zustands-Übergängen des Automaten $A(r)$  kommen 
+      Zu den Zustands-\"Uberg\"angen des Automaten $A(r)$  kommen 
       vier $\varepsilon$-Transitionen hinzu: 
       \begin{enumerate}
       \item Von dem neuen Start-Zustand $q_0$ gibt es jeweils eine
-            $\varepsilon$-Transition zu den Zuständen $q_1$ und $q_3$.
-      \item Von $q_2$ gibt es eine  $\varepsilon$-Transition zurück zu dem
+            $\varepsilon$-Transition zu den Zust\"anden $q_1$ und $q_3$.
+      \item Von $q_2$ gibt es eine  $\varepsilon$-Transition zur\"uck zu dem
             Zustand $q_1$.
       \item Von $q_2$ gibt es eine  $\varepsilon$-Transition zu dem
             Zustand $q_3$.
       \end{enumerate}
-      \textbf{\textcolor{red}{Achtung}}:  Wenn wir bei diesem Automaten versuchen würden, die Zustände
+      \textbf{\textcolor{red}{Achtung}}:  Wenn wir bei diesem Automaten versuchen w\"urden, die Zust\"ande
       $q_0$ und $q_1$ bzw.~$q_2$ und $q_3$ zu identifizieren, dann funktioniert das in 
-      diesem Abschnitt beschriebene Verfahren in bestimmten  Fällen nicht mehr.  Diese
-      Zustände \textbf{dürfen} also \underline{\textbf{\textcolor{red}{nicht}}} identifiziert werden!
+      diesem Abschnitt beschriebene Verfahren in bestimmten  F\"allen nicht mehr.  Diese
+      Zust\"ande \textbf{d\"urfen} also \underline{\textbf{\textcolor{red}{nicht}}} identifiziert werden!
 \end{enumerate}
 
 \exercise
 Konstruieren Sie einen nicht-deterministischen endlichen Automaten, der die durch
-den regulären Ausdruck
+den regul\"aren Ausdruck
 \\[0.2cm]
 \hspace*{1.3cm}
 $(\texttt{a} + \texttt{b}) \cdot \texttt{a}^* \cdot \texttt{b}$
@@ -1244,15 +1244,15 @@ spezifizierte Sprache erkennt.
 
 \exerciseStar
 Konstruieren Sie einen nicht-deterministischen endlichen Automaten, der die durch
-den regulären Ausdruck
+den regul\"aren Ausdruck
 \\[0.2cm]
 \hspace*{1.3cm}
 $\texttt{a}^* \cdot \texttt{b}^*$
 \\[0.2cm]
-spezifizierte Sprache erkennt.  Überlegen Sie sich, warum Sie in diesem Beispiel bei der Konstruktion zur
-Berechnung des Kleene-Abschlusses die Zustände, die in dem im Text beschriebenen
+spezifizierte Sprache erkennt.  \"Uberlegen Sie sich, warum Sie in diesem Beispiel bei der Konstruktion zur
+Berechnung des Kleene-Abschlusses die Zust\"ande, die in dem im Text beschriebenen
 Algorithmus die Namen $q_0$ und $q_1$ bzw.~$q_2$ und $q_3$ haben, nicht identifizieren
-dürfen.
+d\"urfen.
 
 \subsection{Implementing the Conversion of Regular Expressions into \textsc{Fsm}s}
 In this section, we develop a \textsc{SetlX} program that transforms a regular expression
@@ -1679,10 +1679,10 @@ state machines shown in the previous section into \textsc{SetlX} code.
 
 
 
-\section{Übersetzung eines \textsc{EA} in einen regulären Ausdruck}
+\section{\"Ubersetzung eines \textsc{EA} in einen regul\"aren Ausdruck}
 Wir runden die Theorie ab, indem wir zeigen, dass sich zu jedem deterministischen endlichen
-Automaten $A$ ein regulärer Ausdruck $r(A)$ angeben lässt, der dieselbe Sprache spezifiziert,
-die von dem Automaten $A$ akzeptiert wird, für den also
+Automaten $A$ ein regul\"arer Ausdruck $r(A)$ angeben l\"asst, der dieselbe Sprache spezifiziert,
+die von dem Automaten $A$ akzeptiert wird, f\"ur den also
 \\[0.2cm]
 \hspace*{1.3cm}
 $L\bigl(r(A)\bigr) = L(A)$
@@ -1692,43 +1692,43 @@ gilt.  Der  Automat $A$ habe die Form
 \hspace*{1.3cm}
 $A = \langle \{ q_0, q_1, \cdots, q_n \}, \Sigma, \delta, q_0, F \rangle$.
 \\[0.2cm]
-Für jedes Paar von Zuständen $\pair(p_1,p_2) \in Q \times Q$ definieren wir einen regulären Ausdruck
-$r(p_1, p_2)$.   Die Idee bei dieser Definition ist, dass der reguläre Ausdruck
+F\"ur jedes Paar von Zust\"anden $\pair(p_1,p_2) \in Q \times Q$ definieren wir einen regul\"aren Ausdruck
+$r(p_1, p_2)$.   Die Idee bei dieser Definition ist, dass der regul\"are Ausdruck
 $r(p_1, p_2)$ alle die Strings $w$ spezifiziert, die den Automaten $A$ von dem Zustand
-$p_1$ in den Zustand $p_2$ überführen, formal gilt:
+$p_1$ in den Zustand $p_2$ \"uberf\"uhren, formal gilt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $L\bigl(r(p_1, p_2)\bigr) = 
   \bigl\{ w \in \Sigma^* \mid \pair(p_1,w) \leadsto^* \pair(p_2, \varepsilon) \bigr\}$
 \\[0.2cm]  
-Die Definition der regulären Ausdrücke erfolgt über einen Trick: Wir definieren für
-$k=0,\cdots,n+1$ reguläre Ausdrücke $r^{(k)}(p_1, p_2)$.   Diese reguläre Ausdrücke
+Die Definition der regul\"aren Ausdr\"ucke erfolgt \"uber einen Trick: Wir definieren f\"ur
+$k=0,\cdots,n+1$ regul\"are Ausdr\"ucke $r^{(k)}(p_1, p_2)$.   Diese regul\"are Ausdr\"ucke
 beschreiben gerade die Strings, die den Automaten $A$ von dem Zustand
-$p_1$ in den Zustand $p_2$ überführen, \underline{ohne} dass dabei zwischendurch ein
+$p_1$ in den Zustand $p_2$ \"uberf\"uhren, \underline{ohne} dass dabei zwischendurch ein
 Zustand aus der Menge 
 \\[0.2cm]
 \hspace*{1.3cm}
 $Q_k := \bigl\{ q_i \mid i \in \{k,\cdots,n \}  \bigl\} = \{ q_k, \cdots, q_n \}$ 
 \\[0.2cm]
-besucht wird.  Die Menge $Q_k$ enthält also nur die Zustände, deren Index größer oder
+besucht wird.  Die Menge $Q_k$ enth\"alt also nur die Zust\"ande, deren Index gr\"o{\ss}er oder
 gleich $k$ ist.  Formal definieren wir dazu die dreistellige Relation 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\mapsto_k \;\subseteq\; (Q \times \Sigma^* \times Q)$.
 \\[0.2cm]
-Für zwei Zustände $p, q \in Q$ und einen String $w$ soll 
+F\"ur zwei Zust\"ande $p, q \in Q$ und einen String $w$ soll 
 \\[0.2cm]
 \hspace*{1.3cm}
 $p \stackrel{w}{\mapsto}_k q$
 \\[0.2cm]
 genau dann gelten, wenn der Automat $A$ von dem Zustand $p$ beim Lesen des Wortes $w$ in
-den Zustand $q$ übergeht, ohne dabei \underline{zwischendurch} in einen Zustand aus der
-Menge $Q_k$ zu wechseln.  Mit ``zwischendurch'' ist hier gemeint, dass die Zustände $p$
-und $q$ sehr wohl in der Menge $Q_k$ liegen können, nur die Zwischenzustände dürfen nicht in $Q_k$
+den Zustand $q$ \"ubergeht, ohne dabei \underline{zwischendurch} in einen Zustand aus der
+Menge $Q_k$ zu wechseln.  Mit ``zwischendurch'' ist hier gemeint, dass die Zust\"ande $p$
+und $q$ sehr wohl in der Menge $Q_k$ liegen k\"onnen, nur die Zwischenzust\"ande d\"urfen nicht in $Q_k$
 liegen.  Die formale Definition der Relation  
-$p \stackrel{w}{\mapsto}_k q$ erfolgt durch Induktion nach der Länge des Wortes $w$:
+$p \stackrel{w}{\mapsto}_k q$ erfolgt durch Induktion nach der L\"ange des Wortes $w$:
 \begin{enumerate}
-\item[I.A.:] $|w| \leq 1$.  Im Induktions-Anfang haben wir zwei Fälle:
+\item[I.A.:] $|w| \leq 1$.  Im Induktions-Anfang haben wir zwei F\"alle:
   \begin{enumerate}
   \item $p \stackrel{\varepsilon}{\mapsto}_k p$,
 
@@ -1737,8 +1737,8 @@ $p \stackrel{w}{\mapsto}_k q$ erfolgt durch Induktion nach der Länge des Wortes 
   \item $\delta(p, c) = q \;\Rightarrow\; p \stackrel{c}{\mapsto}_k q$,
 
         denn wenn der Automat beim Lesen des Buchstabens $c$ von dem Zustand $p$ direkt
-        in den Zustand $q$ übergeht, dann werden zwischendurch keine Zustände aus $Q_k$
-        besucht, denn es werden überhaupt keine Zustände zwischendurch besucht.
+        in den Zustand $q$ \"ubergeht, dann werden zwischendurch keine Zust\"ande aus $Q_k$
+        besucht, denn es werden \"uberhaupt keine Zust\"ande zwischendurch besucht.
   \end{enumerate}
 \item[I.S.:] $w = cv$ mit $|v| \geq 1$.
 
@@ -1747,41 +1747,41 @@ $p \stackrel{w}{\mapsto}_k q$ erfolgt durch Induktion nach der Länge des Wortes 
               \Rightarrow p \stackrel{cv}{\mapsto}_k r$.
 
              Wenn der Automat $A$ von dem Zustand $p$ durch Lesen des Buchstabens $c$
-             in einen  Zustand $q \notin Q_k$ übergeht und wenn der Automat dann von
-             diesem Zustand $q$ beim Lesen von $v$ in den Zustand $r$ übergehen kann, ohne
-             dabei Zustände aus $Q_k$ zu benutzen, dann geht der Automat beim Lesen von
-             $cv$ aus dem Zustand $p$ in den Zustand $r$ über,
-             ohne zwischendurch in Zustände aus $Q_k$ zu wechseln.
+             in einen  Zustand $q \notin Q_k$ \"ubergeht und wenn der Automat dann von
+             diesem Zustand $q$ beim Lesen von $v$ in den Zustand $r$ \"ubergehen kann, ohne
+             dabei Zust\"ande aus $Q_k$ zu benutzen, dann geht der Automat beim Lesen von
+             $cv$ aus dem Zustand $p$ in den Zustand $r$ \"uber,
+             ohne zwischendurch in Zust\"ande aus $Q_k$ zu wechseln.
 \end{enumerate}
-Damit können wir nun für alle $k=0,\cdots,n+1$ die regulären Ausdrücke
-$r^{(k)}(p_1, p_2)$ definieren.  Wir werden diese regulären Ausdrücke so definieren, dass
+Damit k\"onnen wir nun f\"ur alle $k=0,\cdots,n+1$ die regul\"aren Ausdr\"ucke
+$r^{(k)}(p_1, p_2)$ definieren.  Wir werden diese regul\"aren Ausdr\"ucke so definieren, dass
 hinterher
 \\[0.2cm]
 \hspace*{1.3cm}
 $L\bigl(r^{(k)}(p_1, p_2)\bigr) = \bigl\{ w \in \Sigma^* \mid p_1 \stackrel{w}{\mapsto}_k p_2 \bigr\}$
 \\[0.2cm]
 gilt.
-Die Definition der regulären Ausdrücke $r^{(k)}(p_1, p_2)$ erfolgt durch eine Induktion nach $k$.
+Die Definition der regul\"aren Ausdr\"ucke $r^{(k)}(p_1, p_2)$ erfolgt durch eine Induktion nach $k$.
 \begin{enumerate}
 \item[I.A.:] $k = 0$.  
 
-  Dann gilt $Q_0 = Q$, die Menge $Q_0$ enthält also alle Zustände
-  und damit dürfen wir, wenn wir vom Zustand $p_1$ in den Zustand $p_2$ übergehen,
-  zwischendurch überhaupt keine Zustände besuchen.
+  Dann gilt $Q_0 = Q$, die Menge $Q_0$ enth\"alt also alle Zust\"ande
+  und damit d\"urfen wir, wenn wir vom Zustand $p_1$ in den Zustand $p_2$ \"ubergehen,
+  zwischendurch \"uberhaupt keine Zust\"ande besuchen.
 
-  Wir betrachten zunächst den Fall $p_1 \not= p_2$.  Dann kann $p_1 \stackrel{w}{\mapsto}_0 p_2$ nur dann gelten, wenn $w$ aus einem
+  Wir betrachten zun\"achst den Fall $p_1 \not= p_2$.  Dann kann $p_1 \stackrel{w}{\mapsto}_0 p_2$ nur dann gelten, wenn $w$ aus einem
   einzigen Buchstaben besteht.   Es sei
   \\[0.2cm]
   \hspace*{1.3cm}
   $\{ c_1, \cdots, c_l \} := \{ c \in \Sigma \mid \delta(p_1,c) = p_2 \}$
   \\[0.2cm]
-  die Menge aller Buchstaben, die den Zustand $p_1$ in den Zustand $p_2$ überführen.
+  die Menge aller Buchstaben, die den Zustand $p_1$ in den Zustand $p_2$ \"uberf\"uhren.
   Falls diese Menge nicht leer ist, setzen wir 
   \\[0.2cm]
   \hspace*{1.3cm}
   $r^{(0)}(p_1, p_2) := c_1 + \cdots + c_l$. 
   \\[0.2cm]
-  Ist die obige Menge leer, so gibt es keinen direkten Übergang von
+  Ist die obige Menge leer, so gibt es keinen direkten \"Ubergang von
   $p_1$ nach $p_2$ und wir setzen 
   \\[0.2cm]
   \hspace*{1.3cm}
@@ -1792,24 +1792,24 @@ Die Definition der regulären Ausdrücke $r^{(k)}(p_1, p_2)$ erfolgt durch eine In
   \hspace*{1.3cm}
   $\{ c_1, \cdots, c_l \} := \{ c \in \Sigma \mid \delta(p_1,c) = p_1 \}$
   \\[0.2cm]
-  als die Menge aller Buchstaben, die den Zustand $p_1$ in sich selbst überführen,
-  so können wir in dem Fall, dass diese Menge nicht leer ist, 
+  als die Menge aller Buchstaben, die den Zustand $p_1$ in sich selbst \"uberf\"uhren,
+  so k\"onnen wir in dem Fall, dass diese Menge nicht leer ist, 
   \\[0.2cm]
   \hspace*{1.3cm}
   $r^{(0)}(p_1, p_1) := c_1 + \cdots + c_l + \varepsilon$,
   \\[0.2cm]
-  setzen.  Ist die obige Menge leer, so gibt es nur den Übergang mit dem leeren Wort
+  setzen.  Ist die obige Menge leer, so gibt es nur den \"Ubergang mit dem leeren Wort
   von $p_1$ nach $p_1$ und wir setzen 
   \\[0.2cm]
   \hspace*{1.3cm}
   $r^{(0)}(p_1, p_1) := \varepsilon$.
 \item[I.S.:] $k \mapsto k+1$.  
 
-  Bei dem Übergang von $r^{(k)}(p_1, p_2)$ zu  $r^{(k+1)}(p_1, p_2)$ dürfen wir zusätzlich
+  Bei dem \"Ubergang von $r^{(k)}(p_1, p_2)$ zu  $r^{(k+1)}(p_1, p_2)$ d\"urfen wir zus\"atzlich
   den Zustand $q_k$ benutzen, denn $q_k$ ist das einzige Element der Menge $Q_k$, das
   nicht in der Menge $Q_{k+1}$ enthalten ist.  Wird ein String $w$ gelesen, der
-  den Zustand $p_1$ in den Zustand $p_2$ überführt, ohne dabei zwischendurch in einen
-  Zustand aus der Menge $Q_{k+1}$ zu wechseln, so gibt es zwei Möglichkeiten:
+  den Zustand $p_1$ in den Zustand $p_2$ \"uberf\"uhrt, ohne dabei zwischendurch in einen
+  Zustand aus der Menge $Q_{k+1}$ zu wechseln, so gibt es zwei M\"oglichkeiten:
   \begin{enumerate}
   \item Es gilt bereits $p_1 \stackrel{w}{\mapsto}_k p_2$.
   \item Der String $w$ kann so in mehrere Teile $w_1 s_1\cdots s_l w_2$ aufgeteilt werden,
@@ -1818,15 +1818,15 @@ Die Definition der regulären Ausdrücke $r^{(k)}(p_1, p_2)$ erfolgt durch eine In
         \item $p_1 \stackrel{w_1}{\mapsto}_k q_k$,
 
                von dem Zustand $p_1$ gelangt der Automat also beim Lesen von $w_1$
-               zunächst in den Zustand $q_k$, wobei zwischendurch der Zustand
+               zun\"achst in den Zustand $q_k$, wobei zwischendurch der Zustand
                $q_k$ nicht benutzt wird.
-        \item $q_k \stackrel{s_i}{\mapsto}_k q_k$ \quad für alle $i = \{ 1, \cdots, l\}$,
+        \item $q_k \stackrel{s_i}{\mapsto}_k q_k$ \quad f\"ur alle $i = \{ 1, \cdots, l\}$,
 
               von dem Zustand $q_k$ wechselt der Automat beim Lesen der Teilstrings
               $s_i$ wieder in den Zustand $q_k$.
         \item $q_k \stackrel{w_2}{\mapsto}_k p_2$,
 
-              schließlich wechselt der Automat von dem Zustand $q_k$ in den Zustand
+              schlie{\ss}lich wechselt der Automat von dem Zustand $q_k$ in den Zustand
               $p_2$, wobei der Rest $w_2$ gelesen wird.
         \end{itemize}
         Daher definieren wir
@@ -1837,89 +1837,89 @@ Die Definition der regulären Ausdrücke $r^{(k)}(p_1, p_2)$ erfolgt durch eine In
          r^{(k)}(p_1,q_k) \cdot \bigl(r^{(k)}(q_k,q_k)\bigr)^* \cdot r^{(k)}(q_k,p_2)$.
         \\[0.2cm]
         Dieser Ausdruck kann wie folgt gelesen werden:  Um von $p_1$ nach $p_2$ zu kommen,
-        ohne dabei zwischendurch Zustände aus $Q_{k+1}$ zu benutzen, kann der Automat entweder direkt
-        von $p_1$ nach $p_2$ gelangen, ohne zwischendurch Zustände aus  $Q_k$ zu benutzen, was dem Ausdruck 
+        ohne dabei zwischendurch Zust\"ande aus $Q_{k+1}$ zu benutzen, kann der Automat entweder direkt
+        von $p_1$ nach $p_2$ gelangen, ohne zwischendurch Zust\"ande aus  $Q_k$ zu benutzen, was dem Ausdruck 
         $r^{(k)}(p_1,p_2)$ entspricht, oder aber der Automat wechselt von $p_1$ ein erstes Mal
-        in den Zustand $q_k$, was den Ausdruck $r^{(k)}(p_1,q_k)$ erklärt, wechselt dann beliebig oft
-        von $q_k$ nach $q_k$,  was den Ausdruck  $\bigl(r^{(k)}(q_k,q_k)\bigr)^*$ erklärt und wechselt
-        schließlich von $q_k$ in den Zustand $p_2$, wofür der Ausdruck $r^{(k)}(q_k,p_2)$ steht. 
+        in den Zustand $q_k$, was den Ausdruck $r^{(k)}(p_1,q_k)$ erkl\"art, wechselt dann beliebig oft
+        von $q_k$ nach $q_k$,  was den Ausdruck  $\bigl(r^{(k)}(q_k,q_k)\bigr)^*$ erkl\"art und wechselt
+        schlie{\ss}lich von $q_k$ in den Zustand $p_2$, wof\"ur der Ausdruck $r^{(k)}(q_k,p_2)$ steht. 
   \end{enumerate}  
 \end{enumerate}
-Nun haben wir alles Material zusammen, um die Ausdrücke $r(p_1,p_2)$ definieren zu können.
+Nun haben wir alles Material zusammen, um die Ausdr\"ucke $r(p_1,p_2)$ definieren zu k\"onnen.
 Wir setzen 
 \\[0.2cm]
 \hspace*{1.3cm}
 $r(p_1,p_2) := r^{(n+1)}(p_1,p_2)$. 
 \\[0.2cm]
-Dieser reguläre Ausdruck beschreibt die Wörter, die den Automaten von dem Zustand $p_1$ in
-den Zustand $p_2$ überführen, ohne dass der Automat dabei in einen Zustand der Menge
+Dieser regul\"are Ausdruck beschreibt die W\"orter, die den Automaten von dem Zustand $p_1$ in
+den Zustand $p_2$ \"uberf\"uhren, ohne dass der Automat dabei in einen Zustand der Menge
 $Q_{n+1}$ wechselt.   Nun gilt aber
 \\[0.2cm]
 \hspace*{1.3cm}
 $Q_{n+1} = \{ q_i | i \in \{0,\cdots,n \} \wedge i \geq n+1 \} = \{\}$,
 \\[0.2cm]
-die Menge ist also leer!  Folglich werden durch den regulären Ausdruck $r^{(n+1)}(p_1,p_2)$
-überhaupt keine Zustände ausgeschlossen:  Der Ausdruck beschreibt also genau die Strings,
-die den Zustand $p_1$ in den Zustand $p_2$ überführen, es gilt also
+die Menge ist also leer!  Folglich werden durch den regul\"aren Ausdruck $r^{(n+1)}(p_1,p_2)$
+\"uberhaupt keine Zust\"ande ausgeschlossen:  Der Ausdruck beschreibt also genau die Strings,
+die den Zustand $p_1$ in den Zustand $p_2$ \"uberf\"uhren, es gilt also
 \\[0.2cm]
 \hspace*{1.3cm}
 $r^{(n+1)}(p_1,p_2) = r(p_1,p_2)$.
 \\[0.2cm]
-Um nun einen regulären Ausdruck konstruieren zu können, der die Sprache des Automaten $A$
-beschreibt, schreiben wir die Menge $F$ der akzeptierenden Zustände von $A$ als
+Um nun einen regul\"aren Ausdruck konstruieren zu k\"onnen, der die Sprache des Automaten $A$
+beschreibt, schreiben wir die Menge $F$ der akzeptierenden Zust\"ande von $A$ als
 \\[0.2cm]
 \hspace*{1.3cm}
 $F = \{ t_1, \cdots, t_m \}$
 \\[0.2cm]
-und definieren den regulären Ausdruck $r(A)$ als
+und definieren den regul\"aren Ausdruck $r(A)$ als
 \\[0.2cm]
 \hspace*{1.3cm}
 $r(A) := r(q_0, t_1) + \cdots + r(q_0, t_m)$.
 \\[0.2cm]
 Dieser Ausdruck beschreibt genau die Strings, die den Automaten $A$ aus dem Start-Zustand
-in einen der akzeptierenden Zustände überführen.
+in einen der akzeptierenden Zust\"ande \"uberf\"uhren.
 \qed
 \vspace*{0.3cm}
 
 
 \noindent
 Damit sehen wir jetzt, dass die Konzepte ``\emph{deterministischer endlicher Automat}'' und
-``\emph{regulärer Ausdruck}'' äquivalent sind.
+``\emph{regul\"arer Ausdruck}'' \"aquivalent sind.
 \begin{enumerate}
-\item Jeder deterministische endliche Automat kann in einen äquivalenten regulären
-      Ausdruck übersetzt werden.
-\item Jeder reguläre Ausdruck kann in einen äquivalenten nicht-deterministischen endlichen Automaten
+\item Jeder deterministische endliche Automat kann in einen \"aquivalenten regul\"aren
+      Ausdruck \"ubersetzt werden.
+\item Jeder regul\"are Ausdruck kann in einen \"aquivalenten nicht-deterministischen endlichen Automaten
       transformiert werden.
-\item Ein nicht-deterministischer endlicher Automat lässt sich durch die
-      Teilmengen-Konstruktion in einen endlichen Automaten überführen.
+\item Ein nicht-deterministischer endlicher Automat l\"asst sich durch die
+      Teilmengen-Konstruktion in einen endlichen Automaten \"uberf\"uhren.
 \end{enumerate}
 
 \exercise
-Konstruieren Sie für den in Abbildung \ref{fig:abstara.dot} gezeigten endlichen Automaten einen
-äquivalenten regulären Ausdruck.  
+Konstruieren Sie f\"ur den in Abbildung \ref{fig:abstara.dot} gezeigten endlichen Automaten einen
+\"aquivalenten regul\"aren Ausdruck.  
 
 
 \solution
-Der Automat hat die Zustände $0$ und $1$.  Wir berechnen zunächst die regulären Ausdrücke
-$r^{(k)}(i,j)$ für alle $i,j\in\{0,1\}$ der Reihe nach für die Werte $k =0$, $1$ und $2$:
+Der Automat hat die Zust\"ande $0$ und $1$.  Wir berechnen zun\"achst die regul\"aren Ausdr\"ucke
+$r^{(k)}(i,j)$ f\"ur alle $i,j\in\{0,1\}$ der Reihe nach f\"ur die Werte $k =0$, $1$ und $2$:
 \begin{enumerate}
-\item Für $k = 0$ finden wir:
+\item F\"ur $k = 0$ finden wir:
       \begin{enumerate}
       \item $r^{(0)}(0, 0) = \texttt{a} + \varepsilon$,
       \item $r^{(0)}(0, 1) = \texttt{b}$,
       \item $r^{(0)}(1, 0) = \emptyset$,
       \item $r^{(0)}(1, 1) = \texttt{a} + \varepsilon$.
       \end{enumerate}
-\item Für $k=1$ haben wir:
+\item F\"ur $k=1$ haben wir:
       \begin{enumerate}
-      \item Für $r^{(1)}(0, 0)$ finden wir:
+      \item F\"ur $r^{(1)}(0, 0)$ finden wir:
             \begin{eqnarray*}
                   r^{(1)}(0, 0) 
             & = & r^{(0)}(0, 0) + 
                   r^{(0)}(0, 0) \cdot \bigl(r^{(0)}(0, 0)\bigr)^* \cdot r^{(0)}(0, 0) \\
             & = & r^{(0)}(0, 0) \cdot \bigl(r^{(0)}(0, 0)\bigr)^*
             \end{eqnarray*}
-             wobei wir im letzten Schritt die für reguläre Ausdrücke allgemeingültige Umformung
+             wobei wir im letzten Schritt die f\"ur regul\"are Ausdr\"ucke allgemeing\"ultige Umformung
              \\[0.2cm]
              \hspace*{1.3cm}
              $
@@ -1930,7 +1930,7 @@ $r^{(k)}(i,j)$ für alle $i,j\in\{0,1\}$ der Reihe nach für die Werte $k =0$, $1$
              $
              \\[0.2cm]
              verwendet haben.
-             Setzen wir für $r^{(0)}(0, 0)$ den oben gefundenen Ausdruck $\texttt{a} + \varepsilon$ ein, 
+             Setzen wir f\"ur $r^{(0)}(0, 0)$ den oben gefundenen Ausdruck $\texttt{a} + \varepsilon$ ein, 
              so erhalten wir 
              \\[0.2cm]
              \hspace*{1.3cm}
@@ -1941,7 +1941,7 @@ $r^{(k)}(i,j)$ für alle $i,j\in\{0,1\}$ der Reihe nach für die Werte $k =0$, $1$
              \\[0.2cm]
              \hspace*{1.3cm}
              $r^{(1)}(0, 0) = \texttt{a}^*$.
-      \item Für $r^{(1)}(0, 1)$ finden wir:
+      \item F\"ur $r^{(1)}(0, 1)$ finden wir:
             \begin{eqnarray*}
                   r^{(1)}(0, 1) 
             & = & r^{(0)}(0, 1) + 
@@ -1952,7 +1952,7 @@ $r^{(k)}(i,j)$ für alle $i,j\in\{0,1\}$ der Reihe nach für die Werte $k =0$, $1$
             & = & (\varepsilon + \texttt{a}^*) \cdot \texttt{b} \\
             & = & \texttt{a}^* \cdot \texttt{b} 
         \end{eqnarray*}
-      \item Für $r^{(1)}(1, 0)$ finden wir:
+      \item F\"ur $r^{(1)}(1, 0)$ finden wir:
             \begin{eqnarray*}
                   r^{(1)}(1, 0) 
             & = & r^{(0)}(1, 0) + 
@@ -1960,7 +1960,7 @@ $r^{(k)}(i,j)$ für alle $i,j\in\{0,1\}$ der Reihe nach für die Werte $k =0$, $1$
             & = & \emptyset + \emptyset \cdot (\texttt{a} + \varepsilon)^* \cdot (\texttt{a} + \varepsilon) \\
             & = & \emptyset
             \end{eqnarray*}
-      \item Für $r^{(1)}(1, 1)$ finden wir
+      \item F\"ur $r^{(1)}(1, 1)$ finden wir
             \begin{eqnarray*}
                   r^{(1)}(1, 1)
             & = & r^{(0)}(1, 1) + 
@@ -1971,7 +1971,7 @@ $r^{(k)}(i,j)$ für alle $i,j\in\{0,1\}$ der Reihe nach für die Werte $k =0$, $1$
             & = & \texttt{a} + \varepsilon  
             \end{eqnarray*}
       \end{enumerate}
-\item Für $k=2$ müssen wir lediglich den regulären Ausdruck $r^{(2)}(0, 1)$ berechnen.  Es gilt
+\item F\"ur $k=2$ m\"ussen wir lediglich den regul\"aren Ausdruck $r^{(2)}(0, 1)$ berechnen.  Es gilt
             \begin{eqnarray*}
                   r^{(2)}(0, 1)
             & = & r^{(1)}(0, 1) + 
@@ -1984,21 +1984,21 @@ $r^{(k)}(i,j)$ für alle $i,j\in\{0,1\}$ der Reihe nach für die Werte $k =0$, $1$
         \end{eqnarray*}
 \end{enumerate}
 Da der Zustand 0 der Start-Zustand und der Zustand 1 der einzige akzeptierende Zustand
-ist, können wir nun den regulären Ausdruck $r(A)$ angeben: 
+ist, k\"onnen wir nun den regul\"aren Ausdruck $r(A)$ angeben: 
 \\[0.2cm]
 \hspace*{1.3cm}
 $r(A) = r^{(2)}(0, 1) = \texttt{a}^* \cdot \texttt{b} \cdot \texttt{a}^*$.
 \\[0.2cm]
-Dieses Ergebnis, das wir mühevoll abgeleitet haben, hätten wir auch durch einen einfachen
-Blick auf den Automaten erhalten können, aber die oben gezeigte Rechnung formalisiert das,
-was der geübte Betrachter unmittelbar erkennt und der beschriebene Algorithmus hat den
-Vorteil, dass er sich implementieren lässt.
+Dieses Ergebnis, das wir m\"uhevoll abgeleitet haben, h\"atten wir auch durch einen einfachen
+Blick auf den Automaten erhalten k\"onnen, aber die oben gezeigte Rechnung formalisiert das,
+was der ge\"ubte Betrachter unmittelbar erkennt und der beschriebene Algorithmus hat den
+Vorteil, dass er sich implementieren l\"asst.
 \qed
 
 \exercise
-Konstruieren Sie für den in Abbildung \ref{fig:exercise-13.eps} auf Seite
+Konstruieren Sie f\"ur den in Abbildung \ref{fig:exercise-13.eps} auf Seite
 \pageref{fig:exercise-13.eps} gezeigten endlichen Automaten einen
-regulären Ausdruck, der dieselbe Sprache beschreibt, die von dem abgebildeten Automaten erkannt
+regul\"aren Ausdruck, der dieselbe Sprache beschreibt, die von dem abgebildeten Automaten erkannt
 wird.   
 
 \begin{figure}[!ht]

--- a/Lecture-Notes/formal-languages.tex
+++ b/Lecture-Notes/formal-languages.tex
@@ -105,7 +105,7 @@
 
 \newcommand{\solution}{\vspace*{0.2cm}
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 
 \newcommand{\solutionEng}{\vspace*{0.2cm}
 \noindent

--- a/Lecture-Notes/grenzen-kontextfrei-save.tex
+++ b/Lecture-Notes/grenzen-kontextfrei-save.tex
@@ -1,58 +1,58 @@
 \chapter{Grenzen kontextfreier Sprachen} 
 In diesem Kapitel diskutieren wir die Grenzen kontextfreier Sprachen und leiten dazu dass
-sogenannte ``\emph{große Pumping-Lemma}'' her, mit dessen Hilfe wir beispielsweise zeigen
-können, dass die Sprache $L_{\mbox{\scriptsize \textsl{square}}}$, die durch
+sogenannte ``\emph{gro{\ss}e Pumping-Lemma}'' her, mit dessen Hilfe wir beispielsweise zeigen
+k\"onnen, dass die Sprache $L_{\mbox{\scriptsize \textsl{square}}}$, die durch
 \\[0.2cm]
 \hspace*{1.3cm} $L_{\mbox{\scriptsize \textsl{square}}} = \bigl\{ ww \mid w \in \Sigma^*\bigr\}$
 \\[0.2cm]
-definiert wird, für das Alphabet $\Sigma =\{\texttt{a}, \texttt{b}\}$ keine kontextfreie Sprache ist.
+definiert wird, f\"ur das Alphabet $\Sigma =\{\texttt{a}, \texttt{b}\}$ keine kontextfreie Sprache ist.
 
 
 \section{Die verallgemeinerte Chomsky-Normalform}
 In diesem Abschnitt zeigen wir, wie eine kontextfreie Sprache in die \emph{verallgemeinerte Chomsky-Normal\-form}
-(vCNF) überführt werden kann.  Die Überführung einer Sprache in verallgemeinerte
+(vCNF) \"uberf\"uhrt werden kann.  Die \"Uberf\"uhrung einer Sprache in verallgemeinerte
 Chomsky-Normalform erfolgt in mehreren Schritten.
 \begin{enumerate}
-\item Zunächst beseitigen wir \emph{nutzlose Symbole}.
+\item Zun\"achst beseitigen wir \emph{nutzlose Symbole}.
 
       Ist $G = \langle V, T, R, S \rangle$ eine Grammatik, so nennen wir eine syntaktische Variable $A \in V$
-      \emph{nützlich}, wenn es einen String $w \in T^*$ sowie Strings $\alpha,\beta \in (V \cup T)^*$ gibt, 
+      \emph{n\"utzlich}, wenn es einen String $w \in T^*$ sowie Strings $\alpha,\beta \in (V \cup T)^*$ gibt, 
       so dass 
       \\[0.2cm]
       \hspace*{1.3cm}
       $S \Rightarrow^* \alpha A \beta \Rightarrow^* w$
       \\[0.2cm]
-      gilt.  Eine syntaktische Variable ist also genau dann nützlich, wenn diese Variable in der Herleitung
+      gilt.  Eine syntaktische Variable ist also genau dann n\"utzlich, wenn diese Variable in der Herleitung
       eines Wortes $w \in L(G)$ verwendet werden kann.
 
-      Ein Terminal $t$ ist \emph{nützlich}, wenn es Wörter $w_1, w_2 \in T^*$ gibt, so dass
+      Ein Terminal $t$ ist \emph{n\"utzlich}, wenn es W\"orter $w_1, w_2 \in T^*$ gibt, so dass
       \\[0.2cm]
       \hspace*{1.3cm}
       $S \Rightarrow^* w_1 t w_2$
       \\[0.2cm]
-      gilt.  Ein Terminal $t$ ist also genau dann nützlich, wenn es in einem Wort der Sprache $L(G)$
-      auftritt.  Variablen und Terminale, die nicht nützlich sind, bezeichnen wir als
+      gilt.  Ein Terminal $t$ ist also genau dann n\"utzlich, wenn es in einem Wort der Sprache $L(G)$
+      auftritt.  Variablen und Terminale, die nicht n\"utzlich sind, bezeichnen wir als
       \emph{nutzlose Symbole}.
-\item Anschließend zeigen wir, dass alle \emph{$\varepsilon$-Regeln} aus der Grammatik eliminiert werden können.
+\item Anschlie{\ss}end zeigen wir, dass alle \emph{$\varepsilon$-Regeln} aus der Grammatik eliminiert werden k\"onnen.
       Dabei bezeichnen wir eine Grammatik-Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $A \rightarrow \varepsilon$
       \\[0.2cm]
       als eine \emph{$\varepsilon$-Regel}.
-\item Schließlich zeigen wir, wie alle Grammatik-Regeln der Form 
+\item Schlie{\ss}lich zeigen wir, wie alle Grammatik-Regeln der Form 
       \\[0.2cm]
       \hspace*{1.3cm}
       $A \rightarrow B$
       \\[0.2cm]
-      mit $A,B \in V$ eliminiert werden können.  Solche Grammatik-Regeln werden als
+      mit $A,B \in V$ eliminiert werden k\"onnen.  Solche Grammatik-Regeln werden als
       \emph{Unit-Regeln} bezeichnet.
 \end{enumerate}
 
 \subsection{Beseitigung nutzloser Symbole}
-Die Erkennung nutzloser Symbole ist eine Überprüfung, die in manchen Parser-Generatoren
+Die Erkennung nutzloser Symbole ist eine \"Uberpr\"ufung, die in manchen Parser-Generatoren
 (beispielsweise in \textsl{Bison}\footnote{
-\textsl{Bison} ist ein Parser-Generator für die Sprache \texttt{C}.}) 
+\textsl{Bison} ist ein Parser-Generator f\"ur die Sprache \texttt{C}.}) 
 eingebaut ist, weil das Auftreten nutzloser Symbole oft
 einen Hinweis darauf gibt, dass die Grammatik nicht die Sprache beschreibt, die intendiert ist.  
 Insofern ist die jetzt vorgestellte Technik auch von praktischem Interesse.
@@ -65,8 +65,8 @@ ist eine \emph{erzeugende} Variable, wenn es ein Wort $w \in T^*$ gibt, so dass
 \hspace*{1.3cm}
 $A \Rightarrow^* w$
 \\[0.2cm]
-gilt, aus einer erzeugende Variable lässt sich also immer mindestens ein Wort aus $T^*$ herleiten. 
-Die Notation $A \Rightarrow^* w$ drückt aus, dass das Wort $w$ aus der Variablen $A$ in endlich vielen
+gilt, aus einer erzeugende Variable l\"asst sich also immer mindestens ein Wort aus $T^*$ herleiten. 
+Die Notation $A \Rightarrow^* w$ dr\"uckt aus, dass das Wort $w$ aus der Variablen $A$ in endlich vielen
 Schritten abgeleitet werden kann.
 \qed 
 \end{Definition}
@@ -76,13 +76,13 @@ Offenbar ist eine syntaktische Variable, die nicht erzeugend ist, nutzlos.  Die 
 erzeugenden Variablen einer Grammatik $G$  kann mit Hilfe der folgenden induktiven Definition
 gefunden werden.
 \begin{enumerate}
-\item Enthält die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
+\item Enth\"alt die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
        $A \rightarrow w$ \quad mit $w \in T^*$, 
       \\[0.2cm]
       so ist die Variable $A$ offenbar erzeugend.
-\item Enthält die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
+\item Enth\"alt die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
        $A \rightarrow \alpha$ 
@@ -106,7 +106,7 @@ Aufgrund der Regel
 \hspace*{1.3cm}
 $A \rightarrow \texttt{x}$
 \\[0.2cm]
-ist zunächst $A$ erzeugend.  Aufgrund der Regel
+ist zun\"achst $A$ erzeugend.  Aufgrund der Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \rightarrow A$
@@ -118,9 +118,9 @@ nutzlos.  \qed
 
 \noindent
 Ist $G = \langle V, T, R, S \rangle$ eine Grammatik und ist $E$ die Menge der erzeugenden Variablen,
-so können wir alle Variablen, die nicht erzeugend sind, einfach weglassen.  Zusätzlich müssen wir
-natürlich auch die Regeln weglassen, in denen Variablen auftreten, die nicht erzeugend sind.  Dabei
-ändert sich die von der Grammatik $G$ erzeugte Sprache offenbar nicht.
+so k\"onnen wir alle Variablen, die nicht erzeugend sind, einfach weglassen.  Zus\"atzlich m\"ussen wir
+nat\"urlich auch die Regeln weglassen, in denen Variablen auftreten, die nicht erzeugend sind.  Dabei
+\"andert sich die von der Grammatik $G$ erzeugte Sprache offenbar nicht.
 \pagebreak
 
 Eine Variable kann gleichzeitig erzeugend und trotzdem nutzlos sein.  Als einfaches
@@ -132,30 +132,30 @@ Beispiel betrachten wir die Grammatik  $G = \langle \{S, A, B \}, \{ \texttt{x},
 \end{eqnarray*}
 gegeben sind.  Die erzeugenden Variable sind in diesem Falle $A$, $B$ und $S$.  Die Variable
 $B$ ist trotzdem nutzlos, denn von $S$ aus ist diese Variable gar nicht \emph{erreichbar}.
-Formal definieren wir für eine Grammatik $G = \langle V, T, R, S \rangle$ eine syntaktische Variable $X$ als
-\emph{erreichbar}, wenn es Wörter $\alpha, \beta \in (V \cup T)^*$ gibt, so dass 
+Formal definieren wir f\"ur eine Grammatik $G = \langle V, T, R, S \rangle$ eine syntaktische Variable $X$ als
+\emph{erreichbar}, wenn es W\"orter $\alpha, \beta \in (V \cup T)^*$ gibt, so dass 
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \Rightarrow^* \alpha X \beta$
 \\[0.2cm]
-gilt. Für eine gegebene Grammatik $G$  lässt sich die Menge der Variablen, die erreichbar
+gilt. F\"ur eine gegebene Grammatik $G$  l\"asst sich die Menge der Variablen, die erreichbar
 sind, mit dem folgenden 
 induktiven Algorithmus berechnen.
 \begin{enumerate}
 \item Das Start-Symbol $S$ ist erreichbar.
-\item Enthält die Grammatik $G$ eine Regel der Form
+\item Enth\"alt die Grammatik $G$ eine Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $X \rightarrow \alpha$
       \\[0.2cm]
       und ist $X$ erreichbar, so sind auch alle Variablen, die in $\alpha$ auftreten, erreichbar.
 \end{enumerate}
-Offenbar sind Variablen, die nicht erreichbar sind, nutzlos und wir können diese Variablen, sowie alle
-Regeln, in denen diese Variablen auftreten, weglassen, ohne dass sich dabei die Sprache ändert.
+Offenbar sind Variablen, die nicht erreichbar sind, nutzlos und wir k\"onnen diese Variablen, sowie alle
+Regeln, in denen diese Variablen auftreten, weglassen, ohne dass sich dabei die Sprache \"andert.
 Damit haben wir jetzt ein Verfahren, um aus einer Grammatik alle nutzlosen Variablen zu entfernen.
 \begin{enumerate}
-\item Zunächst entfernen wir alle Variablen, die nicht erzeugend sind.
-\item Anschließend entfernen wir alle Variablen, die nicht erreichbar sind.
+\item Zun\"achst entfernen wir alle Variablen, die nicht erzeugend sind.
+\item Anschlie{\ss}end entfernen wir alle Variablen, die nicht erreichbar sind.
 \end{enumerate}
 Es ist wichtig zu verstehen, dass die Reihenfolge der obigen Regeln nicht umgedreht werden darf.
 Dazu betrachten wir die Grammatik  $G = \langle \{S, A, B, C\}, \{ \texttt{x}, \texttt{y} \}, R, S \rangle$, deren Regeln durch
@@ -178,7 +178,7 @@ $A \Rightarrow^* \texttt{x}$, \quad
 $S \Rightarrow^* \texttt{x}$  \quad und \quad
 $B \Rightarrow^* \texttt{y}$.
 \\[0.2cm]
-Damit sieht es zunächst so aus, als ob nur $C$ nutzlos ist.  Das stimmt aber nicht, auch die Variable
+Damit sieht es zun\"achst so aus, als ob nur $C$ nutzlos ist.  Das stimmt aber nicht, auch die Variable
 $B$ ist nutzlos, denn wenn wir die Variable $C$ aus der Grammatik entfernen, dann wird auch die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -188,10 +188,10 @@ entfernt und damit ist dann $B$ nicht mehr erreichbar und somit ebenfalls nutzlo
 \pagebreak
 
 \remark
-An dieser Stelle können wir uns fragen, warum es funktioniert, wenn wir erst alle Variablen 
-entfernen, die nicht erzeugend sind und anschließend dann die nicht erreichbaren Variablen entfernen.
+An dieser Stelle k\"onnen wir uns fragen, warum es funktioniert, wenn wir erst alle Variablen 
+entfernen, die nicht erzeugend sind und anschlie{\ss}end dann die nicht erreichbaren Variablen entfernen.
 Der Grund ist, dass eine Variable $B$, die nicht erreichbar ist, niemals von einer
-anderen Variablen $A$, die erreichbar ist, benötigt wird um ein Wort $w\in T*$ abzuleiten, denn
+anderen Variablen $A$, die erreichbar ist, ben\"otigt wird um ein Wort $w\in T*$ abzuleiten, denn
 wenn die Variable $B$ in der Ableitung
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -200,23 +200,23 @@ $A \Rightarrow^* w$
 auftritt, dann folgt aus der Erreichbarkeit von $A$ auch die Erreichbarkeit von $B$.
 Wenn also $A$ erreichbar ist und gleichzeitig erzeugend und wir andererseits $B$ als
 nicht erreichbar erkannt haben, dann kann $B$ getrost entfernt werden, denn das kann 
-an der Tatsache, dass $A$ erzeugend ist, nichts ändern.
+an der Tatsache, dass $A$ erzeugend ist, nichts \"andern.
 
 \subsection{Beseitigung von $\varepsilon$-Regeln}
-Ist $G_1$ eine Grammatik, so dass die Sprache $L(G_1)$ den leeren String nicht enthält, so
-können wir eine Grammatik $G_2$ finden, welche keine Regeln der Form
+Ist $G_1$ eine Grammatik, so dass die Sprache $L(G_1)$ den leeren String nicht enth\"alt, so
+k\"onnen wir eine Grammatik $G_2$ finden, welche keine Regeln der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $A \rightarrow \varepsilon$
 \\[0.2cm]
-enthält und welche dieselbe Sprache beschreibt wie die Grammatik $G_1$, es gilt also $L(G_1) = L(G_2)$. 
+enth\"alt und welche dieselbe Sprache beschreibt wie die Grammatik $G_1$, es gilt also $L(G_1) = L(G_2)$. 
 Regeln  der Form $A \rightarrow \varepsilon$ bezeichnen wir als $\varepsilon$-Regeln.  Bei
-bestimmten Algorithmen stören solche $\varepsilon$-Regeln, deswegen wollen wir jetzt ein Verfahren
-entwickeln, mit dem $\varepsilon$-Regeln eliminiert werden können.  
-Wir diskutieren das Verfahren zunächst an einem Beispiel.
+bestimmten Algorithmen st\"oren solche $\varepsilon$-Regeln, deswegen wollen wir jetzt ein Verfahren
+entwickeln, mit dem $\varepsilon$-Regeln eliminiert werden k\"onnen.  
+Wir diskutieren das Verfahren zun\"achst an einem Beispiel.
 
 \example
-Die Regeln der im Folgenden angegebenen Grammatik $G_1$ beschreiben arithmetische Ausdrücke,
+Die Regeln der im Folgenden angegebenen Grammatik $G_1$ beschreiben arithmetische Ausdr\"ucke,
 in denen Zahlen addiert oder subtrahiert werden.  Wir verwenden dabei die syntaktischen Variablen
 \textsl{Expr} und \textsl{ExprRest} sowie das Terminal \texttt{NUMBER}:
 \\[0.2cm]
@@ -259,19 +259,19 @@ bei denen die Variable $B$ genau einmal auf der rechten Seite der Regel auftritt
 \hspace*{1.3cm}
 $A \rightarrow \alpha \gamma$
 \\[0.2cm]
-hinzugefügt.  Haben wir eine Regel, bei der die Variable $B$ zweimal auf der rechten Seite auftritt, die
+hinzugef\"ugt.  Haben wir eine Regel, bei der die Variable $B$ zweimal auf der rechten Seite auftritt, die
 Regel hat dann also die Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $A \Rightarrow \alpha B \gamma B \delta$,
 \\[0.2cm]
-so fügen wir der Grammatik die folgenden drei Regeln hinzu:
+so f\"ugen wir der Grammatik die folgenden drei Regeln hinzu:
 \begin{enumerate}
 \item $A \Rightarrow \alpha B \gamma \delta$,
 \item $A \Rightarrow \alpha \gamma B \delta$,
 \item $A \Rightarrow \alpha \gamma \delta$.
 \end{enumerate}
-Im Allgemeinen gilt:  Enthält die rechte Seite einer Regel der Form
+Im Allgemeinen gilt:  Enth\"alt die rechte Seite einer Regel der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $A \Rightarrow \alpha_1 \uarr{p}{1}{B} \alpha_2 \uarr{p}{2}{B} \alpha_3 \cdots 
@@ -279,7 +279,7 @@ $A \Rightarrow \alpha_1 \uarr{p}{1}{B} \alpha_2 \uarr{p}{2}{B} \alpha_3 \cdots
 \\[0.2cm]
 die syntaktische Variable $B$ an $n$ verschiedenen Positionen $\{p_1, p_2, \cdots, p_n \}$, 
 so werden der Grammatik $2^n - 1$ 
-neue Regeln hinzugefügt.  Jede dieser Regeln entspricht einem Element der Menge
+neue Regeln hinzugef\"ugt.  Jede dieser Regeln entspricht einem Element der Menge
 \\[0.2cm]
 \hspace*{1.3cm}
 $P := \bigl\{ M \in 2^{\{p_1, \cdots, p_n\}} \mid M \not= \{\} \bigr\}$,
@@ -300,9 +300,9 @@ $A \Rightarrow \alpha_1 \alpha_2 \alpha_3  \uarr{p}{3}{B}
 \\[0.2cm]
 denn die Auftreten der Variablen $B$ an den Positionen $p_1$, $p_2$ und $p_4$ werden entfernt.
 Da die Menge $P$ genau ein Element weniger als die Potenz-Menge $2^{\{p_1, \cdots, p_n\}}$ hat,
-erhalten wir insgesamt $2^{n}-1$ neue Regeln, die Anzahl der Regeln wächst folglich exponentiell
-an. Das Verfahren ist daher nicht von praktischem Interesse.  Wir benötigen es lediglich zum späteren
-Nachweis  der Tatsache, dass für alle kontextfreien Sprachen, die das leere Wort nicht enthalten,
+erhalten wir insgesamt $2^{n}-1$ neue Regeln, die Anzahl der Regeln w\"achst folglich exponentiell
+an. Das Verfahren ist daher nicht von praktischem Interesse.  Wir ben\"otigen es lediglich zum sp\"ateren
+Nachweis  der Tatsache, dass f\"ur alle kontextfreien Sprachen, die das leere Wort nicht enthalten,
 eine Grammatik in \emph{verallgemeinerter Chomsky-Normalform} angegeben werden kann.
 
 
@@ -312,14 +312,14 @@ Regeln der Form
 \hspace*{1.3cm}
 $A \rightarrow B$,
 \\[0.2cm]
-bei der die rechte Seite nur aus einer einzigen Variablen besteht, heißen \emph{Unit-Regeln}.
-Diese Unit-Regeln können wie folgt eliminiert werden:  Sind alle Regeln, bei denen die
+bei der die rechte Seite nur aus einer einzigen Variablen besteht, hei{\ss}en \emph{Unit-Regeln}.
+Diese Unit-Regeln k\"onnen wie folgt eliminiert werden:  Sind alle Regeln, bei denen die
 Variable $B$ auf der linken Seite steht, durch
 \\[0.2cm]
 \hspace*{1.3cm}
 $B \rightarrow \beta_1 \mid \cdots \mid \beta_n$ 
 \\[0.2cm]
-gegeben, so können wir die Regel $A \rightarrow B$ durch die Regeln
+gegeben, so k\"onnen wir die Regel $A \rightarrow B$ durch die Regeln
 \\[0.2cm]
 \hspace*{1.3cm}
 $A \rightarrow \beta_1 \mid \cdots \mid \beta_n$ 
@@ -327,7 +327,7 @@ $A \rightarrow \beta_1 \mid \cdots \mid \beta_n$
 ersetzen und erhalten dabei eine Grammatik, die dieselbe Sprache beschreibt.
 
 \example
-Wir betrachten die folgende Grammatik für arithmetische Ausdrücke.
+Wir betrachten die folgende Grammatik f\"ur arithmetische Ausdr\"ucke.
 \begin{eqnarray*}
   \textsl{Expr}      & \rightarrow & \textsl{Expr} \quoted{+} \textsl{Product}  \\
                      & \mid        & \textsl{Product}                                \\[0.1cm]
@@ -336,14 +336,14 @@ Wir betrachten die folgende Grammatik für arithmetische Ausdrücke.
   \textsl{Factor}    & \rightarrow & \quoted{(} \textsl{Expr} \quoted{)}        \\
                      & \mid        & \texttt{NUMBER} 
 \end{eqnarray*}
-Diese Grammatik enthält die folgenden beiden Unit-Regeln:
+Diese Grammatik enth\"alt die folgenden beiden Unit-Regeln:
 \begin{eqnarray*}
   \textsl{Expr}    & \rightarrow & \textsl{Product}                                \\
   \textsl{Product} & \rightarrow & \textsl{Factor}                                 
 \end{eqnarray*}
 Die Regel $\textsl{Factor} \rightarrow \texttt{NUMBER}$ ist keine Unit-Regeln, denn
 \texttt{NUMBER} ist ein Terminal und keine syntaktische Variable.
-Wir eliminieren zunächst die Unit-Regel $\textsl{Expr} \rightarrow \textsl{Product}$.  
+Wir eliminieren zun\"achst die Unit-Regel $\textsl{Expr} \rightarrow \textsl{Product}$.  
 Wir erhalten dann die folgende
 Grammatik: 
 \begin{eqnarray*}
@@ -383,8 +383,8 @@ Eliminieren wir nun die Unit-Regel $\textsl{Product} \rightarrow \textsl{Factor}
   \textsl{Factor}    & \rightarrow & \quoted{(} \textsl{Expr} \quoted{)}        \\
                      & \mid        & \texttt{NUMBER} 
 \end{eqnarray*}
-Wie man sieht, wächst die Grammatik durch die Eliminierung von Unit-Regeln stark an.
-Das oben skiziierte Verfahren kann sehr mühsam sein, wenn es einen \emph{Zyklus} von
+Wie man sieht, w\"achst die Grammatik durch die Eliminierung von Unit-Regeln stark an.
+Das oben skiziierte Verfahren kann sehr m\"uhsam sein, wenn es einen \emph{Zyklus} von
 Unit-Regeln gibt, wie das bei den folgenden Grammatik-Regeln der Fall
 ist:
 \begin{eqnarray*}
@@ -410,7 +410,7 @@ Eliminieren wir jetzt die Regel $C \rightarrow A$, so erhalten wir:
   B & \rightarrow & \texttt{y} \mid \texttt{z} \mid A \\[0.1cm]
   C & \rightarrow & \texttt{z} \mid \texttt{x} \mid \texttt{y} \mid C
 \end{eqnarray*}
-Hier können wir die Regel $C \rightarrow C$ ersatzlos streichen und anschließend die 
+Hier k\"onnen wir die Regel $C \rightarrow C$ ersatzlos streichen und anschlie{\ss}end die 
 Unit-Regel $A \rightarrow C$ eliminieren.  Das liefert:
 \begin{eqnarray*}
   A & \rightarrow & \texttt{x} \mid \texttt{y} \mid \texttt{z}  \\[0.1cm]
@@ -429,49 +429,49 @@ $B$ und $C$ durch die Beseitigung der Unit-Regeln nutzlos geworden sind.
 
 \begin{Definition}[Verallgemeinerte Chomsky-Normalform]
 Eine Grammatik $G$ ist in \emph{verallgemeinerter Chomsky-Normalform} (vCNF) falls folgende
-Bedingungen erfüllt sind:
+Bedingungen erf\"ullt sind:
 \begin{enumerate}
-\item $G$ enthält keine Unit-Regeln,
-\item $G$ enthält keine $\varepsilon$-Produktionen enthält und
-\item $G$ enthält keine nutzlosen Symbole. \qed  
+\item $G$ enth\"alt keine Unit-Regeln,
+\item $G$ enth\"alt keine $\varepsilon$-Produktionen enth\"alt und
+\item $G$ enth\"alt keine nutzlosen Symbole. \qed  
 \end{enumerate}
 \end{Definition}
 
 \noindent
-Mit Hilfe der in diesem Abschnitt vorgeführten Verfahren lässt sich jede Grammatik $G$, deren Sprache
- $L(G)$ das leere Wort $\varepsilon$ nicht enthält,  zu einer äquivalenten
+Mit Hilfe der in diesem Abschnitt vorgef\"uhrten Verfahren l\"asst sich jede Grammatik $G$, deren Sprache
+ $L(G)$ das leere Wort $\varepsilon$ nicht enth\"alt,  zu einer \"aquivalenten
 Grammatik umschreiben, die in verallgemeinerter Chomsky-Normalform ist.
-Dazu führen wir die folgenden Schritte in nachstehender Reihenfolge durch:
+Dazu f\"uhren wir die folgenden Schritte in nachstehender Reihenfolge durch:
 \begin{enumerate}
 \item Wir eliminieren die $\varepsilon$-Regeln.
 \item Danach entfernen wir die Unit-Regeln.
-\item Schließlich beseitigen wir die nutzlosen Symbole.
+\item Schlie{\ss}lich beseitigen wir die nutzlosen Symbole.
 \end{enumerate}
 Die dabei entstehende Grammatik hat dann offenbar die verallgemeinerte Chomsky-Normalform, denn bei der
-Beseitigung von Unit-Regeln werden keine $\varepsilon$-Regeln neu eingeführt und durch die Beseitigung
+Beseitigung von Unit-Regeln werden keine $\varepsilon$-Regeln neu eingef\"uhrt und durch die Beseitigung
 von nutzlosen Symbolen entstehen weder $\varepsilon$-Regeln noch Unit-Regeln.
 
-Wird das Verfahren auf eine Grammatik $G$ angewendet, für die $\varepsilon \in L(G)$ gilt,
-so gilt für die Sprache, die von der resultierenden Grammatik $G'$ erzeugt wird, die Gleichung
+Wird das Verfahren auf eine Grammatik $G$ angewendet, f\"ur die $\varepsilon \in L(G)$ gilt,
+so gilt f\"ur die Sprache, die von der resultierenden Grammatik $G'$ erzeugt wird, die Gleichung
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(G') = L(G) \backslash \{\varepsilon\}$,
 \\[0.2cm]
-die Sprache ändert sich also nur insofern, dass das leere Wort aus der Sprache entfernt wird.
+die Sprache \"andert sich also nur insofern, dass das leere Wort aus der Sprache entfernt wird.
 
-\section{Parse-Bäume als Listen}
-Zum Beweis des Pumping-Lemmas für kontextfreie Sprachen benötigen wir eine
-Abschätzung, bei der wir die Länge eines Wortes $w$ aus einer kontextfreien Sprachen $L(G)$ 
-mit der Höhe des Parse-Baums für $W$ in Verbindung bringen.  Es zeigt sich, dass es zum Nachweis dieser
-Abschätzung hilfreich ist, wenn wir einen Parse-Baum als Liste aller Pfade des Parse-Baums auffassen.
+\section{Parse-B\"aume als Listen}
+Zum Beweis des Pumping-Lemmas f\"ur kontextfreie Sprachen ben\"otigen wir eine
+Absch\"atzung, bei der wir die L\"ange eines Wortes $w$ aus einer kontextfreien Sprachen $L(G)$ 
+mit der H\"ohe des Parse-Baums f\"ur $W$ in Verbindung bringen.  Es zeigt sich, dass es zum Nachweis dieser
+Absch\"atzung hilfreich ist, wenn wir einen Parse-Baum als Liste aller Pfade des Parse-Baums auffassen.
 Die Idee wird am ehesten anhand eines Beispiels klar.  Abbildung \ref{fig:parse-tree.dot2}
-zeigt einen Parse-Baum für den String ``\texttt{2*3+4}''. 
+zeigt einen Parse-Baum f\"ur den String ``\texttt{2*3+4}''. 
 
 
 \begin{figure}[!ht]
   \centering
       \epsfig{file=Abbildungen/parse-tree.eps, scale=0.6}
-  \caption{Ein Parse-Baum für den String ``\texttt{2*3+4}''.}
+  \caption{Ein Parse-Baum f\"ur den String ``\texttt{2*3+4}''.}
   \label{fig:parse-tree.dot2}
 \end{figure}
 
@@ -502,15 +502,15 @@ Ist $G = \langle V, T, R, S \rangle$ eine Grammatik, ist $w \in T^*$, $A \in V$ 
 \[ A \Rightarrow^* w,  \]
 so definieren wir $\textsl{parseTree}(A \Rightarrow^* w)$ induktiv:
 \begin{enumerate}
-\item Falls $(A \rightarrow t_1t_2 \cdots t_m)\in R$ mit $A \in V$ und $t_i \in T$ für alle
+\item Falls $(A \rightarrow t_1t_2 \cdots t_m)\in R$ mit $A \in V$ und $t_i \in T$ f\"ur alle
       $i=1,\cdots,m$, so setzen wir
       \[ \textsl{parseTree}(A \Rightarrow^*t) = \bigl[\, [A, t_1],\,  [A, t_2],\,\cdots,\,  [A, t_m]\, \bigr].  \]
 \item Falls  $A \Rightarrow^* w$ gilt, weil
       \[ (A \rightarrow B_1B_2 \cdots B_m) \in R, \quad 
-         B_i \Rightarrow^* w_i\; \mbox{für alle $i=1,\cdots,m$}, \quad
+         B_i \Rightarrow^* w_i\; \mbox{f\"ur alle $i=1,\cdots,m$}, \quad
          \mbox{mit} \; w = w_1w_2 \cdots w_m
       \]
-      gilt, so definieren wir (unter Benutzung der \textsc{Setl}-Notation für die Definition von Listen)
+      gilt, so definieren wir (unter Benutzung der \textsc{Setl}-Notation f\"ur die Definition von Listen)
       \[ 
         \textsl{parseTree}(A \Rightarrow^*w)  =
         \bigl[\; [A] + l \,:\,
@@ -518,7 +518,7 @@ so definieren wir $\textsl{parseTree}(A \Rightarrow^* w)$ induktiv:
         \bigr]. 
       \]
 
-      Damit diese Definition auch tatsächlich alle Fälle abdeckt, müssen wir noch den Fall
+      Damit diese Definition auch tats\"achlich alle F\"alle abdeckt, m\"ussen wir noch den Fall
       diskutieren, dass  eines der Symbole $B_i$ ein Terminal ist: In diesem Fall setzen wir
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -526,7 +526,7 @@ so definieren wir $\textsl{parseTree}(A \Rightarrow^* w)$ induktiv:
 \end{enumerate}
 \end{Definition}
 
-Wir definieren die \emph{Breite} $b$ einer Grammatik als die größte Anzahl von Symbolen, die 
+Wir definieren die \emph{Breite} $b$ einer Grammatik als die gr\"o{\ss}te Anzahl von Symbolen, die 
 auf der rechten Seite einer Grammatik-Regel der Form
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -534,8 +534,8 @@ $A \rightarrow \alpha$
 \\[0.2cm]
 auftreten, bei der $\alpha$ kein einzelnes Terminal ist.  Mit dieser Definition ist klar, dass die Breite
 einer nicht-trivialen Grammatik in verallgemeinerter Chomsky-Normalform mindestens den Wert zwei hat,
-denn eine solche Grammatik enthält ja weder $\varepsilon$-Regeln noch Unit-Regeln.  Falls die Grammatik
-also eine Regel enthält, auf deren rechten Seite eine Variable auftritt, dann muss die rechte Seite
+denn eine solche Grammatik enth\"alt ja weder $\varepsilon$-Regeln noch Unit-Regeln.  Falls die Grammatik
+also eine Regel enth\"alt, auf deren rechten Seite eine Variable auftritt, dann muss die rechte Seite
 dieser Regel mindestens zwei verschiedene Zeichen enthalten.
 
 
@@ -545,22 +545,22 @@ dieser Regel mindestens zwei verschiedene Zeichen enthalten.
   \hspace*{1.3cm}
   $A \Rightarrow^* w$
   \\[0.2cm]
-  für eine syntaktische Variable $A \in V$ und ein Wort $w \in T^*$.  Falls $n$ die Länge der längsten Liste in
+  f\"ur eine syntaktische Variable $A \in V$ und ein Wort $w \in T^*$.  Falls $n$ die L\"ange der l\"angsten Liste in
   \[ \textsl{parseTree}(A \Rightarrow^* w) \]
-  ist, so gilt für die Länge des Wortes $w$ die Abschätzung
+  ist, so gilt f\"ur die L\"ange des Wortes $w$ die Absch\"atzung
   \\[0.2cm]
   \hspace*{1.3cm}
   $|w| \leq b^{n}$.  
 \end{Lemma}
 
 \noindent
-\textbf{Beweis}: Wir führen den Beweis durch Induktion nach  $n$.
+\textbf{Beweis}: Wir f\"uhren den Beweis durch Induktion nach  $n$.
 \begin{enumerate}
 \item[I.A.] $n=2$:  Dann besteht die Ableitung nur aus einem Schritt und daher muss es eine Regel der Form
             \\
             \hspace*{1.3cm}
             $A \rightarrow t_1t_2 \cdots t_m$ \quad mit $w = t_1t_2 \cdots t_m$ und $t_i \in T$
-            für alle $i=1,\cdots,m$
+            f\"ur alle $i=1,\cdots,m$
             \\[0.2cm]
             in der Grammatik $G$ geben.  Es gilt dann
             \[ \textsl{parseTree}(A \Rightarrow^* w) = 
@@ -571,21 +571,21 @@ dieser Regel mindestens zwei verschiedene Zeichen enthalten.
             \hspace*{1.3cm}
             $|w| = |t_1t_2 \cdots t_m| = m \leq b \leq b^{2}$,
             \\[0.2cm]
-            wobei die Ungleichung $m \leq b$ aus der Tatsache folgt, dass Länge der Regeln der Grammatik
-            $G$ durch die Breite $b$ beschränkt ist.
+            wobei die Ungleichung $m \leq b$ aus der Tatsache folgt, dass L\"ange der Regeln der Grammatik
+            $G$ durch die Breite $b$ beschr\"ankt ist.
 \item[I.S.] $n \mapsto n+1$: Da die Ableitung nun aus mehr als einem Schritt besteht, hat die Ableitung die Form
             \\[0.2cm]
             \hspace*{1.3cm}
             $A \Rightarrow B_1 B_2 \cdots B_m \Rightarrow^* w_1 w_2 \cdots w_m = w$.
             \\[0.2cm]
-            Außerdem haben dann die Listen in
+            Au{\ss}erdem haben dann die Listen in
             \[ \textsl{parseTree}(B_i \Rightarrow^* w_i) 
             \]
-            für alle $i=1,\cdots,m$ höchstens die Länge $n$.
+            f\"ur alle $i=1,\cdots,m$ h\"ochstens die L\"ange $n$.
             Nach Induktions-Voraussetzung wissen wir also, dass
             \\[0.2cm]
             \hspace*{1.3cm}
-            $|w_i| \leq b^{n}$ \quad für alle $i=1,\cdots,m$
+            $|w_i| \leq b^{n}$ \quad f\"ur alle $i=1,\cdots,m$
             \\[0.2cm]
             gilt.  Daher haben wir
             \\[0.2cm]
@@ -594,50 +594,50 @@ dieser Regel mindestens zwei verschiedene Zeichen enthalten.
              m \cdot b^n \leq b \cdot b^n \leq b^{n+1}$. \qed
 \end{enumerate}
 
-\section{Das Pumping-Lemma für kontextfreie Sprachen}
+\section{Das Pumping-Lemma f\"ur kontextfreie Sprachen}
 \begin{Satz}[Pumping-Lemma]
 Es sei $L$ eine kontextfreie Sprache.  Dann gibt es ein $n \in \mathbb{N}$, so dass jeder String
-$s \in L$, dessen Länge größer oder gleich $n$ ist, in der Form 
+$s \in L$, dessen L\"ange gr\"o{\ss}er oder gleich $n$ ist, in der Form 
 \[ s = uvwxy \]
-geschrieben werden kann, so dass außerdem folgendes gilt:
+geschrieben werden kann, so dass au{\ss}erdem folgendes gilt:
 \begin{enumerate}
 \item $|vwx| \leq n$,
 
-      der mittlere Teil des Strings hat also eine Länge von höchstens $n$ Buchstaben.
+      der mittlere Teil des Strings hat also eine L\"ange von h\"ochstens $n$ Buchstaben.
 \item $vx \not= \varepsilon$,
 
-      die Teilstrings $v$ und $x$ können also nicht beide gleichzeitig leer sein.
+      die Teilstrings $v$ und $x$ k\"onnen also nicht beide gleichzeitig leer sein.
 \item $\forall h \in \mathbb{N}: uv^hwx^hy \in L$.
 
-      Dieser Bedingung  verdankt das Pumping-Lemma seinen Namen, denn die Strings $v$ und $x$ können
+      Dieser Bedingung  verdankt das Pumping-Lemma seinen Namen, denn die Strings $v$ und $x$ k\"onnen
       beliebig oft \emph{gepumpt} werden. \qed
 \end{enumerate}
 \end{Satz}
 
 \noindent
-\textbf{Beweis}: Wir zeigen den Satz zunächst für den Fall, dass die Sprache
-$L$ das leere Wort nicht enthält.  Dazu konstruieren wir mit dem im letzten Abschnitt gezeigten
+\textbf{Beweis}: Wir zeigen den Satz zun\"achst f\"ur den Fall, dass die Sprache
+$L$ das leere Wort nicht enth\"alt.  Dazu konstruieren wir mit dem im letzten Abschnitt gezeigten
 Verfahren eine Grammatik $G = \langle V, T, R, S \rangle$ in verallgemeinerter Chomsky-Normalform, so dass
 \[ L = L(G) \]
-gilt. Wir nehmen an, dass die Grammatik $G$ insgesamt $k$ syntaktische Variablen enthält und außerdem die
+gilt. Wir nehmen an, dass die Grammatik $G$ insgesamt $k$ syntaktische Variablen enth\"alt und au{\ss}erdem die
 Breite $b$ hat.  Wir definieren
 \[ n := b^{k+2}. \]
 Sei nun $s \in L$ mit $|s| \geq n$.  Wir betrachten die Listen aus
 \[ \textsl{parseTree}(S \Rightarrow^* s). \]
-Falls alle Listen hier eine Länge kleiner-gleich $k+1$ hätten, so würde aus Lemma
+Falls alle Listen hier eine L\"ange kleiner-gleich $k+1$ h\"atten, so w\"urde aus Lemma
 \ref{lemma:length} folgen, dass  
 \[ |s| \leq b^{k+1} < n \]
 gilt, im Widerspruch zu der Voraussetzung $|s| \geq n$.  Also muss es in 
-$\textsl{parseTree}(S \Rightarrow^* s)$ eine Liste geben, die mindestens die Länge $k + 2$
-hat.  Wir wählen die längste Liste unter dieser Listen aus.
+$\textsl{parseTree}(S \Rightarrow^* s)$ eine Liste geben, die mindestens die L\"ange $k + 2$
+hat.  Wir w\"ahlen die l\"angste Liste unter dieser Listen aus.
 Diese Liste hat dann die Form
-\[ [A_1, \cdots, A_l, t] \quad \mbox{mit $A_i \in V$ für alle $i \in \{1,\cdots,l\}$},\quad t \in T,
+\[ [A_1, \cdots, A_l, t] \quad \mbox{mit $A_i \in V$ f\"ur alle $i \in \{1,\cdots,l\}$},\quad t \in T,
    \quad \mbox{sowie $l \geq k+1$}.
  \]
-Wegen $l \geq k + 1$  können nicht alle Variablen $A_1$, $\cdots$, $A_l$
+Wegen $l \geq k + 1$  k\"onnen nicht alle Variablen $A_1$, $\cdots$, $A_l$
 voneinander verschieden sein, denn es gibt ja nur insgesamt $k$ verschiedene syntaktische
 Variablen.   Wir finden daher in der Menge $\{ l, l-1, \cdots, l-k \}$
-zwei Indices $i,j$ mit $i \not=j$ und $A_i = A_j =: A$.  Ohne Beschränkung der Allgemeinheit gelte
+zwei Indices $i,j$ mit $i \not=j$ und $A_i = A_j =: A$.  Ohne Beschr\"ankung der Allgemeinheit gelte
 $i < j$.   Die Ableitung von $s$ hat dann die folgende Form
 \[ S \Rightarrow^* u A_i y \Rightarrow^* u v A_j x y \Rightarrow^* u v w x y = s. \] 
 Insbesondere gilt also
@@ -651,51 +651,51 @@ Damit haben wir dann aber folgendes:
 \item $S \Rightarrow^* uAy \Rightarrow^* uvAxy \Rightarrow^* uv^2Ax^2y \Rightarrow^* uv^3Ax^3y
        \Rightarrow^* \cdots \Rightarrow^* uv^kAx^ky \Rightarrow^* uv^kwx^ky$.
 \end{enumerate}
-Wir müssen jetzt noch zeigen, dass $vx \not= \varepsilon$ gilt.  Die Ableitung
+Wir m\"ussen jetzt noch zeigen, dass $vx \not= \varepsilon$ gilt.  Die Ableitung
 \[ A \Rightarrow^* vAx \]
 ist eigentlich die Ableitung
 \[ A_i \Rightarrow^* vA_jx \]
-und enthält daher mindestens einen Ableitungsschritt.
-Wir führen den Nachweis der Behauptung $vx \not= \varepsilon$ indirekt und nehmen $v = x =
+und enth\"alt daher mindestens einen Ableitungsschritt.
+Wir f\"uhren den Nachweis der Behauptung $vx \not= \varepsilon$ indirekt und nehmen $v = x =
 \varepsilon$ an.
-Dann würde wegen $A_i = A_j$ also
+Dann w\"urde wegen $A_i = A_j$ also
 \\[0.2cm]
 \hspace*{1.3cm}
 $A_i \Rightarrow^+ A_i$
 \\[0.2cm]
 gelten. 
-Da die Grammatik $G$ nach Voraussetzung keine Unit-Regeln enthält, hat der erste 
+Da die Grammatik $G$ nach Voraussetzung keine Unit-Regeln enth\"alt, hat der erste 
 Schritt dieser Ableitung dann die Form
 \[ A \Rightarrow B_1 B_2 \cdots B_m \Rightarrow^* A \quad \mbox{mit $m \geq 2$}. \] 
-Dann muss aber für wenigstens ein $o \in \{1, \cdots, m\}$
+Dann muss aber f\"ur wenigstens ein $o \in \{1, \cdots, m\}$
 \[ B_o \Rightarrow^* \varepsilon  \]
 gelten und das geht nicht, da eine Grammatik in Chomsky-Normalform keine $\varepsilon$-Regeln
-enthält.  Also ist die Annahme $vx = \varepsilon$ widerlegt.
+enth\"alt.  Also ist die Annahme $vx = \varepsilon$ widerlegt.
 
-Als nächstes zeigen wir, dass die Ungleichung $|vwx| \leq n$ gilt.  Wir haben
+Als n\"achstes zeigen wir, dass die Ungleichung $|vwx| \leq n$ gilt.  Wir haben
 \[ A = A_i \Rightarrow^* vA_jx \Rightarrow^* vwx. \]
 Weil einerseits $i \in \{l-k, l-(k-1), \cdots,l \}$ gilt und andererseits die der
 Ableitung
 $A \Rightarrow^* vwx$ zugeordnete Liste aus $\textsl{parseTree}(S \Rightarrow^* w)$ von
-maximaler Länge war, wissen wir, 
-dass die Länge der längsten Liste in 
+maximaler L\"ange war, wissen wir, 
+dass die L\"ange der l\"angsten Liste in 
 \[ \textsl{parseTree}(A \Rightarrow^* vwx) \]
 kleiner-gleich  $k+2$ ist.
   Nach dem Lemma
-\ref{lemma:length} folgt damit für die Länge von $vwx$ die Abschätzung
+\ref{lemma:length} folgt damit f\"ur die L\"ange von $vwx$ die Absch\"atzung
 \[ |vwx| \leq b^{k+2} = n. \]
 
-Zum Schluss müssen wir noch festlegen, was in dem Fall zu tun ist, wenn $\varepsilon \in L$ ist.  
-Überführen wir dann die Grammatik $G$ in verallgemeinerte Chomsky-Normalform, so erhalten wir eine
-Grammatik $G'$, für die
+Zum Schluss m\"ussen wir noch festlegen, was in dem Fall zu tun ist, wenn $\varepsilon \in L$ ist.  
+\"Uberf\"uhren wir dann die Grammatik $G$ in verallgemeinerte Chomsky-Normalform, so erhalten wir eine
+Grammatik $G'$, f\"ur die
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(G') = L(G) \backslash \{\varepsilon\}$
 \\[0.2cm]
-gilt.  Für die Sprache $L(G')$ gilt das Pumping-Lemma.  Im Beweis oben haben wir $n = b^{k+2}$
-definiert. Damit gilt sicher $n > 0$.  Damit gilt das Pumping-Lemma auch für das leere Wort, denn
-für das leere Wort $s = \varepsilon$ ist die Voraussetzung $|s| \geq n$
-nicht erfüllt, so dass die Behauptung des  Pumping-Lemmas für das leere Wort trivialerweise gilt.
+gilt.  F\"ur die Sprache $L(G')$ gilt das Pumping-Lemma.  Im Beweis oben haben wir $n = b^{k+2}$
+definiert. Damit gilt sicher $n > 0$.  Damit gilt das Pumping-Lemma auch f\"ur das leere Wort, denn
+f\"ur das leere Wort $s = \varepsilon$ ist die Voraussetzung $|s| \geq n$
+nicht erf\"ullt, so dass die Behauptung des  Pumping-Lemmas f\"ur das leere Wort trivialerweise gilt.
 \qed
 \vspace*{0.2cm}
 
@@ -711,26 +711,26 @@ bestimmte Sprachen nicht kontextfrei sind.
 nicht kontextfrei}
 Wir weisen nun nach, dass die Sprache
 \[ L = \{ \mathtt{a}^k \mathtt{b}^k \mathtt{c}^k \mid k \in \mathbb{N} \} \]
-nicht kontextfrei ist.  Wir führen diesen Nachweis indirekt und nehmen zunächst an, dass $L$
-kontextfrei ist.  Nach dem Pumping-Lemma gibt es dann eine natürliche Zahl $n$, so dass jeder String
-$s \in L$, dessen Länge größer oder gleich $n$ ist, sich in Teilstrings der Form
+nicht kontextfrei ist.  Wir f\"uhren diesen Nachweis indirekt und nehmen zun\"achst an, dass $L$
+kontextfrei ist.  Nach dem Pumping-Lemma gibt es dann eine nat\"urliche Zahl $n$, so dass jeder String
+$s \in L$, dessen L\"ange gr\"o{\ss}er oder gleich $n$ ist, sich in Teilstrings der Form
 \[ s = uvwxy \]
-zerlegen lässt, so dass außerdem folgendes gilt:
+zerlegen l\"asst, so dass au{\ss}erdem folgendes gilt:
 \begin{enumerate}
 \item $|vwx| \leq n$,
 \item $vx \not= \varepsilon$,
 \item $\forall i \in \mathbb{N}: uv^iwx^iy \in L$.
 
-      Insbesondere können wir hier $i=0$ wählen und erhalten dann
+      Insbesondere k\"onnen wir hier $i=0$ w\"ahlen und erhalten dann
       $uwy \in L$. 
 \end{enumerate}
 Wir definieren nun den String $s$ wie folgt:
 \[ s := \mathtt{a}^n\mathtt{b}^n\mathtt{c}^n. \]
-Dieser String hat die Länge $3 \cdot n \geq n$ und erfüllt damit die Voraussetzung über die Länge.
+Dieser String hat die L\"ange $3 \cdot n \geq n$ und erf\"ullt damit die Voraussetzung \"uber die L\"ange.
 Damit finden wir also eine Zerlegung $s=uvwxy$ mit den obigen Eigenschaften.  Da der Teilstring
-$vwx$ eine Länge kleiner oder gleich $n$ hat, können in diesem String nicht gleichzeitig die
+$vwx$ eine L\"ange kleiner oder gleich $n$ hat, k\"onnen in diesem String nicht gleichzeitig die
 Buchstaben \qote{a} und \qote{c} vorkommen. Wir betrachten die nach dieser Erkenntnis noch
-möglichen  Fälle getrennt.
+m\"oglichen  F\"alle getrennt.
 \begin{enumerate}
 \item Fall: In dem String $vwx$ kommen nur die Buchstaben \qote{a} und \qote{b} vor,  der Buchstabe
       \qote{c} kommt nicht vor: 
@@ -743,7 +743,7 @@ möglichen  Fälle getrennt.
       \hspace*{1.3cm}
       $\textsl{count}(vx,\mathtt{a}) + \textsl{count}(vx,\mathtt{b}) > 0$.
       \\[0.2cm]
-      Wir nehmen zunächst an, dass $\textsl{count}(vx,\mathtt{a}) > 0$ gilt,
+      Wir nehmen zun\"achst an, dass $\textsl{count}(vx,\mathtt{a}) > 0$ gilt,
       der Fall $\textsl{count}(vx,\mathtt{b}) > 0$ ist analog zu behandeln.
       Dann erhalten wir einerseits
       \[ 
@@ -754,7 +754,7 @@ möglichen  Fälle getrennt.
                               & = & n.
       \end{array}
       \]
-      Zählen wir nun die Häufigkeit, mit welcher der Buchstabe \qote{a}
+      Z\"ahlen wir nun die H\"aufigkeit, mit welcher der Buchstabe \qote{a}
       in dem String $uwy$ auftritt, so erhalten wir
       \[ 
       \begin{array}[t]{lcl}
@@ -773,7 +773,7 @@ möglichen  Fälle getrennt.
       und daraus folgt $uwy \not\in L$, was im Widerspruch zum Pumping-Lemma steht.
 \item Fall: In dem String $vwx$ kommt der Buchstabe \qote{a} nicht vor.
    
-      Dieser Fall lässt sich analog zum ersten Fall behandeln. \qed
+      Dieser Fall l\"asst sich analog zum ersten Fall behandeln. \qed
 \end{enumerate}
 
 \exercise
@@ -783,7 +783,7 @@ nicht kontextfrei ist.
 \vspace*{0.2cm}
 
 \noindent
-\textbf{Hinweis}: Argumentieren Sie über die Länge der betrachteten Strings.
+\textbf{Hinweis}: Argumentieren Sie \"uber die L\"ange der betrachteten Strings.
 
 %%% Local Variables: 
 %%% mode: latex

--- a/Lecture-Notes/grenzen-kontextfrei.tex
+++ b/Lecture-Notes/grenzen-kontextfrei.tex
@@ -1,37 +1,37 @@
 \chapter{Grenzen kontextfreier Sprachen} 
 In diesem Kapitel diskutieren wir die Grenzen kontextfreier Sprachen und leiten dazu das
-sogenannte ``\emph{große Pumping-Lemma}'' her, mit dessen Hilfe wir beispielsweise zeigen
-können, dass die Sprache $L_{\mbox{\scriptsize \textsl{square}}}$, die durch
+sogenannte ``\emph{gro{\ss}e Pumping-Lemma}'' her, mit dessen Hilfe wir beispielsweise zeigen
+k\"onnen, dass die Sprache $L_{\mbox{\scriptsize \textsl{square}}}$, die durch
 \\[0.2cm]
 \hspace*{1.3cm} $L_{\mbox{\scriptsize \textsl{square}}} = \bigl\{ ww \mid w \in \Sigma^*\bigr\}$
 \\[0.2cm]
-definiert wird, für das Alphabet $\Sigma =\{\texttt{a}, \texttt{b}\}$ keine kontextfreie Sprache
-ist.  Bevor wir das Pumping-Lemma für kontextfreie Sprachen beweisen, zeigen wir, wie sich nutzlose
+definiert wird, f\"ur das Alphabet $\Sigma =\{\texttt{a}, \texttt{b}\}$ keine kontextfreie Sprache
+ist.  Bevor wir das Pumping-Lemma f\"ur kontextfreie Sprachen beweisen, zeigen wir, wie sich nutzlose
 Symbole aus einer Grammatik entfernen lassen. 
 
 \section{Beseitigung nutzloser Symbole$^*$}
 In diesem Abschnitt zeigen wir, wie wir nutzlose Symbole aus einer kontextfreien Grammatik entfernen
-können. Ist $G = \langle V, T, R, S \rangle$ eine kontextfreie Grammatik, so nennen wir
-eine syntaktische Variable $A \in V$ \emph{nützlich}, wenn es Strings $w \in T^*$ und
+k\"onnen. Ist $G = \langle V, T, R, S \rangle$ eine kontextfreie Grammatik, so nennen wir
+eine syntaktische Variable $A \in V$ \emph{n\"utzlich}, wenn es Strings $w \in T^*$ und
 $\alpha,\beta \in (V \cup T)^*$ gibt, so dass  
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \Rightarrow^* \alpha A \beta \Rightarrow^* w$
 \\[0.2cm]
-gilt.  Eine syntaktische Variable ist also genau dann nützlich, wenn diese Variable in der Herleitung
-eines Wortes $w \in L(G)$ verwendet werden kann.  Analog heißt
-ein Terminal $t \in T$ \emph{nützlich}, wenn es Wörter $w_1, w_2 \in T^*$ gibt, so dass
+gilt.  Eine syntaktische Variable ist also genau dann n\"utzlich, wenn diese Variable in der Herleitung
+eines Wortes $w \in L(G)$ verwendet werden kann.  Analog hei{\ss}t
+ein Terminal $t \in T$ \emph{n\"utzlich}, wenn es W\"orter $w_1, w_2 \in T^*$ gibt, so dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \Rightarrow^* w_1 t w_2$
 \\[0.2cm]
-gilt.  Ein Terminal $t$ ist also genau dann nützlich, wenn es in einem Wort  $w \in L(G)$
-auftritt.  Variablen und Terminale, die nicht nützlich sind, bezeichnen wir als
+gilt.  Ein Terminal $t$ ist also genau dann n\"utzlich, wenn es in einem Wort  $w \in L(G)$
+auftritt.  Variablen und Terminale, die nicht n\"utzlich sind, bezeichnen wir als
 \emph{nutzlose Symbole}.
 
-Die Erkennung nutzloser Symbole ist eine Überprüfung, die in manchen Parser-Generatoren
+Die Erkennung nutzloser Symbole ist eine \"Uberpr\"ufung, die in manchen Parser-Generatoren
 (beispielsweise in \textsl{Bison}\footnote{
-\textsl{Bison} ist ein Parser-Generator für die Sprache \texttt{C}.}) 
+\textsl{Bison} ist ein Parser-Generator f\"ur die Sprache \texttt{C}.}) 
 eingebaut ist, weil das Auftreten nutzloser Symbole oft
 einen Hinweis darauf gibt, dass die Grammatik nicht die Sprache beschreibt, die intendiert ist.  
 Insofern ist die jetzt vorgestellte Technik auch von praktischem Interesse.
@@ -44,8 +44,8 @@ ist eine \emph{erzeugende} Variable, wenn es ein Wort $w \in T^*$ gibt, so dass
 \hspace*{1.3cm}
 $A \Rightarrow^* w$
 \\[0.2cm]
-gilt, aus einer erzeugende Variable lässt sich also immer mindestens ein Wort aus $T^*$ herleiten. 
-Die Notation $A \Rightarrow^* w$ drückt aus, dass das Wort $w$ aus der Variablen $A$ in endlich vielen
+gilt, aus einer erzeugende Variable l\"asst sich also immer mindestens ein Wort aus $T^*$ herleiten. 
+Die Notation $A \Rightarrow^* w$ dr\"uckt aus, dass das Wort $w$ aus der Variablen $A$ in endlich vielen
 Schritten abgeleitet werden kann.
 \qed 
 \end{Definition}
@@ -55,13 +55,13 @@ Offenbar ist eine syntaktische Variable, die nicht erzeugend ist, nutzlos.  Die 
 erzeugenden Variablen einer Grammatik $G$  kann mit Hilfe der folgenden induktiven Definition
 gefunden werden.
 \begin{enumerate}
-\item Enthält die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
+\item Enth\"alt die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
        $A \rightarrow w$ \quad mit $w \in T^*$, 
       \\[0.2cm]
       so ist die Variable $A$ offenbar erzeugend.
-\item Enthält die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
+\item Enth\"alt die Grammatik $G = \langle V, T, R, S \rangle$ eine Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
        $A \rightarrow \alpha$ 
@@ -85,7 +85,7 @@ Aufgrund der Regel
 \hspace*{1.3cm}
 $A \rightarrow \texttt{x}$
 \\[0.2cm]
-ist zunächst $A$ erzeugend.  Aufgrund der Regel
+ist zun\"achst $A$ erzeugend.  Aufgrund der Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \rightarrow A$
@@ -97,9 +97,9 @@ nutzlos.  \qed
 
 \noindent
 Ist $G = \langle V, T, R, S \rangle$ eine Grammatik und ist $E$ die Menge der erzeugenden Variablen,
-so können wir alle Variablen, die nicht erzeugend sind, einfach weglassen.  Zusätzlich müssen wir
-natürlich auch die Regeln weglassen, in denen Variablen auftreten, die nicht erzeugend sind.  Dabei
-ändert sich die von der Grammatik $G$ erzeugte Sprache offenbar nicht.
+so k\"onnen wir alle Variablen, die nicht erzeugend sind, einfach weglassen.  Zus\"atzlich m\"ussen wir
+nat\"urlich auch die Regeln weglassen, in denen Variablen auftreten, die nicht erzeugend sind.  Dabei
+\"andert sich die von der Grammatik $G$ erzeugte Sprache offenbar nicht.
 
 Eine Variable kann gleichzeitig erzeugend und trotzdem nutzlos sein.  Als einfaches
 Beispiel betrachten wir die Grammatik  $G = \langle \{S, A, B \}, \{ \texttt{x}, \texttt{y} \}, R, S \rangle$, deren Regeln durch
@@ -110,30 +110,30 @@ Beispiel betrachten wir die Grammatik  $G = \langle \{S, A, B \}, \{ \texttt{x},
 \end{eqnarray*}
 gegeben sind.  Die erzeugenden Variable sind in diesem Falle $A$, $B$ und $S$.  Die Variable
 $B$ ist trotzdem nutzlos, denn von $S$ aus ist diese Variable gar nicht \emph{erreichbar}.
-Formal definieren wir für eine Grammatik $G = \langle V, T, R, S \rangle$ eine syntaktische Variable $X$ als
-\emph{erreichbar}, wenn es Wörter $\alpha, \beta \in (V \cup T)^*$ gibt, so dass 
+Formal definieren wir f\"ur eine Grammatik $G = \langle V, T, R, S \rangle$ eine syntaktische Variable $X$ als
+\emph{erreichbar}, wenn es W\"orter $\alpha, \beta \in (V \cup T)^*$ gibt, so dass 
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \Rightarrow^* \alpha X \beta$
 \\[0.2cm]
-gilt. Für eine gegebene Grammatik $G$  lässt sich die Menge der Variablen, die erreichbar
+gilt. F\"ur eine gegebene Grammatik $G$  l\"asst sich die Menge der Variablen, die erreichbar
 sind, mit dem folgenden 
 induktiven Algorithmus berechnen.
 \begin{enumerate}
 \item Das Start-Symbol $S$ ist erreichbar.
-\item Enthält die Grammatik $G$ eine Regel der Form
+\item Enth\"alt die Grammatik $G$ eine Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $X \rightarrow \alpha$
       \\[0.2cm]
       und ist $X$ erreichbar, so sind auch alle Variablen, die in $\alpha$ auftreten, erreichbar.
 \end{enumerate}
-Offenbar sind Variablen, die nicht erreichbar sind, nutzlos und wir können diese Variablen, sowie alle
-Regeln, in denen diese Variablen auftreten, weglassen, ohne dass sich dabei die Sprache ändert.
+Offenbar sind Variablen, die nicht erreichbar sind, nutzlos und wir k\"onnen diese Variablen, sowie alle
+Regeln, in denen diese Variablen auftreten, weglassen, ohne dass sich dabei die Sprache \"andert.
 Damit haben wir jetzt ein Verfahren, um aus einer Grammatik alle nutzlosen Variablen zu entfernen.
 \begin{enumerate}
-\item Zunächst entfernen wir alle Variablen, die nicht erzeugend sind.
-\item Anschließend entfernen wir alle Variablen, die nicht erreichbar sind.
+\item Zun\"achst entfernen wir alle Variablen, die nicht erzeugend sind.
+\item Anschlie{\ss}end entfernen wir alle Variablen, die nicht erreichbar sind.
 \end{enumerate}
 Es ist wichtig zu verstehen, dass die Reihenfolge der obigen Regeln nicht umgedreht werden darf.
 Dazu betrachten wir die Grammatik  $G = \langle \{S, A, B, C\}, \{ \texttt{x}, \texttt{y} \}, R, S \rangle$, deren Regeln durch
@@ -156,7 +156,7 @@ $A \Rightarrow^* \texttt{x}$, \quad
 $S \Rightarrow^* \texttt{x}$  \quad und \quad
 $B \Rightarrow^* \texttt{y}$.
 \\[0.2cm]
-Damit sieht es zunächst so aus, als ob nur $C$ nutzlos ist.  Das stimmt aber nicht, auch die Variable
+Damit sieht es zun\"achst so aus, als ob nur $C$ nutzlos ist.  Das stimmt aber nicht, auch die Variable
 $B$ ist nutzlos, denn wenn wir die Variable $C$ aus der Grammatik entfernen, dann wird auch die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -165,10 +165,10 @@ $S \rightarrow BC$
 entfernt und damit ist dann $B$ nicht mehr erreichbar und somit ebenfalls nutzlos.
 
 \remark
-An dieser Stelle können wir uns fragen, warum es funktioniert, wenn wir erst alle Variablen 
-entfernen, die nicht erzeugend sind und anschließend dann die nicht erreichbaren Variablen entfernen.
+An dieser Stelle k\"onnen wir uns fragen, warum es funktioniert, wenn wir erst alle Variablen 
+entfernen, die nicht erzeugend sind und anschlie{\ss}end dann die nicht erreichbaren Variablen entfernen.
 Der Grund ist, dass eine Variable $B$, die nicht erreichbar ist, niemals von einer
-anderen Variablen $A$, die erreichbar ist, benötigt wird um ein Wort $w\in T^*$ abzuleiten, denn
+anderen Variablen $A$, die erreichbar ist, ben\"otigt wird um ein Wort $w\in T^*$ abzuleiten, denn
 wenn die Variable $B$ in der Ableitung
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -177,11 +177,11 @@ $A \Rightarrow^* w$
 auftritt, dann folgt aus der Erreichbarkeit von $A$ auch die Erreichbarkeit von $B$.
 Wenn also eine Variable $A$ gleichzeitig erreichbar und  erzeugend ist und wir andererseits eine Variable
 $B$ als nicht erreichbar erkannt haben, dann kann $B$ getrost entfernt werden, denn das kann 
-an der Tatsache, dass $A$ erzeugend ist, nichts ändern. \eox
+an der Tatsache, dass $A$ erzeugend ist, nichts \"andern. \eox
 
 \remark
 Der nachfolgende Beweis des Pumping-Lemmas ist logisch von der Beseitigung der nutzlosen
-Symbole unabhängig.  Das war in einer früheren Version dieses Skriptes anders, denn bei
+Symbole unabh\"angig.  Das war in einer fr\"uheren Version dieses Skriptes anders, denn bei
 dem damals verwendeten Beweis war es notwendig, die Grammatik vorher in
 \emph{Chomsky-Normal-Form} zu transformieren.  Die Beseitigung der nutzlosen
 Symbole ist ein Teil dieser Transformation.  Der gleich folgende Beweis setzt nicht mehr
@@ -189,14 +189,14 @@ voraus, dass die Grammatik in Chomsky-Normal-Form vorliegt.  Da die Technik der
 Beseitigung nutzloser Symbole aber auch einen praktischen Wert hat, habe ich diesen
 Abschnitt trotzdem beibehalten. 
 
-\section{Parse-Bäume als Listen}
-Zum Beweis des Pumping-Lemmas für kontextfreie Sprachen benötigen wir eine
-Abschätzung, bei der wir die Länge eines Wortes $w$ aus einer kontextfreien Sprache $L(G)$ 
-mit der Höhe des Parse-Baums für $W$ in Verbindung bringen.  Es zeigt sich, dass es zum Nachweis dieser
-Abschätzung hilfreich ist, wenn wir einen Parse-Baum als Liste aller Pfade des Parse-Baums auffassen.
+\section{Parse-B\"aume als Listen}
+Zum Beweis des Pumping-Lemmas f\"ur kontextfreie Sprachen ben\"otigen wir eine
+Absch\"atzung, bei der wir die L\"ange eines Wortes $w$ aus einer kontextfreien Sprache $L(G)$ 
+mit der H\"ohe des Parse-Baums f\"ur $W$ in Verbindung bringen.  Es zeigt sich, dass es zum Nachweis dieser
+Absch\"atzung hilfreich ist, wenn wir einen Parse-Baum als Liste aller Pfade des Parse-Baums auffassen.
 Die Idee wird am ehesten anhand eines Beispiels klar.  Abbildung
 \ref{fig:parse-tree.dot2} auf Seite \pageref{fig:parse-tree.dot2}
-zeigt einen Parse-Baum für den String ``\texttt{2*3+4}'', der mit Hilfe der in Abbildung
+zeigt einen Parse-Baum f\"ur den String ``\texttt{2*3+4}'', der mit Hilfe der in Abbildung
 \ref{fig:ArithExpr} gezeigten Grammatik erstellt wurde. 
 
 \begin{figure}[htbp]
@@ -217,7 +217,7 @@ zeigt einen Parse-Baum für den String ``\texttt{2*3+4}'', der mit Hilfe der in A
   \vspace*{-0.5cm}
   \end{minipage}}}
   \end{center}
-  \caption{Grammatik für arithmetische Ausdrücke.}
+  \caption{Grammatik f\"ur arithmetische Ausdr\"ucke.}
   \label{fig:ArithExpr}
 \end{figure}
 \vspace*{0.3cm}
@@ -226,7 +226,7 @@ zeigt einen Parse-Baum für den String ``\texttt{2*3+4}'', der mit Hilfe der in A
 \begin{figure}[!ht]
   \centering
       \epsfig{file=Abbildungen/parse-tree.eps, scale=0.6}
-  \caption{Ein Parse-Baum für den String ``\texttt{2*3+4}''.}
+  \caption{Ein Parse-Baum f\"ur den String ``\texttt{2*3+4}''.}
   \label{fig:parse-tree.dot2}
 \end{figure}
 
@@ -274,11 +274,11 @@ so definieren wir $\textsl{parseTree}(A \Rightarrow^* w)$ induktiv als Liste von
       \\[0.2cm]
       \hspace*{1.3cm}
       $ (A \rightarrow B_1B_2 \cdots B_m) \in R, \quad 
-         B_i \Rightarrow^* w_i\; \mbox{für alle $i=1,\cdots,m$} \quad
+         B_i \Rightarrow^* w_i\; \mbox{f\"ur alle $i=1,\cdots,m$} \quad
          \mbox{und} \; w = w_1w_2 \cdots w_m
       $
       \\[0.2cm]
-      gilt, so definieren wir (unter Benutzung der \textsc{SetlX}-Notation für die Definition von Listen)
+      gilt, so definieren wir (unter Benutzung der \textsc{SetlX}-Notation f\"ur die Definition von Listen)
       \\[0.2cm]
       \hspace*{1.3cm}
       $ 
@@ -288,7 +288,7 @@ so definieren wir $\textsl{parseTree}(A \Rightarrow^* w)$ induktiv als Liste von
         \bigr]
       $.
       \\[0.2cm]
-      Damit diese Definition auch tatsächlich alle Fälle abdeckt, müssen wir noch den Fall
+      Damit diese Definition auch tats\"achlich alle F\"alle abdeckt, m\"ussen wir noch den Fall
       diskutieren, dass  eines der Symbole $B_i$ ein Terminal ist: In diesem Fall setzen wir
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -296,7 +296,7 @@ so definieren wir $\textsl{parseTree}(A \Rightarrow^* w)$ induktiv als Liste von
 \end{enumerate}
 \end{Definition}
 
-Wir definieren die \emph{Breite} $b$ einer Grammatik als die größte Anzahl von Symbolen, die 
+Wir definieren die \emph{Breite} $b$ einer Grammatik als die gr\"o{\ss}te Anzahl von Symbolen, die 
 auf der rechten Seite einer Grammatik-Regel der Form
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -304,22 +304,22 @@ $A \rightarrow \alpha$
 \\[0.2cm]
 auftreten.  
 
-\begin{Lemma}[Beschränktheits-Lemma] \label{lemma:length}
+\begin{Lemma}[Beschr\"anktheits-Lemma] \label{lemma:length}
   Die Grammatik $G = \langle V, T, R, S \rangle$ habe die Breite $b$.  Ferner gelte
   \\[0.2cm]
   \hspace*{1.3cm}
   $A \Rightarrow^* w$
   \\[0.2cm]
-  für eine syntaktische Variable $A \in V$ und ein Wort $w \in T^*$.  Falls $n$ die Länge der längsten Liste in
+  f\"ur eine syntaktische Variable $A \in V$ und ein Wort $w \in T^*$.  Falls $n$ die L\"ange der l\"angsten Liste in
   \[ \textsl{parseTree}(A \Rightarrow^* w) \]
-  ist, so gilt für die Länge des Wortes $w$ die Abschätzung
+  ist, so gilt f\"ur die L\"ange des Wortes $w$ die Absch\"atzung
   \\[0.2cm]
   \hspace*{1.3cm}
   $|w| \leq b^{n-1}$.  
 \end{Lemma}
 
 \noindent
-\textbf{Beweis}: Wir führen den Beweis durch Induktion nach der Länge $n$ der längsten
+\textbf{Beweis}: Wir f\"uhren den Beweis durch Induktion nach der L\"ange $n$ der l\"angsten
 Liste in $\textsl{parseTree}(A \Rightarrow^* w)$.
 \begin{enumerate}
 \item[I.A.] $n=2$:  Wenn alle Listen in $\textsl{parseTree}(A \Rightarrow^* w)$ 
@@ -328,7 +328,7 @@ Liste in $\textsl{parseTree}(A \Rightarrow^* w)$.
             \\[0.2cm]
             \hspace*{1.3cm}
             $A \rightarrow t_1t_2 \cdots t_m$ \quad mit $w = t_1t_2 \cdots t_m$ und $t_i \in T$
-            für alle $i=1,\cdots,m$
+            f\"ur alle $i=1,\cdots,m$
             \\[0.2cm]
             in der Grammatik $G$ geben.  Es gilt dann
             \[ \textsl{parseTree}(A \Rightarrow^* w) = 
@@ -339,22 +339,22 @@ Liste in $\textsl{parseTree}(A \Rightarrow^* w)$.
             \hspace*{1.3cm}
             $|w| = |t_1t_2 \cdots t_m| = m \leq b = b^{1} = b^{2-1}$,
             \\[0.2cm]
-            wobei die Ungleichung $m \leq b$ aus der Tatsache folgt, dass die Länge der Regeln der Grammatik
-            $G$ durch die Breite $b$ beschränkt ist.
+            wobei die Ungleichung $m \leq b$ aus der Tatsache folgt, dass die L\"ange der Regeln der Grammatik
+            $G$ durch die Breite $b$ beschr\"ankt ist.
 \item[I.S.] $n \mapsto n+1$: Da die Ableitung nun aus mehr als einem Schritt besteht, hat die Ableitung die Form
             \\[0.2cm]
             \hspace*{1.3cm}
             $A \Rightarrow B_1 B_2 \cdots B_m \Rightarrow^* w_1 w_2 \cdots w_m = w$.
             \\[0.2cm]
-            Außerdem haben dann die Listen in
+            Au{\ss}erdem haben dann die Listen in
             \[ 
                \textsl{parseTree}(B_i \Rightarrow^* w_i) 
             \]
-            für alle $i=1,\cdots,m$ höchstens die Länge $n$.
+            f\"ur alle $i=1,\cdots,m$ h\"ochstens die L\"ange $n$.
             Nach Induktions-Voraussetzung wissen wir also, dass
             \\[0.2cm]
             \hspace*{1.3cm}
-            $|w_i| \leq b^{n-1}$ \quad für alle $i=1,\cdots,m$
+            $|w_i| \leq b^{n-1}$ \quad f\"ur alle $i=1,\cdots,m$
             \\[0.2cm]
             gilt.  Daher haben wir
             \\[0.2cm]
@@ -364,22 +364,22 @@ Liste in $\textsl{parseTree}(A \Rightarrow^* w)$.
             $. \qed
 \end{enumerate}
 
-\section{Das Pumping-Lemma für kontextfreie Sprachen}
+\section{Das Pumping-Lemma f\"ur kontextfreie Sprachen}
 \begin{Satz}[Pumping-Lemma]
 Es sei $L$ eine kontextfreie Sprache.  Dann gibt es ein $n \in \mathbb{N}$, so dass jeder String
-$s \in L$, dessen Länge größer oder gleich $n$ ist, in der Form 
+$s \in L$, dessen L\"ange gr\"o{\ss}er oder gleich $n$ ist, in der Form 
 \[ s = uvwxy \]
-geschrieben werden kann, so dass außerdem folgendes gilt:
+geschrieben werden kann, so dass au{\ss}erdem folgendes gilt:
 \begin{enumerate}
 \item $|vwx| \leq n$,
 
-      der mittlere Teil des Strings hat folglich eine Länge von höchstens $n$ Buchstaben.
+      der mittlere Teil des Strings hat folglich eine L\"ange von h\"ochstens $n$ Buchstaben.
 \item $vx \not= \varepsilon$,
 
-      die Teilstrings $v$ und $x$ können also nicht beide gleichzeitig leer sein.
+      die Teilstrings $v$ und $x$ k\"onnen also nicht beide gleichzeitig leer sein.
 \item $\forall h \in \mathbb{N}_0: uv^hwx^hy \in L$.
 
-      die Strings $v$ und $x$ können beliebig oft repliziert (\emph{gepumpt}) werden. 
+      die Strings $v$ und $x$ k\"onnen beliebig oft repliziert (\emph{gepumpt}) werden. 
 \end{enumerate}
 \end{Satz}
 
@@ -387,35 +387,35 @@ geschrieben werden kann, so dass außerdem folgendes gilt:
 \textbf{Beweis}:  Da $L$ eine kontextfreie Sprache ist, gibt es eine kontextfreie
 Grammatik $G = \langle V, T, R, S \rangle$, so dass 
 \[ L = L(G) \]
-gilt. Wir nehmen an, dass die Grammatik $G$ insgesamt $k$ syntaktische Variablen enthält
-und außerdem die 
+gilt. Wir nehmen an, dass die Grammatik $G$ insgesamt $k$ syntaktische Variablen enth\"alt
+und au{\ss}erdem die 
 Breite $b$ hat.  Wir definieren
 \\[0.2cm]
 \hspace*{1.3cm}
 $n := b^{k+1}$. 
 \\[0.2cm] 
-Sei nun $s \in L$ mit $|s| \geq n$.  Wir wählen einen Parse-Baum $\tau$ aus, der einerseits
-den String $s$ ableitet und der andererseits unter allen Parse-Bäumen, die den String $s$
-aus $S$ ableiten, die minimale Anzahl von Knoten hat.  Für diesen Parse-Baum $\tau$
+Sei nun $s \in L$ mit $|s| \geq n$.  Wir w\"ahlen einen Parse-Baum $\tau$ aus, der einerseits
+den String $s$ ableitet und der andererseits unter allen Parse-B\"aumen, die den String $s$
+aus $S$ ableiten, die minimale Anzahl von Knoten hat.  F\"ur diesen Parse-Baum $\tau$
 betrachten wir die Listen aus
 \\[0.2cm]
 \hspace*{1.3cm}
 $\tau = \textsl{parseTree}(S \Rightarrow^* s)$. 
 \\[0.2cm] 
-Falls alle Listen hier eine Länge kleiner-gleich $k+1$ hätten, so würde aus den Beschränktheits-Lemma
+Falls alle Listen hier eine L\"ange kleiner-gleich $k+1$ h\"atten, so w\"urde aus den Beschr\"anktheits-Lemma
 \ref{lemma:length} folgen, dass  
 \\[0.2cm]
 \hspace*{1.3cm}
 $ |s| \leq b^{(k+1)-1} = b^k < b^{k+1} = n, \quad \mbox{also} \quad |s| < n$
 \\[0.2cm] 
 gilt, im Widerspruch zu der Voraussetzung $|s| \geq n$.  Also muss es in 
-$\tau$ eine Liste geben, die mindestens die Länge $k + 2$
-hat.  Wir wählen die längste Liste unter den  Listen in $\tau$ aus.
+$\tau$ eine Liste geben, die mindestens die L\"ange $k + 2$
+hat.  Wir w\"ahlen die l\"angste Liste unter den  Listen in $\tau$ aus.
 Diese Liste hat dann die Form
-\[ [A_1, \cdots, A_l, t] \quad \mbox{mit $A_i \in V$ für alle $i \in \{1,\cdots,l\}$},\quad t \in T,
+\[ [A_1, \cdots, A_l, t] \quad \mbox{mit $A_i \in V$ f\"ur alle $i \in \{1,\cdots,l\}$},\quad t \in T,
    \quad \mbox{sowie $l \geq k+1$}.
  \]
-Wegen $l \geq k + 1$  können nicht alle Variablen $A_1$, $\cdots$, $A_l$
+Wegen $l \geq k + 1$  k\"onnen nicht alle Variablen $A_1$, $\cdots$, $A_l$
 voneinander verschieden sein, denn es gibt ja nur insgesamt $k$ verschiedene syntaktische
 Variablen.   Wir finden daher in der Menge $\{ l, l-1, \cdots, l-k \}$
 zwei verschiedene Indizes $i$ und $j$,  so dass die Variablen $A_i$ und $A_j$ gleich sind und definieren
@@ -434,26 +434,26 @@ Damit haben wir aber folgendes:
        \Rightarrow^* \cdots \Rightarrow^* uv^hAx^hy \Rightarrow^* uv^hwx^hy$, also
       \\[0.2cm]
       \hspace*{1.3cm}
-      $uv^hwx^hy \in L$ \quad für beliebige $h \in \mathbb{N}_0$.
+      $uv^hwx^hy \in L$ \quad f\"ur beliebige $h \in \mathbb{N}_0$.
       \vspace*{0.2cm}
 
 \end{enumerate}
-Wir müssen jetzt noch zeigen, dass $vx \not= \varepsilon$ gilt.  Die Ableitung
+Wir m\"ussen jetzt noch zeigen, dass $vx \not= \varepsilon$ gilt.  Die Ableitung
 \[ A \Rightarrow^* vAx \]
 ist eigentlich die Ableitung
 \[ A_i \Rightarrow^* vA_jx \]
-und enthält daher mindestens einen Ableitungsschritt.
-Wir führen den Nachweis der Behauptung $vx \not= \varepsilon$ indirekt und nehmen $v = x =
+und enth\"alt daher mindestens einen Ableitungsschritt.
+Wir f\"uhren den Nachweis der Behauptung $vx \not= \varepsilon$ indirekt und nehmen $v = x =
 \varepsilon$ an.
-Dann würde wegen $A_i = A_j$ also
+Dann w\"urde wegen $A_i = A_j$ also
 \\[0.2cm]
 \hspace*{1.3cm}
 $A_i \Rightarrow^+ A_i$
 \\[0.2cm]
 gelten, wobei das Zeichen $^+$ an dem Pfeil $\Rightarrow$ anzeigt, dass diese Ableitung
 mindestens einen Schritt 
-enthält.  In diesem Fall wäre aber der Parse-Baum $\tau$ nicht minimal, denn wir könnten
-die Ableitungs-Schritte, die $A_i$ in $A_i$ überführen, einfach weglassen.
+enth\"alt.  In diesem Fall w\"are aber der Parse-Baum $\tau$ nicht minimal, denn wir k\"onnten
+die Ableitungs-Schritte, die $A_i$ in $A_i$ \"uberf\"uhren, einfach weglassen.
 Damit ist die Annahme $vx = \varepsilon$ widerlegt und es muss $vx \not= \varepsilon$ gelten.
 \vspace*{0.2cm}
 
@@ -462,12 +462,12 @@ Als letztes zeigen wir, dass die Ungleichung $|vwx| \leq n$ gilt.  Wir haben
 Weil einerseits $i \in \{l-k, l-(k-1), \cdots,l \}$ gilt und andererseits die der
 Ableitung
 $A \Rightarrow^* vwx$ zugeordnete Liste aus $\textsl{parseTree}(S \Rightarrow^* w)$ von
-maximaler Länge war, wissen wir, 
-dass die Länge der längsten Liste in 
+maximaler L\"ange war, wissen wir, 
+dass die L\"ange der l\"angsten Liste in 
 \[ \textsl{parseTree}(A \Rightarrow^* vwx) \]
 kleiner-gleich  $k+2$ ist.
-  Nach dem Beschränktheits-Lemma
-\ref{lemma:length} folgt damit für die Länge von $vwx$ die Abschätzung
+  Nach dem Beschr\"anktheits-Lemma
+\ref{lemma:length} folgt damit f\"ur die L\"ange von $vwx$ die Absch\"atzung
 \\[0.2cm]
 \hspace*{1.3cm}
 $|vwx| \leq b^{(k+2)-1} = b^{k+1} = n$.   \qed
@@ -486,26 +486,26 @@ bestimmte Sprachen nicht kontextfrei sind.
 nicht kontextfrei}
 Wir weisen nun nach, dass die Sprache
 \[ L = \{ \mathtt{a}^k \mathtt{b}^k \mathtt{c}^k \mid k \in \mathbb{N} \} \]
-nicht kontextfrei ist.  Wir führen diesen Nachweis indirekt und nehmen zunächst an, dass $L$
-kontextfrei ist.  Nach dem Pumping-Lemma gibt es dann eine natürliche Zahl $n$, so dass jeder String
-$s \in L$, dessen Länge größer oder gleich $n$ ist, sich in Teilstrings der Form
+nicht kontextfrei ist.  Wir f\"uhren diesen Nachweis indirekt und nehmen zun\"achst an, dass $L$
+kontextfrei ist.  Nach dem Pumping-Lemma gibt es dann eine nat\"urliche Zahl $n$, so dass jeder String
+$s \in L$, dessen L\"ange gr\"o{\ss}er oder gleich $n$ ist, sich in Teilstrings der Form
 \[ s = uvwxy \]
-zerlegen lässt, so dass außerdem folgendes gilt:
+zerlegen l\"asst, so dass au{\ss}erdem folgendes gilt:
 \begin{enumerate}
 \item $|vwx| \leq n$,
 \item $vx \not= \varepsilon$,
 \item $\forall i \in \mathbb{N}_0: uv^iwx^iy \in L$.
 
-      Insbesondere können wir hier $i=0$ wählen und erhalten dann
+      Insbesondere k\"onnen wir hier $i=0$ w\"ahlen und erhalten dann
       $uwy \in L$. 
 \end{enumerate}
 Wir definieren nun den String $s$ wie folgt:
 \[ s := \mathtt{a}^n\mathtt{b}^n\mathtt{c}^n. \]
-Dieser String hat die Länge $3 \cdot n \geq n$ und erfüllt also die Voraussetzung über die Länge.
+Dieser String hat die L\"ange $3 \cdot n \geq n$ und erf\"ullt also die Voraussetzung \"uber die L\"ange.
 Damit finden wir eine Zerlegung $s=uvwxy$ mit den obigen Eigenschaften.  Da der Teilstring
-$vwx$ eine Länge kleiner oder gleich $n$ hat, können in diesem String nicht gleichzeitig die
+$vwx$ eine L\"ange kleiner oder gleich $n$ hat, k\"onnen in diesem String nicht gleichzeitig die
 Buchstaben \qote{a} und \qote{c} vorkommen. Wir betrachten die nach dieser Erkenntnis noch
-möglichen  Fälle getrennt.
+m\"oglichen  F\"alle getrennt.
 \begin{enumerate}
 \item Fall: In dem String $vwx$ kommen nur die Buchstaben \qote{a} und \qote{b} vor,  der Buchstabe
       \qote{c} kommt nicht vor: 
@@ -518,7 +518,7 @@ möglichen  Fälle getrennt.
       \hspace*{1.3cm}
       $\textsl{count}(vx,\mathtt{a}) + \textsl{count}(vx,\mathtt{b}) > 0$.
       \\[0.2cm]
-      Wir nehmen zunächst an, dass $\textsl{count}(vx,\mathtt{a}) > 0$ gilt,
+      Wir nehmen zun\"achst an, dass $\textsl{count}(vx,\mathtt{a}) > 0$ gilt,
       der Fall $\textsl{count}(vx,\mathtt{b}) > 0$ ist analog zu behandeln.
       Dann erhalten wir einerseits
       \[ 
@@ -529,7 +529,7 @@ möglichen  Fälle getrennt.
                               & = & n.
       \end{array}
       \]
-      Zählen wir nun die Häufigkeit, mit welcher der Buchstabe \qote{a}
+      Z\"ahlen wir nun die H\"aufigkeit, mit welcher der Buchstabe \qote{a}
       in dem String $uwy$ auftritt, so erhalten wir
       \[ 
       \begin{array}[t]{lcl}
@@ -548,7 +548,7 @@ möglichen  Fälle getrennt.
       und daraus folgt $uwy \not\in L$, was im Widerspruch zum Pumping-Lemma steht.
 \item Fall: In dem String $vwx$ kommt der Buchstabe \qote{a} nicht vor.
    
-      Dieser Fall lässt sich analog zum ersten Fall behandeln. \qed
+      Dieser Fall l\"asst sich analog zum ersten Fall behandeln. \qed
 \end{enumerate}
 
 \exercise
@@ -558,28 +558,28 @@ nicht kontextfrei ist.
 \vspace*{0.2cm}
 
 \noindent
-\textbf{Hinweis}: Argumentieren Sie über die Länge der betrachteten Strings. \eox
+\textbf{Hinweis}: Argumentieren Sie \"uber die L\"ange der betrachteten Strings. \eox
 \vspace*{0.2cm}
 
 \solution
-Wir führen den Beweis indirekt und nehmen an, dass die Sprache $L_{\mathrm{square}}$ kontextfrei
-wäre.  Nach dem Pumping-Lemma für kontextfreie Sprachen gibt es dann eine positive
-natürliche Zahl $n$, so dass sich jeder String $s \in L_{\mathrm{square}}$ mit $|s| \geq n$ in fünf 
-Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten lässt, so dass gilt:
+Wir f\"uhren den Beweis indirekt und nehmen an, dass die Sprache $L_{\mathrm{square}}$ kontextfrei
+w\"are.  Nach dem Pumping-Lemma f\"ur kontextfreie Sprachen gibt es dann eine positive
+nat\"urliche Zahl $n$, so dass sich jeder String $s \in L_{\mathrm{square}}$ mit $|s| \geq n$ in f\"unf 
+Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten l\"asst, so dass gilt:
 \begin{enumerate}
 \item $s = uvwxy$,
 \item $|vwx| \leq n$,
 \item $vx \not= \varepsilon$,
 \item $\forall h \in \mathbb{N}_0: uv^hwx^hy \in L_{\mathrm{square}}$. 
 \end{enumerate} 
-Wir betrachten nun den String $s = a^{n^2}$.  Für die Länge dieses Strings gilt offenbar
+Wir betrachten nun den String $s = a^{n^2}$.  F\"ur die L\"ange dieses Strings gilt offenbar
 \[ |s| = \big| a^{n^2} \big| = n^2 \geq n. \]
 Also gibt es eine Aufspaltung von $s$ der Form $s = uvwxy$ mit den oben angegebenen Eigenschaften.
-Da $a$ der einzige Buchstabe ist, der in $s$ vorkommt, können in den Teilstrings $u$, $v$, $w$, $x$ und $y$
-auch keine anderen Buchstaben vorkommen und es muss natürliche Zahlen $c$, $d$, $e$, $f$, und $g$ geben, so
+Da $a$ der einzige Buchstabe ist, der in $s$ vorkommt, k\"onnen in den Teilstrings $u$, $v$, $w$, $x$ und $y$
+auch keine anderen Buchstaben vorkommen und es muss nat\"urliche Zahlen $c$, $d$, $e$, $f$, und $g$ geben, so
 dass  
 \[ u = a^c,\; v = a^d,\; w = a^e,\; x = a^f\; \mbox{und}\; y = a^g \]
-gilt.  Wir untersuchen, welche Konzequenzen sich daraus für die Zahlen $c$, $d$, $e$, $f$, $g$ ergeben.
+gilt.  Wir untersuchen, welche Konzequenzen sich daraus f\"ur die Zahlen $c$, $d$, $e$, $f$, $g$ ergeben.
 \begin{enumerate}
 \item Die Zerlegung $s = uvwxy$ schreibt sich als $a^{n^2} = a^ca^da^ea^fa^g$ und daraus folgt
       \begin{equation}
@@ -602,9 +602,9 @@ gilt.  Wir untersuchen, welche Konzequenzen sich daraus für die Zahlen $c$, $d$,
         \forall h \in \mathbb{N}_0: a^ca^{d\cdot h}a^ea^{f\cdot h}a^g \in L_{\mathrm{square}}. 
       \end{equation}
 \end{enumerate}
-Die letzte Gleichung muss insbesondere auch für den Wert $h=2$ gelten:
+Die letzte Gleichung muss insbesondere auch f\"ur den Wert $h=2$ gelten:
 \[ a^ca^{2\cdot d}a^ea^{2\cdot f}a^g \in L_{\mathrm{square}}.  \]
-Nach Definition der Sprache $L_{\mathrm{square}}$ gibt es dann eine natürliche Zahl
+Nach Definition der Sprache $L_{\mathrm{square}}$ gibt es dann eine nat\"urliche Zahl
 $k$, so dass gilt
 \begin{equation}
   \label{eq:f5}
@@ -636,8 +636,8 @@ Damit haben wir insgesamt  $k^2 < (n+1)^2$ gezeigt und das impliziert
 \end{equation}
 Zusammen mit Ungleichung (\ref{eq:f6}) liefert Ungleichung (\ref{eq:f7}) nun die Ungleichungs-Kette
 \[ n < k < n + 1. \]
-Da andererseits $k$ eine natürliche Zahl sein muss und $n$ ebenfalls eine natürliche Zahl ist,
-haben wir jetzt einen Widerspruch, denn zwischen $n$ und $n+1$ gibt es keine natürliche Zahl.
+Da andererseits $k$ eine nat\"urliche Zahl sein muss und $n$ ebenfalls eine nat\"urliche Zahl ist,
+haben wir jetzt einen Widerspruch, denn zwischen $n$ und $n+1$ gibt es keine nat\"urliche Zahl.
 \qed
 
 
@@ -648,10 +648,10 @@ definiert.  Zeigen Sie, dass die Sprache
 nicht kontextfrei ist. \eox
 
 \solution
-Wir führen den Beweis indirekt und nehmen an, dass die Sprache $L$ kontextfrei
-wäre.  Nach dem Pumping-Lemma für kontextfreie Sprachen gibt es dann eine positive
-natürliche Zahl $n$, so dass sich jeder String $s \in L$ mit $|s| \geq n$ in fünf 
-Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten lässt, so dass gilt:
+Wir f\"uhren den Beweis indirekt und nehmen an, dass die Sprache $L$ kontextfrei
+w\"are.  Nach dem Pumping-Lemma f\"ur kontextfreie Sprachen gibt es dann eine positive
+nat\"urliche Zahl $n$, so dass sich jeder String $s \in L$ mit $|s| \geq n$ in f\"unf 
+Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten l\"asst, so dass gilt:
 \begin{enumerate}
 \item $s = uvwxy$,
 \item $|vwx| \leq n$,
@@ -660,36 +660,36 @@ Teilstrings $u$, $v$, $w$, $x$, und $y$ aufspalten lässt, so dass gilt:
 \end{enumerate} 
 Wir betrachten nun den String $s := a^{n}b^{n}a^{n}b^{n}$.  Definieren wir $t:= a^nb^n$,
 so ist klar, dass $s = tt$ ist und damit gilt $s \in L$.
-Für die Länge von $s$ gilt 
+F\"ur die L\"ange von $s$ gilt 
 \[ |s| = \big| a^{n}b^{n}a^{n}b^{n} \big| = 4 \cdot n \geq n. \]
 Also gibt es nach dem Pumping-Lemma eine Aufspaltung von $s$ der Form $s = uvwxy$ mit den
 oben angegebenen Eigenschaften. 
-Im weiteren führen wir eine Fallunterscheidung nach der Lage des Strings $vwx$ innerhalb
-des gesamten Strings $s = a^{n}b^{n}a^{n}b^{n}$ durch.  Dabei berücksichtigen wir, dass
-$|vwx| \leq n$ gilt.  Zur Vereinfachung der Darstellung des Beweises vereinbaren wir für zwei Strings
+Im weiteren f\"uhren wir eine Fallunterscheidung nach der Lage des Strings $vwx$ innerhalb
+des gesamten Strings $s = a^{n}b^{n}a^{n}b^{n}$ durch.  Dabei ber\"ucksichtigen wir, dass
+$|vwx| \leq n$ gilt.  Zur Vereinfachung der Darstellung des Beweises vereinbaren wir f\"ur zwei Strings
 $r$ und $s$ die Schreibweise 
 \\[0.2cm]
 \hspace*{1.3cm}
 $r \sqsubseteq s$ \quad g.d.w. \quad $r$ ist Teilstring von $s$.
 \\[0.2cm]
-Wollen wir zusätzlich die Position einschränken, an der $r$ innerhalb von $s$ auftritt, so
+Wollen wir zus\"atzlich die Position einschr\"anken, an der $r$ innerhalb von $s$ auftritt, so
 schreiben wir
 \\[0.2cm]
 \hspace*{1.3cm}
 $r \sqsubseteq_{i,j} s$ \quad g.d.w. \quad
 $r \sqsubseteq s[i \mathtt{..} j]$. 
 \\[0.2cm]
-Die Schreibweise $r \sqsubseteq_{i,j} s$ drückt also aus, dass der Teilstring $r$ ab der
-Position $i$ in dem String $s$ auftritt und dass das Ende $r$ nicht über die Position $j$ hinausreicht.
+Die Schreibweise $r \sqsubseteq_{i,j} s$ dr\"uckt also aus, dass der Teilstring $r$ ab der
+Position $i$ in dem String $s$ auftritt und dass das Ende $r$ nicht \"uber die Position $j$ hinausreicht.
 
 
-Für die Lage des Teilstrings $vwx$ innerhalb von $a^{n}b^{n}a^{n}b^{n}$ gibt es aufgrund
-der Längenbeschränkung $|vwx| \leq n$ nur drei Möglichkeiten:
+F\"ur die Lage des Teilstrings $vwx$ innerhalb von $a^{n}b^{n}a^{n}b^{n}$ gibt es aufgrund
+der L\"angenbeschr\"ankung $|vwx| \leq n$ nur drei M\"oglichkeiten:
 \begin{enumerate}
 \item Fall: \quad $vwx \sqsubseteq_{1,2\cdot n} a^{n}b^{n}a^{n}b^{n}$,  
 
       der Teilstring
-      $vwx$ liegt also in der ersten Hälfte von $s$ und ist folglich Teil von
+      $vwx$ liegt also in der ersten H\"alfte von $s$ und ist folglich Teil von
       $a^{n}b^{n}$.
 \item Fall: \quad $vwx \sqsubseteq_{n+1,3\cdot n} a^{n}b^{n}a^{n}b^{n}$,  
 
@@ -698,21 +698,21 @@ der Längenbeschränkung $|vwx| \leq n$ nur drei Möglichkeiten:
 \item Fall: \quad $vwx \sqsubseteq_{2\cdot n+1, 4 \cdot n} a^{n}b^{n}a^{n}b^{n}$,  
   
       der Teilstring
-      $vwx$ liegt in der zweiten Hälfte von $s$ und ist folglich Teil von
+      $vwx$ liegt in der zweiten H\"alfte von $s$ und ist folglich Teil von
       $a^{n}b^{n}$.
 \end{enumerate}
-Wir setzen nun im Pumping-Lemma in der vierten Aussage für $h$ den Wert $0$ ein und folgern, dass der
+Wir setzen nun im Pumping-Lemma in der vierten Aussage f\"ur $h$ den Wert $0$ ein und folgern, dass der
 String 
 \\[0.2cm]
 \hspace*{1.3cm}
 $uv^0wx^0y = uwy$ 
 \\[0.2cm]
 in der Sprache $L$ liegt.  Wir zeigen, dass dies zu einem Widerspruch
-führt und untersuchen dazu die obigen drei Fälle der Reihe nach.
+f\"uhrt und untersuchen dazu die obigen drei F\"alle der Reihe nach.
 \begin{enumerate}
 \item Fall: \quad $vwx \sqsubseteq_{1,2\cdot n} a^{n}b^{n}a^{n}b^{n}$.
 
-      Da $vx$ in der ersten Hälfte von
+      Da $vx$ in der ersten H\"alfte von
       $s = a^{n}b^{n}a^{n}b^{n}$ liegt und der String $uwy$ aus $s$ dadurch entsteht, dass
       wir $v$ und $x$ weglassen, hat der String $uwy$ die Form
       \\[0.2cm]
@@ -724,9 +724,9 @@ führt und untersuchen dazu die obigen drei Fälle der Reihe nach.
       Wenn wir also 
       \\[0.2cm]
       \hspace*{1.3cm}
-      $t't' = a^{n-k_1}b^{n-k_2}a^{n}b^{n}$ \quad für ein $t' \in \Sigma^*$
+      $t't' = a^{n-k_1}b^{n-k_2}a^{n}b^{n}$ \quad f\"ur ein $t' \in \Sigma^*$
       \\[0.2cm]
-      hätten, so würde das erste Auftreten von $t'$ in den Teilstring $a^{n}$ hineinragen und müsste folglich
+      h\"atten, so w\"urde das erste Auftreten von $t'$ in den Teilstring $a^{n}$ hineinragen und m\"usste folglich
       mit einem $a$ enden.  Das funktioniert aber nicht, denn
       das zweite Auftreten von $t'$ endet mit einem $b$.  Also kann dieser Fall nicht eintreten.
 \item Fall: \quad $vwx \sqsubseteq_{n+1,3\cdot n} a^{n}b^{n}a^{n}b^{n}$,  
@@ -736,22 +736,22 @@ führt und untersuchen dazu die obigen drei Fälle der Reihe nach.
       \\[0.2cm]
       \hspace*{1.3cm} $uwy = a^{n}b^{n-k_1}a^{n-k_2}b^{n}$
       \\[0.2cm]
-      Wenn $uwy \in L$ ist, müsste es also ein $t'$ geben mit
+      Wenn $uwy \in L$ ist, m\"usste es also ein $t'$ geben mit
       \\[0.2cm]
       \hspace*{1.3cm} $t't' = a^{n}b^{n-k_1}a^{n-k_2}b^{n}$ \quad und $t' \in \Sigma^*$.
       \\[0.2cm]
       Wenn wir uns das erste Auftreten von $t'$ in dieser Gleichung ansehen, stellen wir fest, dass $t'$ mit
       dem String $a^{n}$ beginnt.  Betrachten wir das zweite Auftreten von $t'$      , so sehen wir, dass 
-      $t'$ mit dem String $b^{n}$ endet.  Damit hat dann aber $t'$ mindestens die Länge $2
+      $t'$ mit dem String $b^{n}$ endet.  Damit hat dann aber $t'$ mindestens die L\"ange $2
   \cdot n$ und $t't' = uwy$ 
-      hätte mindestens die Länge $4 \cdot n$.  Wegen $vx \not= \varepsilon$  ist dies
-      nicht möglich und auch dieser Fall kann nicht eintreten.  
+      h\"atte mindestens die L\"ange $4 \cdot n$.  Wegen $vx \not= \varepsilon$  ist dies
+      nicht m\"oglich und auch dieser Fall kann nicht eintreten.  
 
 \item Fall: \quad $vwx \sqsubseteq_{2\cdot n+1, 4 \cdot n} a^{n}b^{n}a^{n}b^{n}$.
   
       Dieser Fall ist analog zum ersten Fall.
 \end{enumerate}
-Da wir in jedem Fall einen Widerspruch erhalten haben, können wir schließen, dass die Sprache $L$
+Da wir in jedem Fall einen Widerspruch erhalten haben, k\"onnen wir schlie{\ss}en, dass die Sprache $L$
 nicht kontextfrei sein kann.
 \qed
 
@@ -775,9 +775,9 @@ nicht kontextfrei ist.  Hier bezeichnet $\mathbb{P}$ die Menge der Primzahlen.
 \eox
 
 \solution
-Wir führen den Beweis indirekt und nehmen an, $L$ wäre kontextfrei.  Nach
-dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es für alle Strings $s \in L$, 
-deren Länge größer als $n$ ist, eine Zerlegung
+Wir f\"uhren den Beweis indirekt und nehmen an, $L$ w\"are kontextfrei.  Nach
+dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es f\"ur alle Strings $s \in L$, 
+deren L\"ange gr\"o{\ss}er als $n$ ist, eine Zerlegung
 \\[0.2cm]
 \hspace*{1.3cm}
 $s = uvwxy$
@@ -788,32 +788,32 @@ mit den folgenden drei Eigenschaften gibt:
 \item $vx \not= \varepsilon$, 
 \item $\forall h \in \mathbb{N}_0: u v^h w x^h y \in L$.
 \end{enumerate}
-Wir wählen nun eine Primzahl $p$, die größer als $n+1$ ist und setzen $s = \mathtt{a}^p$.
+Wir w\"ahlen nun eine Primzahl $p$, die gr\"o{\ss}er als $n+1$ ist und setzen $s = \mathtt{a}^p$.
 Wir wissen, dass eine solche Primzahl existieren muss, denn 
 \href{http://en.wikipedia.org/wiki/Prime_number#Number_of_prime_numbers}{es gibt unendlich viele Primzahlen}. 
-Dann gilt $|s| = p > n$ und die Voraussetzung des Pumping-Lemmas ist erfüllt.
+Dann gilt $|s| = p > n$ und die Voraussetzung des Pumping-Lemmas ist erf\"ullt.
 Wir finden also eine Zerlegung von $\mathtt{a}^p$ der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\mathtt{a}^p = uvwxy$ 
 \\[0.2cm]
 mit den oben angegebenen Eigenschaften.
-Aufgrund der Gleichung $s = uvwxy$ können die Teilstrings $u$, $v$, $w$, $x$ und $y$ nur aus dem
-Buchstaben ``\texttt{a}'' bestehen.  Also gibt es natürliche Zahlen $c$, $d$, $e$, $f$ und
+Aufgrund der Gleichung $s = uvwxy$ k\"onnen die Teilstrings $u$, $v$, $w$, $x$ und $y$ nur aus dem
+Buchstaben ``\texttt{a}'' bestehen.  Also gibt es nat\"urliche Zahlen $c$, $d$, $e$, $f$ und
 $g$ so dass gilt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $u = \mathtt{a}^c$, \quad $v = \mathtt{a}^d$, \quad $w = \mathtt{a}^e$, \quad 
 $x = \mathtt{a}^f$ \quad und \quad $y = \mathtt{a}^g$.
 \\[0.2cm]
-Für die Zahlen $c$, $d$, $e$, $f$ und $g$ gilt dann Folgendes:
+F\"ur die Zahlen $c$, $d$, $e$, $f$ und $g$ gilt dann Folgendes:
 \begin{enumerate}
 \item $c + d + e + f + g = p$,
 \item $d + f \not= 0$,
 \item $d + e + f \leq n$,
 \item $\forall h \in \mathbb{N}_0: c + h \cdot d + e + h \cdot f + g \in \mathbb{P}$.
 \end{enumerate}
-Setzen wir in der letzten Gleichung für $h$ den Wert $(c + e + g)$ ein, so erhalten wir
+Setzen wir in der letzten Gleichung f\"ur $h$ den Wert $(c + e + g)$ ein, so erhalten wir
 \\[0.2cm]
 \hspace*{1.3cm}
 $c + (c + e + g) \cdot d + e + (c + e + g) \cdot f + g \in P$.
@@ -823,12 +823,12 @@ Wegen
 \hspace*{1.3cm}
 $c + (c + e + g) \cdot d + e + (c + e + g) \cdot f + g = (c + e + g) \cdot (1 + d + f)$ 
 \\[0.2cm]
-hätten wir dann
+h\"atten wir dann
 \\[0.2cm]
 \hspace*{1.3cm}
 $(c + e + g) \cdot (1 + d + f) \in \mathbb{P}$.
 \\[0.2cm]
-Das kann aber nicht sein, denn wegen $d + f > 0$ ist der Faktor $1 + d + f$ größer als $1$
+Das kann aber nicht sein, denn wegen $d + f > 0$ ist der Faktor $1 + d + f$ gr\"o{\ss}er als $1$
 und wegen
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -839,7 +839,7 @@ wissen wir, dass
 \hspace*{1.3cm}
 $c + e + g \geq  c + g = c + d + e + f + g - (d + e + f) = p - (d + e + f) \geq p - n > 1$ 
 \\[0.2cm]
-ist, so dass auch der Faktor $(c + e + g)$ ebenfalls größer als $1$ ist.  Damit kann das
+ist, so dass auch der Faktor $(c + e + g)$ ebenfalls gr\"o{\ss}er als $1$ ist.  Damit kann das
 Produkt
 \\[0.2cm]
 \hspace*{1.3cm}

--- a/Lecture-Notes/grenzen.tex
+++ b/Lecture-Notes/grenzen.tex
@@ -1,19 +1,19 @@
 \chapter{Grenzen der Berechenbarkeit}
 In jeder Disziplin der Wissenschaft wird die Frage gestellt, welche Grenzen die
 verwendeten Methoden haben.   Wir wollen daher in diesem Kapitel aufzeigen, welche
-informatischen Fragestellungen prinzipiell unlösbar sind.  Beispielhaft untersuchen wir
-zunächst das Halte-Problem.  Anschließend zeigen wir, dass aus der Unlösbarkeit
-des Halte-Problems die Unlösbarkeit vieler weiterer Problem folgt.
+informatischen Fragestellungen prinzipiell unl\"osbar sind.  Beispielhaft untersuchen wir
+zun\"achst das Halte-Problem.  Anschlie{\ss}end zeigen wir, dass aus der Unl\"osbarkeit
+des Halte-Problems die Unl\"osbarkeit vieler weiterer Problem folgt.
 
 \section{Das Halte-Problem}
-Das Halte-Problem ist die Frage, ob eine gegebene Funktion für eine bestimmte Eingabe
-terminiert.  Wir werden zeigen, dass dieses Problem nicht durch ein Programm gelöst werden
-kann.  Dazu führen wir folgende Definition ein.
+Das Halte-Problem ist die Frage, ob eine gegebene Funktion f\"ur eine bestimmte Eingabe
+terminiert.  Wir werden zeigen, dass dieses Problem nicht durch ein Programm gel\"ost werden
+kann.  Dazu f\"uhren wir folgende Definition ein.
 
 \begin{Definition}[Test-Funktion] {\em Ein String $t$ ist eine \emph{Test-Funktion} mit Namen $n$ wenn $t$ ein
 String der Form \\[0.3cm]
 \hspace*{1.3cm} {\tt int $n$(char* x) \{ $\cdots$ \}} \\[0.3cm]
-ist, der sich als Definition einer $C$-Funktion parsen lässt.  Die Menge der
+ist, der sich als Definition einer $C$-Funktion parsen l\"asst.  Die Menge der
 Test-Funktionen bezeichnen wir mit $T\!F$.  Ist $t \in T\!F$ und hat den Namen $n$, so
 schreiben wir $\mathtt{name}(t) = n$.} \hspace*{\fill} $\Box$
 \end{Definition}
@@ -33,15 +33,15 @@ schreiben wir $\mathtt{name}(t) = n$.} \hspace*{\fill} $\Box$
       \texttt{C}-Funktion und keine Definition.
 \item $s_4$ = ``{\tt int hugo(char* x) begin i := 1; end;}''
 
-      $s_4$ ist keine Test-Funktion, denn es lässt sich mit einem
+      $s_4$ ist keine Test-Funktion, denn es l\"asst sich mit einem
       \texttt{C}-Compiler nicht fehlerfrei parsen.
 \item $s_5$ = ``{\tt int hugo(int x) \{ return i*i; \}}''
 
       $s_5$ ist auch keine Test-Funktion, denn der Typ des Arguments ist \texttt{int}
       und nicht \texttt{char*}.
 \end{enumerate}
-Um das Halte-Problem übersichtlicher formulieren zu können, führen wir noch drei
-zusätzliche Notationen ein.
+Um das Halte-Problem \"ubersichtlicher formulieren zu k\"onnen, f\"uhren wir noch drei
+zus\"atzliche Notationen ein.
 \begin{Definition}[$\leadsto$, $\downarrow$, $\uparrow$]
 {\em
 Ist $n$ der Name einer \texttt{C}-Funktion und sind $a_1$, $\cdots$, $a_k$ Argumente, die
@@ -69,31 +69,31 @@ die Definition des Begriffs der Test-Funktion gegeben haben, so gilt:
 \end{enumerate}
 
 \noindent
-Das \emph{Halte-Problem} für \texttt{C} ist die Frage, ob es eine \texttt{C}-Funktion \\[0.1cm]
+Das \emph{Halte-Problem} f\"ur \texttt{C} ist die Frage, ob es eine \texttt{C}-Funktion \\[0.1cm]
 \hspace*{1.3cm} 
 $\texttt{int stops}(\texttt{char*}\;t,\;\texttt{char*}\;a)\; \{\;\cdots\;\}$ \\[0.1cm]
-gibt, die als Eingabe eine Testfunktion $t$ und einen String $a$ erhält und die folgende
+gibt, die als Eingabe eine Testfunktion $t$ und einen String $a$ erh\"alt und die folgende
 Eigenschaft hat:
 \begin{enumerate}
 \item $t \not\in T\!F \quad\Leftrightarrow\quad \mathtt{stops}(t, a) \leadsto 2$.
 
-      Der Aufruf \texttt{stops($t$, $a$)} liefert genau dann den Wert 2 zurück, 
+      Der Aufruf \texttt{stops($t$, $a$)} liefert genau dann den Wert 2 zur\"uck, 
       wenn $t$ keine Test-Funktion ist.
 
 \item $t \in T\!F \,\wedge\, \mathtt{name}(t) = n \,\wedge\, n(a)\downarrow \quad\Leftrightarrow\quad
        \mathtt{stops}(t, a) \leadsto 1$.
 
-      Der Aufruf \texttt{stops($t$, $a$)} liefert genau dann den Wert 1 zurück,
+      Der Aufruf \texttt{stops($t$, $a$)} liefert genau dann den Wert 1 zur\"uck,
       wenn $t$ eine Test-Funktion mit Namen $n$ ist und der Aufruf $n(a)$ terminiert.
 
 \item $t \in T\!F \,\wedge\, \mathtt{name}(t) = n \,\wedge\, n(a)\uparrow \quad\Leftrightarrow\quad
        \mathtt{stops}(t, a) \leadsto 0$.
 
-      Der Aufruf \texttt{stops($t$, $a$)} liefert genau dann den Wert 0 zurück,
+      Der Aufruf \texttt{stops($t$, $a$)} liefert genau dann den Wert 0 zur\"uck,
       wenn $t$ eine Test-Funktion mit Namen $n$ ist und der Aufruf $n(a)$ \underline{nicht} terminiert.
 \end{enumerate}
 Falls eine \texttt{C}-Funktion \texttt{stops} mit den obigen Eigenschaften existiert, dann
-sagen wir, dass das Halte-Problem für \texttt{C} entscheidbar ist.
+sagen wir, dass das Halte-Problem f\"ur \texttt{C} entscheidbar ist.
 
 \begin{Satz}[Turing, 1936]
 {\em
@@ -102,14 +102,14 @@ sagen wir, dass das Halte-Problem für \texttt{C} entscheidbar ist.
 \end{Satz}
 
 \noindent
-\textbf{Beweis}:  Zunächst eine Vorbemerkung.  Um die Unentscheidbarkeit des
-Halte-Problems nachzuweisen müssen wir zeigen, dass etwas, nämlich eine Funktion mit
-gewissen Eigenschaften nicht existiert.  Wie kann so ein Beweis überhaupt funktionieren?
-Wie können wir überhaupt zeigen, dass irgendetwas nicht existiert?
-Die einzige Möglichkeit zu zeigen, dass etwas nicht existiert ist indirekt:
-Wir nehmen also an, dass eine Funktion \texttt{stops} existiert, die das Halte-Problem löst.
+\textbf{Beweis}:  Zun\"achst eine Vorbemerkung.  Um die Unentscheidbarkeit des
+Halte-Problems nachzuweisen m\"ussen wir zeigen, dass etwas, n\"amlich eine Funktion mit
+gewissen Eigenschaften nicht existiert.  Wie kann so ein Beweis \"uberhaupt funktionieren?
+Wie k\"onnen wir \"uberhaupt zeigen, dass irgendetwas nicht existiert?
+Die einzige M\"oglichkeit zu zeigen, dass etwas nicht existiert ist indirekt:
+Wir nehmen also an, dass eine Funktion \texttt{stops} existiert, die das Halte-Problem l\"ost.
 Aus dieser Annahme werden wir dann einen Widerspruch ableiten.  Dieser Widerspruch zeigt
-uns dann, dass eine Funktion \texttt{stops} mit den gewünschten Eigenschaften nicht
+uns dann, dass eine Funktion \texttt{stops} mit den gew\"unschten Eigenschaften nicht
 existieren kann.
 Um zu einem Widerspruch zu kommen, definieren wir den String \textsl{Turing} wie in Abbildung
 \ref{fig:turing-string} gezeigt.
@@ -147,22 +147,22 @@ Mit dieser Definition ist klar, dass \textsl{Turing} eine Test-Funktion mit dem 
 Damit sind wir in der Lage, den String \textsl{Turing} als Eingabe der Funktion \texttt{stops}
 zu verwenden.  Wir betrachten nun den folgenden Aufruf: \\[0.3cm]
 \hspace*{1.3cm} \texttt{stops(\textsl{Turing}, \textsl{Turing})}. \\[0.3cm]
-Offenbar ist \textsl{Turing} eine Test-Funktion.  Daher können nur zwei Fälle auftreten:
+Offenbar ist \textsl{Turing} eine Test-Funktion.  Daher k\"onnen nur zwei F\"alle auftreten:
 \\[0.1cm]
 \hspace*{1.3cm} 
 $\mathtt{stops}(\textsl{Turing}, \textsl{Turing}) \leadsto 0 \quad \vee\quad
  \mathtt{stops}(\textsl{Turing}, \textsl{Turing}) \leadsto 1$. \\[0.1cm]
-Diese beiden Fälle analysieren wir nun im Detail:
+Diese beiden F\"alle analysieren wir nun im Detail:
 \begin{enumerate}
 \item $\mathtt{stops}(\textsl{Turing}, \textsl{Turing}) \leadsto 0$. 
 
       Nach der Spezifikation von \texttt{stops} bedeutet dies \\[0.1cm]
       \hspace*{1.3cm} $\mathtt{turing}(\textsl{Turing}) \uparrow$ \\[0.1cm]
       Schauen wir nun, was wirklich beim Aufruf \texttt{turing(\textsl{Turing})} passiert:
-      In Zeile 3 erhält die Variable \texttt{result} den Wert 0 zugewiesen.  In Zeile 4
-      wird dann getestet, ob \texttt{result} den Wert 1 hat.  Dieser Test schlägt fehl.
-      Daher wird der Block der \texttt{if}-Anweisung nicht ausgeführt und die Funktion liefert als
-      nächstes in Zeile 9 den Wert 0 zurück.  Insbesondere terminiert der Aufruf also, im
+      In Zeile 3 erh\"alt die Variable \texttt{result} den Wert 0 zugewiesen.  In Zeile 4
+      wird dann getestet, ob \texttt{result} den Wert 1 hat.  Dieser Test schl\"agt fehl.
+      Daher wird der Block der \texttt{if}-Anweisung nicht ausgef\"uhrt und die Funktion liefert als
+      n\"achstes in Zeile 9 den Wert 0 zur\"uck.  Insbesondere terminiert der Aufruf also, im
       Widerspruch zu dem, was die Funktion \texttt{stops} behauptet hat.
 
       Damit ist der erste Fall ausgeschlossen.
@@ -172,49 +172,49 @@ Diese beiden Fälle analysieren wir nun im Detail:
       $\mathtt{turing}(\textsl{Turing})$ terminiert: \\[0.1cm]
       \hspace*{1.3cm} $\mathtt{turing}(\textsl{Turing}) \downarrow$ \\[0.1cm]
       Schauen wir nun, was wirklich beim Aufruf \texttt{turing(\textsl{Turing})} passiert:
-      In Zeile 3 erhält die Variable \texttt{result} den Wert 1 zugewiesen.  In Zeile 4
+      In Zeile 3 erh\"alt die Variable \texttt{result} den Wert 1 zugewiesen.  In Zeile 4
       wird dann getestet, ob \texttt{result} den Wert 1 hat.  Diesmal gelingt der Test.
-      Daher wird der Block der \texttt{if}-Anweisung ausgeführt.  Dieser Block
-      besteht aber nur aus einer Endlos-Schleife, aus der wir nie wieder zurück kommen.
+      Daher wird der Block der \texttt{if}-Anweisung ausgef\"uhrt.  Dieser Block
+      besteht aber nur aus einer Endlos-Schleife, aus der wir nie wieder zur\"uck kommen.
       Das steht im Widerspruch zu dem, was die Funktion \texttt{stops} behauptet hat.
 
       Damit ist der zweite Fall ausgeschlossen.
 \end{enumerate}
 Insgesamt haben wir also in jedem Fall einen Widerspruch erhalten.  
 Also ist die Annahme, dass die \texttt{C}-Funktion \texttt{stops}
-das Halte-Problem löst, falsch.  Insgesamt haben wir gezeigt, dass es keine \texttt{C}-Funktion
-geben kann, die das Halte-Problem löst. \hspace*{\fill} $\Box$
+das Halte-Problem l\"ost, falsch.  Insgesamt haben wir gezeigt, dass es keine \texttt{C}-Funktion
+geben kann, die das Halte-Problem l\"ost. \hspace*{\fill} $\Box$
 
 \noindent
-Der Nachweis, dass das Halte-Problem unlösbar ist, wurde 1936 von Alan Turing (1912 -- 1954)
+Der Nachweis, dass das Halte-Problem unl\"osbar ist, wurde 1936 von Alan Turing (1912 -- 1954)
 \cite{turing:36} erbracht.
 \vspace*{0.3cm}
 
-An dieser Stelle können wir uns fragen, ob es vielleicht eine andere Programmier-Sprache
-gibt, in der wir das Halte-Problem dann vielleicht doch lösen könnten.  
+An dieser Stelle k\"onnen wir uns fragen, ob es vielleicht eine andere Programmier-Sprache
+gibt, in der wir das Halte-Problem dann vielleicht doch l\"osen k\"onnten.  
 Wenn es in dieses Programmier-Sprache Unterprogramme gibt, und wenn wir dort
-Programm-Texte als Argumente von Funktionen übergeben können, dann ist leicht zu sehen,
+Programm-Texte als Argumente von Funktionen \"ubergeben k\"onnen, dann ist leicht zu sehen,
 dass der obige Beweis der 
-Unlösbarkeit des Halte-Problems sich durch geeignete syntaktische Modifikationen auch auf
-die andere Programmier-Sprache übertragen lässt.
+Unl\"osbarkeit des Halte-Problems sich durch geeignete syntaktische Modifikationen auch auf
+die andere Programmier-Sprache \"ubertragen l\"asst.
 \vspace*{0.3cm}
 
 \noindent
 \textbf{Aufgabe 1}:  
-Wir nennen eine Menge $X$ \emph{abzählbar}, wenn  es eine Funktion \\[0.1cm]
+Wir nennen eine Menge $X$ \emph{abz\"ahlbar}, wenn  es eine Funktion \\[0.1cm]
 \hspace*{1.3cm} $f: \mathbb{N} \rightarrow X$ \\[0.1cm]
-gibt, so dass es für alle $x\in X$ ein $n \in \mathbb{N}$ gibt, so dass $x$ das Bild von
+gibt, so dass es f\"ur alle $x\in X$ ein $n \in \mathbb{N}$ gibt, so dass $x$ das Bild von
 $n$ unter $f$ ist: \\[0.1cm]
 \hspace*{1.3cm} $\forall x \in X: \exists n \in \mathbb{N}: x = f(n)$.
 \\[0.1cm]
-Zeigen Sie, dass die Potenz-Menge $2^\mathbb{N}$ der natürlichen Zahlen $\mathbb{N}$ 
-nicht abzählbar ist.  
+Zeigen Sie, dass die Potenz-Menge $2^\mathbb{N}$ der nat\"urlichen Zahlen $\mathbb{N}$ 
+nicht abz\"ahlbar ist.  
 \vspace*{0.1cm}
 
 \noindent
-\textbf{Hinweis}: Gehen Sie ähnlich vor wie beim Beweis der Unlösbarkeit des
-Halte-Problems.  Nehmen Sie an, es gäbe eine Funktion $f$, die die Teilmengen von
-$\mathbb{N}$ aufzählt: \\[0.1cm]
+\textbf{Hinweis}: Gehen Sie \"ahnlich vor wie beim Beweis der Unl\"osbarkeit des
+Halte-Problems.  Nehmen Sie an, es g\"abe eine Funktion $f$, die die Teilmengen von
+$\mathbb{N}$ aufz\"ahlt: \\[0.1cm]
 \hspace*{1.3cm}  $\forall x \in 2^\mathbb{N}: \exists n \in \mathbb{N}: x = f(n)$.
 \\[0.1cm]
 Definieren Sie eine Menge \texttt{Cantor} wie folgt:
@@ -224,39 +224,39 @@ Definieren Sie eine Menge \texttt{Cantor} wie folgt:
 Versuchen Sie nun, einen Widerspruch herzuleiten.
 
 
-\section{Das Äquivalenz-Problem}
+\section{Das \"Aquivalenz-Problem}
 Es gibt noch eine ganze Reihe anderer Funktionen, die nicht berechenbar sind.  In der
-Regel werden wir den Nachweis, dass eine bestimmt Funktion nicht berechenbar ist, dadurch führen, dass
-wir zunächst annehmen, dass die gesuchte Funktion doch implementierbar ist.  Unter dieser Annahme
-konstruieren wir dann eine Funktion, die das Halte-Problem löst, was im Widerspruch zu dem am Anfang dieses Abschnitts
+Regel werden wir den Nachweis, dass eine bestimmt Funktion nicht berechenbar ist, dadurch f\"uhren, dass
+wir zun\"achst annehmen, dass die gesuchte Funktion doch implementierbar ist.  Unter dieser Annahme
+konstruieren wir dann eine Funktion, die das Halte-Problem l\"ost, was im Widerspruch zu dem am Anfang dieses Abschnitts
 bewiesen Sachverhalts steht.
 Dieser Widerspruch zwingt uns zu der Folgerung, dass die gesuchte Funktion nicht implementierbar ist.
-Wir werden dieses Verfahren an einem Beispiel demonstrieren. Vorweg benötigen wir aber
+Wir werden dieses Verfahren an einem Beispiel demonstrieren. Vorweg ben\"otigen wir aber
 noch eine Definition.
 
 \begin{Definition}[$\simeq$] 
 {\em 
 Es seien $n_1$ und $n_2$ Namen zweier \texttt{C}-Funktionen und
-  $a_1$, $\cdots$, $a_k$ seien Argumente, mit denen wir diese Funktionen füttern können. Wir definieren \\[0.1cm]
+  $a_1$, $\cdots$, $a_k$ seien Argumente, mit denen wir diese Funktionen f\"uttern k\"onnen. Wir definieren \\[0.1cm]
 \hspace*{1.3cm} $n_1(a_1,\cdots,a_k) \simeq n_2(a_1,\cdots,a_k)$ \\[0.1cm]
-g.d.w. einer der beiden folgen Fälle auftritt:
+g.d.w. einer der beiden folgen F\"alle auftritt:
 \begin{enumerate}
 \item $n_1(a_1,\cdots,a_k)\uparrow \quad\wedge\quad n_2(a_1,\cdots,a_k)\uparrow$
 \item $\exists r: \Bigl(n_1(a_1,\cdots,a_k) \leadsto r \quad\wedge\quad n_2(a_1,\cdots,a_k) \leadsto r\Bigr)$
 
       In diesem Fall sagen wir, dass die beiden Funktions-Aufrufe 
-      $n_1(a_1,\cdots,a_k) \simeq n_2(a_1,\cdots,a_k)$ \emph{partiell äquivalent} sind.
+      $n_1(a_1,\cdots,a_k) \simeq n_2(a_1,\cdots,a_k)$ \emph{partiell \"aquivalent} sind.
       \hspace*{\fill} $\Box$
 \end{enumerate}}
 \end{Definition}
 
 \noindent
-Wir kommen jetzt zum \emph{Äquivalenz-Problem}.  Die Funktion $f$ mit
+Wir kommen jetzt zum \emph{\"Aquivalenz-Problem}.  Die Funktion $f$ mit
 \\[0.2cm]
 \hspace*{1.3cm}
 $f = \texttt{int equal(char* p1, char* p2, char* a) \{ ... \}}$
 \\[0.2cm]
-möge folgender Spezifikation genügen:
+m\"oge folgender Spezifikation gen\"ugen:
 \begin{enumerate}
 \item $p_1 \not\in T\!F \;\vee\; p_2 \not\in T\!F \quad\Leftrightarrow\quad \mathtt{equal}(p_1, p_2, a) \leadsto 2$.
 \item Falls 
@@ -270,18 +270,18 @@ möge folgender Spezifikation genügen:
 \item Ansonsten gilt \\[0.1cm]
       \hspace*{1.3cm} $\mathtt{equal}(p_1, p_2, a) \leadsto 0$.
 \end{enumerate}
-Wir sagen, dass eine Funktion, die der eben angegebenen Spezifikation genügt, das
-\emph{Äquivalenz-Problem} löst.
+Wir sagen, dass eine Funktion, die der eben angegebenen Spezifikation gen\"ugt, das
+\emph{\"Aquivalenz-Problem} l\"ost.
 
 \begin{Satz}[Rice]
-Das Äquivalenz-Problem ist unlösbar.  
+Das \"Aquivalenz-Problem ist unl\"osbar.  
 \end{Satz}
 
 \noindent
 \textbf{Beweis}:
-Wir führen den Beweis indirekt und nehmen
+Wir f\"uhren den Beweis indirekt und nehmen
 an, dass es doch eine Implementierung der Funktion \texttt{equal} gibt, die das
-Äquivalenz-Problem löst.  Wir betrachten die in Abbildung 
+\"Aquivalenz-Problem l\"ost.  Wir betrachten die in Abbildung 
 \ref{fig:stops} angegeben Implementierung der Funktion \texttt{stops}.
 
 
@@ -319,37 +319,37 @@ folgende Form:
 \begin{verbatim}
       int loop(char* x) { while (1) { ++x; } }
 \end{verbatim}
-Es ist offensichtlich, dass die Funktion \texttt{loop} für kein Ergebnis terminiert.
+Es ist offensichtlich, dass die Funktion \texttt{loop} f\"ur kein Ergebnis terminiert.
 Ist also das Argument $p$ eine Test-Funktion mit Namen $n$, so liefert die Funktion \texttt{equal} immer dann den Wert 1,
-wenn $n(a)$ nicht terminiert, andernfalls muss sie den Wert 0 zurück geben.
-Damit liefert die Funktion \texttt{stops} aber für eine Test-Funktion $p$ mit Namen $n$ und ein Argument
-$a$ genau dann 1, wenn der Aufruf $n(a)$ terminiert und würde folglich das Halte-Problem
-lösen.  Das kann nicht sein, also kann es keine Funktion  \texttt{equal}
-geben, die das Äquivalenz-Problem löst. 
+wenn $n(a)$ nicht terminiert, andernfalls muss sie den Wert 0 zur\"uck geben.
+Damit liefert die Funktion \texttt{stops} aber f\"ur eine Test-Funktion $p$ mit Namen $n$ und ein Argument
+$a$ genau dann 1, wenn der Aufruf $n(a)$ terminiert und w\"urde folglich das Halte-Problem
+l\"osen.  Das kann nicht sein, also kann es keine Funktion  \texttt{equal}
+geben, die das \"Aquivalenz-Problem l\"ost. 
 \qed
 \vspace*{0.3cm}
 
 \noindent
-Die Unlösbarkeit des Äquivalenz-Problems und vieler weiterer praktisch interessanter
+Die Unl\"osbarkeit des \"Aquivalenz-Problems und vieler weiterer praktisch interessanter
 Problem folgen aus einem 1953 von Henry G.~Rice \cite{rice:53} bewiesenen Satz.
 
-\section{Weitere unlösbare Probleme}
-Es gibt eine Reihe von Problemen in der Theorie der formalen Sprachen, die unlösbar sind.
-Wir listen examplarisch die wichtigsten unlösbaren Probleme aus dem Bereich der formalen
-Sprachen aufgelistet und verweisen für eine ausführlichere Liste auf das Buch von
+\section{Weitere unl\"osbare Probleme}
+Es gibt eine Reihe von Problemen in der Theorie der formalen Sprachen, die unl\"osbar sind.
+Wir listen examplarisch die wichtigsten unl\"osbaren Probleme aus dem Bereich der formalen
+Sprachen aufgelistet und verweisen f\"ur eine ausf\"uhrlichere Liste auf das Buch von
 Hopfcroft, Motwani und Ullman \cite{hopcroft:06}.
 \begin{enumerate}
-\item Für eine gegebene kontextfreie Grammatik $G$ ist die Frage, ob es zu jedem
-      String $s \in L(G)$ genau einen Parse-Baum für $s$ gibt, unentscheidbar.  Für können
+\item F\"ur eine gegebene kontextfreie Grammatik $G$ ist die Frage, ob es zu jedem
+      String $s \in L(G)$ genau einen Parse-Baum f\"ur $s$ gibt, unentscheidbar.  F\"ur k\"onnen
       also nicht entscheiden, ob eine Grammatik mehrdeutig ist.
-\item Für zwei gegeben kontextfreie Grammatiken $G_1$ und $G_2$ ist die Frage, ob
+\item F\"ur zwei gegeben kontextfreie Grammatiken $G_1$ und $G_2$ ist die Frage, ob
       diese Grammatiken dieselbe Sprache beschreiben, ob also
       \\[0.2cm]
       \hspace*{1.3cm}
       $L(G_1) = L(G_2)$
       \\[0.2cm]
       gilt, ist unentscheidbar.
-\item Ebenso ist für zwei kontextfreie Grammatiken $G_1$ und $G_2$ die Frage,
+\item Ebenso ist f\"ur zwei kontextfreie Grammatiken $G_1$ und $G_2$ die Frage,
       ob 
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -358,24 +358,24 @@ Hopfcroft, Motwani und Ullman \cite{hopcroft:06}.
       gilt, unentscheidbar.
 \end{enumerate}
 Der Beweis der Unentscheidbarkeit der oben genannten Probleme wird aus das
-\emph{Post'sche Korrespondenz-Problem} zurück geführt, dass wir jetzt wenigstens
+\emph{Post'sche Korrespondenz-Problem} zur\"uck gef\"uhrt, dass wir jetzt wenigstens
 formulieren wollen.
 
 \begin{Definition}[Post'sche Korrespondenz-Problem]
 Gegen sei ein Alphabet $\Sigma$ sowie zwei Listen $l_1$ und $l_2$ von Strings aus
-$\Sigma^*$, die beide dieselbe Länge $n$ haben:
+$\Sigma^*$, die beide dieselbe L\"ange $n$ haben:
 \\[0.2cm]
 \hspace*{1.3cm}
-$l_1 = [X_1, \cdots, X_n]$ \quad mit $X_i \in \Sigma^*$ für $i=1,\cdots,n$ \quad und
+$l_1 = [X_1, \cdots, X_n]$ \quad mit $X_i \in \Sigma^*$ f\"ur $i=1,\cdots,n$ \quad und
 \\[0.2cm]
 \hspace*{1.3cm}
-$l_2 = [Y_1, \cdots, Y_n]\;$ \quad mit $Y_i \in \Sigma^*$ für $i=1,\cdots,n$.w
+$l_2 = [Y_1, \cdots, Y_n]\;$ \quad mit $Y_i \in \Sigma^*$ f\"ur $i=1,\cdots,n$.w
 \\[0.2cm]
 Dann nennen wir das Paar $\pair(l_1, l_2)$ eine \emph{Instanz des Post'schen Korrespondenz-Problems}.
 \vspace*{0.2cm}
 
 \noindent  
-Eine Liste $[k_1, k_2, \cdots, k_m]$ von positiven natürlichen Zahlen ist eine Lösung des Post'schen Korrespondenz-Problems
+Eine Liste $[k_1, k_2, \cdots, k_m]$ von positiven nat\"urlichen Zahlen ist eine L\"osung des Post'schen Korrespondenz-Problems
 \\[0.2cm]
 \hspace*{1.3cm}
 $\pair([X_1, \cdots, X_n], [Y_1, \cdots, Y_n])$
@@ -395,7 +395,7 @@ Wir setzen $\Sigma = \{ \mathtt{a}, \mathtt{b}\}$ und definieren
 $P = \pair([\quoted{b}, \quoted{babbb}, \quoted{ba} ], [\quoted{bbb}, \quoted{ba}, \quoted{a}])$.
 \\[0.2cm]
 Dann ist $P$ eine Instanz des Post'schen Korrespondenz-Problems.   $P$ hat
-die  Lösung
+die  L\"osung
 \\[0.2cm]
 \hspace*{1.3cm}
 $L = [2,1,1,3]$,
@@ -413,22 +413,22 @@ $\quoted{babbb} + \quoted{b} + \quoted{b} + \quoted{ba} =
 
 \noindent
 \textbf{Beweis-Idee}:  Der Beweis des Post'schen Korrespondenz-Problems kann auf die
-Unentscheidbarkeit des Halte-Problems zurück geführt werden.  Dazu müssen allerdings erst
-\emph{Turing-Maschinen} eingeführt werden sowie eine Notation, um diese  programmieren.  
+Unentscheidbarkeit des Halte-Problems zur\"uck gef\"uhrt werden.  Dazu m\"ussen allerdings erst
+\emph{Turing-Maschinen} eingef\"uhrt werden sowie eine Notation, um diese  programmieren.  
 Bei den Turing-Maschinen handelt es sich um ein sehr einfaches
-Maschinen-Konzept.  Es lässt sich jdoch zeigen, dass Programme für Turing-Maschinen
-prinzipiell genau so leistungsfähig sind, wie \texttt{C-Programme}:
-Alles das, was wir mit einem \texttt{C}-Programm berechnen können, lässt sich auch mit
+Maschinen-Konzept.  Es l\"asst sich jdoch zeigen, dass Programme f\"ur Turing-Maschinen
+prinzipiell genau so leistungsf\"ahig sind, wie \texttt{C-Programme}:
+Alles das, was wir mit einem \texttt{C}-Programm berechnen k\"onnen, l\"asst sich auch mit
 einer Turing-Maschine berechnen.
 
-Weiter wird dann gezeigt, dass sich die Lösbarkeit des Halte-Problems für Turing-Maschinen
-in ein Post'sches Korrespondenz-Problem übersetzen lässt.  Könnten wir nun das Post'sche
-Korrespondenz-Problem lösen, so könnten wir auch das Halte-Problem für Turing-Maschinen
-lösen und damit dann auch das Halte-Problem für \texttt{C}-Funktionen.
+Weiter wird dann gezeigt, dass sich die L\"osbarkeit des Halte-Problems f\"ur Turing-Maschinen
+in ein Post'sches Korrespondenz-Problem \"ubersetzen l\"asst.  K\"onnten wir nun das Post'sche
+Korrespondenz-Problem l\"osen, so k\"onnten wir auch das Halte-Problem f\"ur Turing-Maschinen
+l\"osen und damit dann auch das Halte-Problem f\"ur \texttt{C}-Funktionen.
 
 Die Detailierung der obigen Beweis-Skizze kann in dem Buch von Hopfcroft
-\cite{hopcroft:06} nachgelesen werden.  Aufgrund seiner Komplexität geht der detailierte 
- Beweis aber weit über den Rahmen der Vorlesung heraus.
+\cite{hopcroft:06} nachgelesen werden.  Aufgrund seiner Komplexit\"at geht der detailierte 
+ Beweis aber weit \"uber den Rahmen der Vorlesung heraus.
 \qed
 
 

--- a/Lecture-Notes/interpreter.tex
+++ b/Lecture-Notes/interpreter.tex
@@ -44,19 +44,19 @@
     WS            : [ \t\v\n\r]   -> skip; 
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{\textsc{Antlr}-Grammatik für eine einfache Programmier-Sprache.}
+\caption{\textsc{Antlr}-Grammatik f\"ur eine einfache Programmier-Sprache.}
 \label{fig:Pure.g4}
 \end{figure}
 
 In diesem Kapitels erstellen wir mit Hilfe des Parser-Generators \textsc{Antlr} einen
-Interpreter für eine einfache Programmiersprache.  Erfreulicherweise akzeptiert
+Interpreter f\"ur eine einfache Programmiersprache.  Erfreulicherweise akzeptiert
 \textsc{Antlr} seit der Version \texttt{4.0} auch Grammatiken, die einfache Links-Rekursion
 enthalten.  Auch eine Links-Faktorisierung der Grammatik ist nicht mehr notwendig.
-Abbildung \ref{fig:Pure.g4} zeigt die \textsc{Antlr}-Grammatik der Programmier-Sprache, für die wir
+Abbildung \ref{fig:Pure.g4} zeigt die \textsc{Antlr}-Grammatik der Programmier-Sprache, f\"ur die wir
 in diesem Abschnitt einen Interpreter entwickeln.  Die Befehle dieser Sprache sind Zuweisungen, Print-Befehle,
 \texttt{if}-Abfragen, sowie \texttt{while}-Schleifen.  Abbildung \ref{fig:sum.sl} zeigt
-ein Beispiel-Programm, das dieser Grammatik entspricht.  Dieses Programm liest zunächst eine Zahl
-ein, die in der Variablen \texttt{n} gespeichert wird.  Anschließend wird die Summe
+ein Beispiel-Programm, das dieser Grammatik entspricht.  Dieses Programm liest zun\"achst eine Zahl
+ein, die in der Variablen \texttt{n} gespeichert wird.  Anschlie{\ss}end wird die Summe
 \\[0.2cm]
 \hspace*{1.3cm}
 $\sum\limits_{i=1}^{n^2} i$
@@ -90,19 +90,19 @@ in der Variablen \texttt{s} akkumuliert und am Ende des Programms ausgegeben.
 
 
 
-Um einen Interpreter für diese Sprache entwickeln zu können, benötigen wir
-zunächst Klassen, mit denen wir die einzelnen Befehle darstellen können.
+Um einen Interpreter f\"ur diese Sprache entwickeln zu k\"onnen, ben\"otigen wir
+zun\"achst Klassen, mit denen wir die einzelnen Befehle darstellen k\"onnen.
 Wir beginnen mit der abstrakten Klasse \texttt{Statement}.  Diese Klasse ist in Abbildung
 \ref{fig:Statement.java} gezeigt und dient dazu,
 Anweisungen unserer Programmier-Sprache darzustellen.
-Wir werden von der Klasse \texttt{Statement} später die Klassen
+Wir werden von der Klasse \texttt{Statement} sp\"ater die Klassen
 \texttt{Assignment}, \texttt{Print}, \texttt{IfThen} und \texttt{While} ableiten.
-Die Klasse \texttt{Statement} ist selber abstrakt und enthält 
+Die Klasse \texttt{Statement} ist selber abstrakt und enth\"alt 
 im wesentlichen die Deklaration der abstrakten Methode $\texttt{execute}()$.  Diese Methode
-können wir später benutzen, um einen Befehle ausführen.
-Zusätzlich speichern wir hier das Flag \texttt{isInteractive} als statische Variable.  Mit
+k\"onnen wir sp\"ater benutzen, um einen Befehle ausf\"uhren.
+Zus\"atzlich speichern wir hier das Flag \texttt{isInteractive} als statische Variable.  Mit
 diesem Flag steuern wir, ob der Interpreter interaktiv in einer Kommandozeile betrieben
-wird, oder ob im Batch-Modus eine Datei abgearbeitet werden soll.  Außerdem haben wir in der
+wird, oder ob im Batch-Modus eine Datei abgearbeitet werden soll.  Au{\ss}erdem haben wir in der
 Klasse \texttt{Statement} noch die statische Methode $\texttt{prompt}()$.  Diese wird nur
 dann benutzt, wenn der Interpreter interaktiv von der Kommandozeile aus betrieben wird.
 In diesem Fall gibt die Methode den folgenden Prompt aus:
@@ -186,13 +186,13 @@ Ausdruck zu speichern.
 \item Die zweite Member-Variable ist \texttt{mRhs}.  Hier wird der arithmetische Ausdruck,
       der auf der rechten Seite des Zuweisungs-Operators steht, kodiert.  Diese
       Member-Variable hat den Typ \texttt{Expr}.  Hierbei handelt es sich um eine
-      abstrakte Klasse zur Darstellung arithmetischer Ausdrücke, von der wir später
+      abstrakte Klasse zur Darstellung arithmetischer Ausdr\"ucke, von der wir sp\"ater
       konkrete Klassen ableiten.  Diese Klasse besitzt eine abstrakte Methode
       $\texttt{eval}()$, mit der ein arithmetischer Ausdruck ausgewertet werden kann.
 \end{enumerate}
 In der Klasse \texttt{Assignment} wertet die Methode $\texttt{execute}()$ den Ausdruck,
-der in der Variablen \texttt{mRhs} gespeichert wird, mit Hilfe  der für Objekte der Klasse
-\texttt{Expr} zur Verfügung stehenden 
+der in der Variablen \texttt{mRhs} gespeichert wird, mit Hilfe  der f\"ur Objekte der Klasse
+\texttt{Expr} zur Verf\"ugung stehenden 
 Methode $\texttt{eval}()$ aus und speichert den erhaltenen Wert in der Hashtabelle
 \texttt{sValueTable} unter dem Namen der Variablen ab. 
 Es handelt sich bei dieser Tabelle um eine sogenannte \emph{Symboltabelle}, in der die
@@ -239,10 +239,10 @@ Abbildung \ref{fig:Read.java} zeigt die Implementierung der Klasse \texttt{Read}
 \\[0.2cm]
 dar.  Daher besitzt diese Klasse eine Member-Variable \texttt{mVar}, in welcher das Ergebnis
 der Lese-Operation abgespeichert wird.  
-Die Methode $\texttt{execute}()$ gibt zunächst den String ``\texttt{> }'' als
-Eingabe-Aufforderung aus.  Anschließend wird ein Objekt der in \textsl{Java}
+Die Methode $\texttt{execute}()$ gibt zun\"achst den String ``\texttt{> }'' als
+Eingabe-Aufforderung aus.  Anschlie{\ss}end wird ein Objekt der in \textsl{Java}
 vordefinierten Klasse \texttt{Scanner} erzeugt.  Diese Klasse stellt die Methode
-$\texttt{nextDouble}()$ zur Verfügung, mit deren Hilfe eine Fließkomma-Zahl eingelesen
+$\texttt{nextDouble}()$ zur Verf\"ugung, mit deren Hilfe eine Flie{\ss}komma-Zahl eingelesen
 werden kann.  Diese wird dann in der Symboltabelle unter dem Namen der Variablen,
 der auf der linken Seite der Zuweisung steht, abgespeichert.
 
@@ -285,17 +285,17 @@ der auf der linken Seite der Zuweisung steht, abgespeichert.
 
 
 
-Von den übrigen Klassen zur Darstellung von Befehlen diskutieren wir noch die Klasse
+Von den \"ubrigen Klassen zur Darstellung von Befehlen diskutieren wir noch die Klasse
 \texttt{While}, die in Abbildung \ref{fig:While.java} gezeigt wird.
 Diese Klasse stellt einen Befehl der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\mathtt{while}\;(b)\; \{ \;\textsl{stmnts}\; \}$
 \\[0.2cm]
-dar, wobei $b$ ein Boole'scher Ausdruck ist, während \textsl{stmnts} eine Liste von Befehlen 
+dar, wobei $b$ ein Boole'scher Ausdruck ist, w\"ahrend \textsl{stmnts} eine Liste von Befehlen 
 ist.  Der Boole'sche Ausdruck wird in der Member-Variablen \texttt{mCond} gespeichert, die Liste von
 Befehlen findet sich in der Member-Variablen \texttt{mStmntList}.  Zur Auswertung eines solchen
-Befehls führen wir solange alle Befehle in der Liste \texttt{mStmntList} aus, wie die Auswertung des
+Befehls f\"uhren wir solange alle Befehle in der Liste \texttt{mStmntList} aus, wie die Auswertung des
 Boole'schen Ausdrucks $b$ den Wert \texttt{true} ergibt.
 
 
@@ -331,24 +331,24 @@ Boole'schen Ausdrucks $b$ den Wert \texttt{true} ergibt.
 \end{figure}
 
 \pagebreak
-Die abstrakte Klasse \texttt{BoolExpr} dient zur Darstellung Boole'scher Ausdrücke.  In unserem Fall
-sind das Ausdrücke der Form
+Die abstrakte Klasse \texttt{BoolExpr} dient zur Darstellung Boole'scher Ausdr\"ucke.  In unserem Fall
+sind das Ausdr\"ucke der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $l \;\texttt{==}\; r$ \quad und \quad $l < r$,
 \\[0.2cm]
-wobei Gleichungen durch die Klasse \texttt{Equal} dargestellt werden, während Ungleichungen durch die
+wobei Gleichungen durch die Klasse \texttt{Equal} dargestellt werden, w\"ahrend Ungleichungen durch die
 Klasse \texttt{LessThan} dargestelt werden, die beide von der Klasse \texttt{BoolExpr} abgeleitet
 sind.  Abbildung \ref{fig:BoolExpr.java} zeigt die Klassen \texttt{BoolExpr} und \texttt{Equal}.
 Die Klasse \texttt{BoolExpr} hat die beiden Member-Variablen \texttt{mLhs} und
-\texttt{mRhs} und repräsentiert die Gleichung
+\texttt{mRhs} und repr\"asentiert die Gleichung
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{mLhs == mRhs}.
 \\[0.2cm]
 Um diese Gleichung auszuwerten, werden rekursiv die linke und die rechte Seite der
 Gleichung, die in \texttt{mLhs} und \texttt{mRhs} gespeichert sind, ausgewertet.
-Anschließend wird das Ergebnis dieser Auswertung zurück gegeben.
+Anschlie{\ss}end wird das Ergebnis dieser Auswertung zur\"uck gegeben.
 Die Klasse \texttt{LessThan} ist analog zur Klasse \texttt{Equal} aufgebaut und wird daher nicht
 gezeigt.
 
@@ -376,12 +376,12 @@ gezeigt.
 \end{figure}
 
  
-Schließlich haben wir noch die Klassen, die zur Repräsentation von arithmetischen Ausdrücken
-benötigt werden.   Diese Klassen werden alle von der abstrakten Klasse \texttt{Expr} abgeleitet, die
+Schlie{\ss}lich haben wir noch die Klassen, die zur Repr\"asentation von arithmetischen Ausdr\"ucken
+ben\"otigt werden.   Diese Klassen werden alle von der abstrakten Klasse \texttt{Expr} abgeleitet, die
 in Abbildung \ref{fig:Expr.java} gezeigt ist.  
 \begin{enumerate}
 \item Die Klasse \texttt{Expr} definiert die statische Variable \texttt{sValueTable}.  Diese Variable
-      beinhaltet eine Hash\-tabelle, in der für jede Variable, der ein Wert zugewiesen wurde,
+      beinhaltet eine Hash\-tabelle, in der f\"ur jede Variable, der ein Wert zugewiesen wurde,
       der aktuelle Wert dieser Variablen gespeichert ist.
 \item Weiter deklariert die Klasse die abstrakte Methode $\texttt{eval}()$, mit der ein
       Ausdruck ausgewertet 
@@ -459,7 +459,7 @@ daher nicht weiter diskutiert.
 
 Abbildung \ref{fig:Variable2.java} zeigt die Implementierung der Klasse \texttt{Variable}.  Die
 Methode $\texttt{eval}()$ wertet eine Variable dadurch aus, dass sie unter dem Namen der Variablen
-in der Hashtabelle \texttt{sValueTable} den zugeordneten Wert nachschlägt.
+in der Hashtabelle \texttt{sValueTable} den zugeordneten Wert nachschl\"agt.
 
 \begin{figure}[!ht]
 \centering
@@ -528,7 +528,7 @@ in der Hashtabelle \texttt{sValueTable} den zugeordneten Wert nachschlägt.
 
 
 Abbildung \ref{fig:SLInterpreter.java} zeigt das Treiber-Programm, das den von
-\textsc{Antlr} erzeugten Parser einbindet.  Das Programm soll später wahlweise in der Form
+\textsc{Antlr} erzeugten Parser einbindet.  Das Programm soll sp\"ater wahlweise in der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{java} \texttt{SLInterpreter} $\textsl{file}_1$ $\cdots$ $\textsl{file}_n$
@@ -538,22 +538,22 @@ oder einfach als
 \hspace*{1.3cm}
 \texttt{java SLInterpreter}
 \\[0.2cm]
-aufgerufen werden.  Im ersten Fall  bezeichnet $\textsl{file}_i$ für $i=1,\cdots,n$
-jeweils eine Datei, die ein auszuführendes Programm enthält.  Im zweiten Fall, oder
-falls anstelle eines Dateinamens der String ``\texttt{-}'' als Argument übergeben wird,
+aufgerufen werden.  Im ersten Fall  bezeichnet $\textsl{file}_i$ f\"ur $i=1,\cdots,n$
+jeweils eine Datei, die ein auszuf\"uhrendes Programm enth\"alt.  Im zweiten Fall, oder
+falls anstelle eines Dateinamens der String ``\texttt{-}'' als Argument \"ubergeben wird,
 sollen die Befehle statt dessen interaktiv
 eingegeben werden.  Die Methode $\textsl{parseFile}()$ behandelt dabei den Fall,
-dass die Befehle aus einer Datei gelesen werden, während die Methode
-$\texttt{parseInteractive}()$ für den Fall der interaktiven Verarbeitung zuständig ist.
+dass die Befehle aus einer Datei gelesen werden, w\"ahrend die Methode
+$\texttt{parseInteractive}()$ f\"ur den Fall der interaktiven Verarbeitung zust\"andig ist.
 Die in der Methode $\texttt{parseInteractive}()$ verwendete Klasse \texttt{InputReader} wird
-dazu benötigt, um von der Standardeingabe zu lesen und einen
+dazu ben\"otigt, um von der Standardeingabe zu lesen und einen
 \texttt{ANTLRInputStream} zu erzeugen.  Wir werden diese Klasse gleich genauer
 diskutieren.  Sowohl die Methode $\texttt{parseFile}()$ als auch die Methode
 $\texttt{parseInteractive}()$ dienen beide nur dazu, ein Objekt der Klasse
 \texttt{ANTLRInputStream} zu erzeugen.  Im ersten Fall wird dieses Objekt aus der zu
 lesenden Datei erzeugt, im zweiten Fall benutzen wir dazu den noch zu diskutierenden \texttt{InputReader}.
-In beiden Fällen wird schließlich die Methode $\texttt{parseAndExecute}()$ aufgerufen,
-deren Aufgabe es ist, die einzelnen Befehle zu erkennen und auszuführen.
+In beiden F\"allen wird schlie{\ss}lich die Methode $\texttt{parseAndExecute}()$ aufgerufen,
+deren Aufgabe es ist, die einzelnen Befehle zu erkennen und auszuf\"uhren.
 
 
 \begin{figure}[!ht]
@@ -627,18 +627,18 @@ deren Aufgabe es ist, die einzelnen Befehle zu erkennen und auszuführen.
 \noindent
 Abbildung \ref{fig:Simple.g} zeigt die Implementierung des Parsers mit dem
 Werkzeug \textsc{Antlr}.  Der Parser liest in Zeile 8 eine nicht-leere Folge von Befehlen,
-die sofort nach dem Einlesen ausgeführt werden.  Die übrigen Grammatik-Regeln erzeugen
+die sofort nach dem Einlesen ausgef\"uhrt werden.  Die \"ubrigen Grammatik-Regeln erzeugen
 jeweils einen abstrakten Syntax-Baum der erkannten Eingabe.  So liefert beispielsweise die
-Regel für die syntaktische Variable \texttt{statement} als Ergebnis ein Objekt der
-abstrakten Klasse \texttt{Statement} zurück.  Wir diskutieren nur den Fall, dass es sich
-bei dem Statement um eine \texttt{while}-Schleife handelt, denn die anderen Fälle sind
-analog.  Zunächst wird in Zeile 11 in der Variablen \texttt{stmnts} eine leere Liste  von
+Regel f\"ur die syntaktische Variable \texttt{statement} als Ergebnis ein Objekt der
+abstrakten Klasse \texttt{Statement} zur\"uck.  Wir diskutieren nur den Fall, dass es sich
+bei dem Statement um eine \texttt{while}-Schleife handelt, denn die anderen F\"alle sind
+analog.  Zun\"achst wird in Zeile 11 in der Variablen \texttt{stmnts} eine leere Liste  von
 \texttt{Statement}s angelegt. 
-Diese Liste enthält später alle Befehle, die im Rumpf der \texttt{while}-Schleife stehen.
-Anschließend wird in Zeile 21 das Schlüsselwort ``\texttt{while}'' zusammen mit der Bedingung erkannt.
+Diese Liste enth\"alt sp\"ater alle Befehle, die im Rumpf der \texttt{while}-Schleife stehen.
+Anschlie{\ss}end wird in Zeile 21 das Schl\"usselwort ``\texttt{while}'' zusammen mit der Bedingung erkannt.
 Dann werden der Reihe nach alle Befehle, die sich im Rumpf der Schleife befinden, der
-Liste \texttt{stmnts} hinzugefügt.  Nach dem Lesen der schließenden geschweiften Klammer
-wird als Rückgabewert ein Objekt der Klasse \texttt{While} erzeugt und zurückgegeben.
+Liste \texttt{stmnts} hinzugef\"ugt.  Nach dem Lesen der schlie{\ss}enden geschweiften Klammer
+wird als R\"uckgabewert ein Objekt der Klasse \texttt{While} erzeugt und zur\"uckgegeben.
 
 
 \begin{figure}[!ht]
@@ -665,21 +665,21 @@ wird als Rückgabewert ein Objekt der Klasse \texttt{While} erzeugt und zurückgeg
 \end{figure}
 Die Spezifikation der Token ist in Abbildung \ref{fig:Simple-2.g}
 gezeigt.  Der Scanner unterscheidet im wesentlichen zwischen Variablen und Zahlen.
-Variablen beginnen mit einem großen oder kleinen Buchstaben, auf den dann zusätzlich Ziffern und der
-Unterstrich folgen können.  Folgen von Ziffern werden als Zahlen interpretiert.  Enthält eine solche
-Folge mehr als ein Zeichen, so darf die erste Ziffer nicht 0 sein.  Darüber hinaus entfernt der
+Variablen beginnen mit einem gro{\ss}en oder kleinen Buchstaben, auf den dann zus\"atzlich Ziffern und der
+Unterstrich folgen k\"onnen.  Folgen von Ziffern werden als Zahlen interpretiert.  Enth\"alt eine solche
+Folge mehr als ein Zeichen, so darf die erste Ziffer nicht 0 sein.  Dar\"uber hinaus entfernt der
 Scanner Whitespace und Kommentare.  Beachten Sie, dass Whitespace und Kommentare an den
 \texttt{channel}  mit den Namen \texttt{HIDDEN} weitergereicht werden.  Dadurch werden sie vom
-Parser ignoriert, stehen aber noch für Fehlermeldungen zur Verfügung.  Außerdem haben wir bei der
+Parser ignoriert, stehen aber noch f\"ur Fehlermeldungen zur Verf\"ugung.  Au{\ss}erdem haben wir bei der
 Spezifikation von mehrzeiligen Kommentaren die sogenannte \emph{non-greedy}-Version des Operators
 ``\texttt{*}'' benutzt.  Die non-greedy-Version des Operators ``\texttt{*}'' wird als
-``\texttt{*?}'' geschrieben und matched sowenig wie möglich.  Daher steht der reguläre Ausdruck
+``\texttt{*?}'' geschrieben und matched sowenig wie m\"oglich.  Daher steht der regul\"are Ausdruck
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{'/*' .*? '*/'}
 \\[0.2cm]
-für einen String, der mit der Zeichenkette ``\texttt{/*}'', mit der Zeichenkette ``\texttt{*/}''
-endet und außerdem so kurz wie möglich ist.  Dadurch werden in einer Zeile der Form
+f\"ur einen String, der mit der Zeichenkette ``\texttt{/*}'', mit der Zeichenkette ``\texttt{*/}''
+endet und au{\ss}erdem so kurz wie m\"oglich ist.  Dadurch werden in einer Zeile der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{/* Hugo */ i := i + 1; /* Anton */}
@@ -737,40 +737,40 @@ zwei getrennte Kommentare erkannt.
 \end{figure}
 
 Abbildung \ref{fig:InputReader.java} zeigt die Klasse \texttt{InputReader}, die dann benutzt wird,
-wenn der Interpreter interaktiv betrieben wird.  Hier müssen wir uns zunächst überlegen, woran der
-Interpreter erkennen soll, dass der Benutzer ein Kommando eingegeben hat.  Ein Ansatz wäre, dass der
-Parser nach jedem Zeilenumbruch überprüft, ob der Benutzer ein vollständiges Kommando eingegeben
-hat.  Dieser Ansatz scheitert aber daran, dass manche Kommandos sich über mehrere Zeilen
-erstrecken.  Daher wartet der Interpreter darauf, dass nacheinander zwei Zeilenumbrüche eingegeben
+wenn der Interpreter interaktiv betrieben wird.  Hier m\"ussen wir uns zun\"achst \"uberlegen, woran der
+Interpreter erkennen soll, dass der Benutzer ein Kommando eingegeben hat.  Ein Ansatz w\"are, dass der
+Parser nach jedem Zeilenumbruch \"uberpr\"uft, ob der Benutzer ein vollst\"andiges Kommando eingegeben
+hat.  Dieser Ansatz scheitert aber daran, dass manche Kommandos sich \"uber mehrere Zeilen
+erstrecken.  Daher wartet der Interpreter darauf, dass nacheinander zwei Zeilenumbr\"uche eingegeben
 werden.  Dann wird die bis dahin gelesene Eingabe in Zeile 23 in einem Feld von Bytes
-zusammengefasst und als Objekt der Klasse \texttt{ByteArrayInputStream} zurück gegeben.
+zusammengefasst und als Objekt der Klasse \texttt{ByteArrayInputStream} zur\"uck gegeben.
 
 
  \exercise
 \begin{enumerate}
 \renewcommand{\labelenumi}{(\alph{enumi})}
-\item Erweitern Sie den Interpreter so, dass auch der Operator ``\texttt{<=}'' unterstützt wird.
+\item Erweitern Sie den Interpreter so, dass auch der Operator ``\texttt{<=}'' unterst\"utzt wird.
 \item Erweitern Sie den Interpreter um \texttt{for}-Schleifen.
 \item Erweitern Sie den Interpreter um die logischen Operatoren
-      ``\texttt{\&\&}'' für das logische \emph{Und}, ``\texttt{||}'' für das logische \emph{Oder}
-      und ``\texttt{!}'' für die Negation an.  Dabei soll der Operator ``\texttt{!}'' am
-      stärksten und der Operator ``\texttt{||}'' am schwächsten binden.
-\item Erweitern Sie die Syntax der arithmetischen Ausdrücke so, dass auch vordefinierte 
+      ``\texttt{\&\&}'' f\"ur das logische \emph{Und}, ``\texttt{||}'' f\"ur das logische \emph{Oder}
+      und ``\texttt{!}'' f\"ur die Negation an.  Dabei soll der Operator ``\texttt{!}'' am
+      st\"arksten und der Operator ``\texttt{||}'' am schw\"achsten binden.
+\item Erweitern Sie die Syntax der arithmetischen Ausdr\"ucke so, dass auch vordefinierte 
       mathematische Funktionen wie $\texttt{exp}()$ oder $\texttt{ln}()$ benutzt werden
-      können.
+      k\"onnen.
 
       \textbf{Hinweis}:  Wenn Sie das Paket \texttt{java.lang.reflect} benutzen,
-      kommen Sie mit einer zusätzlichen Klasse aus und können damit alle in
+      kommen Sie mit einer zus\"atzlichen Klasse aus und k\"onnen damit alle in
       \texttt{java.lang.Math} definierten Methoden implementieren.
-\item Erweitern Sie den Interpreter so, dass auch benutzerdefinierte Funktionen möglich
+\item Erweitern Sie den Interpreter so, dass auch benutzerdefinierte Funktionen m\"oglich
       werden. 
       
-      \textbf{Hinweis}: Jetzt müssen Sie zwischen lokalen und globalen Variablen
+      \textbf{Hinweis}: Jetzt m\"ussen Sie zwischen lokalen und globalen Variablen
       unterscheiden.
       Daher reicht es nicht mehr, die Belegungen der Variablen in einer
       global definierten Hashtabelle zu verwalten. \eox
-\item Erweitern Sie den Interpreter so, dass die Verwendung rationaler Zahlen unterstützt wird.
-      Das Ziel dieser Erweiterung ist eine Sprache, mit der Sie Rechnungen ohne Rundungsfehler durchführen können.
+\item Erweitern Sie den Interpreter so, dass die Verwendung rationaler Zahlen unterst\"utzt wird.
+      Das Ziel dieser Erweiterung ist eine Sprache, mit der Sie Rechnungen ohne Rundungsfehler durchf\"uhren k\"onnen.
 \end{enumerate}
 \renewcommand{\labelenumii}{\arabic{enumii}.}
 

--- a/Lecture-Notes/javacc.tex
+++ b/Lecture-Notes/javacc.tex
@@ -1,25 +1,25 @@
 
 \section{\textsl{JavaCC}}
-Die Sprache \texttt{C} ist in vielen Bereichen von der Sprache \textsl{Java}\/ verdrängt
-worden.  Daher ist es nur natürlich, dass auch für \textsl{Java}\/ Scanner-Generatoren
+Die Sprache \texttt{C} ist in vielen Bereichen von der Sprache \textsl{Java}\/ verdr\"angt
+worden.  Daher ist es nur nat\"urlich, dass auch f\"ur \textsl{Java}\/ Scanner-Generatoren
 entwickelt worden sind.  Hier gibt es mittlerweile eine ganze Menge verschiedener
 Werkzeuge.  Von diesen hat das Werkzeuge \textsl{JavaCC}\/ \cite{kodaganallur:2004}
 einen offiziellen Character, weil
 es wie \textsl{Java}\/ von der Firma \textsl{Sun \/Microsystems} entwickelt worden ist und
 \textsl{JavaCC}\/ ein registriertes Warenzeichen der Firma \textsl{Sun}\/ ist.  Daher habe ich
-von den verschiedenen zur Auswahl stehenden Werkzeugen zunächst \textsl{JavaCC}\/ ausgewählt.
+von den verschiedenen zur Auswahl stehenden Werkzeugen zun\"achst \textsl{JavaCC}\/ ausgew\"ahlt.
 
 Eigentlich ist \textsl{JavaCC}\/ mehr als nur ein Scanner-Generator, denn mit
-\textsl{JavaCC}\/ können Sie auch einen Parser erzeugen.  Diesen Aspekt werden wir in
-einem späteren Kapitel noch besprechen.  Zunächst begnügen wir uns aber damit,
+\textsl{JavaCC}\/ k\"onnen Sie auch einen Parser erzeugen.  Diesen Aspekt werden wir in
+einem sp\"ateren Kapitel noch besprechen.  Zun\"achst begn\"ugen wir uns aber damit,
 \textsl{JavaCC}\/ als Scanner-Generator einzusetzen.  
 
 \subsection{Ein Beispiel}
-Wir demonstrieren die Funktionalität von \textsl{JavaCC}\/
+Wir demonstrieren die Funktionalit\"at von \textsl{JavaCC}\/
 anhand des Beispiels der Notenberechnung, wir setzen das Beispiel aus Abbildung
 \ref{fig:noten.l} also nun noch einmal mit \textsl{JavaCC}\/ um.  Abbildung
 \ref{fig:Klausur.jj} zeigt die Datei \texttt{Klausur.jj}, die eine Eingabe-Spezifikation
-für das Werkzeug \textsl{JavaCC}\/ ist.  
+f\"ur das Werkzeug \textsl{JavaCC}\/ ist.  
 
 
 \begin{figure}[!h]
@@ -78,7 +78,7 @@ für das Werkzeug \textsl{JavaCC}\/ ist.
                       }
                   }
       | <WHITE:   [" ", "\t"]>
-      | <#LETTER: ["a"-"z", "A"-"Z", "ö", "ä", "ü", "Ö", "Ä", "Ü", "ß"]>
+      | <#LETTER: ["a"-"z", "A"-"Z", "\"o", "\"a", "\"u", "\"O", "\"A", "\"U", "{\ss}"]>
     }
 \end{Verbatim}
 \vspace*{-0.3cm}
@@ -86,65 +86,65 @@ für das Werkzeug \textsl{JavaCC}\/ ist.
 \label{fig:Klausur.jj}
 \end{figure}
 
-Eine \textsl{JavaCC}-Eingabe-Spezifikation für einen Scanner besteht aus zwei Teilen:
+Eine \textsl{JavaCC}-Eingabe-Spezifikation f\"ur einen Scanner besteht aus zwei Teilen:
 \begin{enumerate}
-\item Die \emph{Klassen-Definition} wird durch die Schlüsselwörter
+\item Die \emph{Klassen-Definition} wird durch die Schl\"usselw\"orter
       ``\texttt{PARSER\_BEGIN}'' und ``\texttt{PARSER\_END}''
       eingeschlossen.  In der Abbildung erstreckt sich dieser Teil
       von Zeile 1 -- 21.
 \item Die \textsl{Token-\/Definition} definiert verschiedene Tokens durch
-      reguläre Ausdrücke.
-      In unserem Beispiel beginnt sie mit dem Schlüsselwort ``\texttt{TOKEN}''
-      in Zeile 23, dem eine Doppelpunkt und eine öffnende geschweifte Klammer
-      ``\texttt{\{}'' folgt.   Sie endet in Zeile 45 mit der schließenden geschweiften
+      regul\"are Ausdr\"ucke.
+      In unserem Beispiel beginnt sie mit dem Schl\"usselwort ``\texttt{TOKEN}''
+      in Zeile 23, dem eine Doppelpunkt und eine \"offnende geschweifte Klammer
+      ``\texttt{\{}'' folgt.   Sie endet in Zeile 45 mit der schlie{\ss}enden geschweiften
       Klammer ``\texttt{\}}''.
 \end{enumerate}
-Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
+Wir diskutieren die Eingabe-Spezifikation jetzt Zeile f\"ur Zeile.
 \begin{enumerate}
-\item In Zeile 1 folgt hinter dem Schlüsselwort ``\texttt{PARSER\_BEGIN}'' der in Klammern
-      eingeschlossene Name der Datei, die die Spezifikation enthält, wobei die
+\item In Zeile 1 folgt hinter dem Schl\"usselwort ``\texttt{PARSER\_BEGIN}'' der in Klammern
+      eingeschlossene Name der Datei, die die Spezifikation enth\"alt, wobei die
       Datei-Endung weggelassen wird.  Die Datei-Endung lautet immer ``\texttt{.jj}''.
-\item Anschließend folgt eine Klassen-Definition.  Der Name dieser Klasse muss ebenfalls
-      mit dem Datei-Namen übereinstimmen.
+\item Anschlie{\ss}end folgt eine Klassen-Definition.  Der Name dieser Klasse muss ebenfalls
+      mit dem Datei-Namen \"ubereinstimmen.
   
-      In unserem Fall enthält die Klasse zunächst die Definitionen verschiedener
+      In unserem Fall enth\"alt die Klasse zun\"achst die Definitionen verschiedener
       statischer Variablen.
       \begin{enumerate}
-      \item Die in Zeile 4 definierte Variable \texttt{sName} enthält später den Namen 
+      \item Die in Zeile 4 definierte Variable \texttt{sName} enth\"alt sp\"ater den Namen 
             des Studenten, dessen Note berechnet werden soll.  Wir initialisieren diese
-            Variable aber zunächst mit \texttt{null}.  Dadurch haben wir später die
-            Möglichkeit zu prüfen, ob bereits Punkte eines Studenten gelesen worden sind
+            Variable aber zun\"achst mit \texttt{null}.  Dadurch haben wir sp\"ater die
+            M\"oglichkeit zu pr\"ufen, ob bereits Punkte eines Studenten gelesen worden sind
             oder ob bisher erst die Kopfzeilen der Eingabe-Datei gelesen wurden.
       \item Die in Zeile 5 definierte Variable \texttt{sSumPoints} gibt die Summe aller
             Punkte an, die ein Student erzielt hat.
       \item Die in Zeile 6 definierte Variable \texttt{sMaxPoints} gibt die maximal erreichbare Punktezahl an.
       \end{enumerate}
-      Anschließend wird die Methode \texttt{main} definiert.  Diese Methode ist erforderlich, damit
+      Anschlie{\ss}end wird die Methode \texttt{main} definiert.  Diese Methode ist erforderlich, damit
       der erzeugte Scanner aufgerufen werden kann.  
       \begin{enumerate}
       \item Als erstes erzeugen wir einen \emph{Token-Manager}.  Da der Konstruktor 
-            für einen Token-Manager als Eingabe ein Objekt vom Type
+            f\"ur einen Token-Manager als Eingabe ein Objekt vom Type
             \texttt{SimpleCharStream} erwartet, 
-            konvertieren wir den Eingabestrom ``\texttt{System.in}'' zunächst in ein solches
+            konvertieren wir den Eingabestrom ``\texttt{System.in}'' zun\"achst in ein solches
             Objekt und erzeugen dann in Zeile 10 den Token-Manager, als Objekt der
             Klasse \texttt{KlausurTokenManager}.  
       \item Die Methode \texttt{main} bekommt die maximale Punktzahl als Argument
-            übergeben und speichert diese in Zeile 12 in der Variablen \texttt{sMaxPoints}
+            \"ubergeben und speichert diese in Zeile 12 in der Variablen \texttt{sMaxPoints}
             ab.
-      \item Anschließend lesen wir in der \texttt{while}-Schleife solange Tokens, bis wir
-            das \textsl{End-Of-File}-Token lesen.  Dieses Token können wir daran erkennen,
+      \item Anschlie{\ss}end lesen wir in der \texttt{while}-Schleife solange Tokens, bis wir
+            das \textsl{End-Of-File}-Token lesen.  Dieses Token k\"onnen wir daran erkennen,
             dass die Member-Variable \texttt{t.kind} den Wert 0 hat.
             Diese Schleife bezeichnen wir im Folgenden als die \emph{Scanner-Schleife}.
        
             Jedesmal, wenn der Scanner ein Token erkennt, werden die mit dem Token
-            spezifizierten Aktionen ausgeführt, mehr dazu später.
+            spezifizierten Aktionen ausgef\"uhrt, mehr dazu sp\"ater.
       \end{enumerate}
       Neben der Methode $\textsl{main}()$, die in jeder Parser-Klasse vorhanden
-      sein muss, enthält die Klasse \texttt{Klausur} noch die Definition der statischen
-      Methode $\texttt{note}()$, mit der später die Note berechnet wird.  Hier
+      sein muss, enth\"alt die Klasse \texttt{Klausur} noch die Definition der statischen
+      Methode $\texttt{note}()$, mit der sp\"ater die Note berechnet wird.  Hier
       wird dieselbe Formel verwendet, die wir auch schon in dem entsprechenden
       \textsl{Flex}-Beispiel benutzt haben.
-\item Nun folgen nach dem Schlüsselwort \texttt{Token} und einem Doppelpunkt die
+\item Nun folgen nach dem Schl\"usselwort \texttt{Token} und einem Doppelpunkt die
       einzelnen Token-Definitionen.  Diese werden insgesamt von geschweiften Klammern
       eingefasst und die einzelnen Token-Spezifikationen werden durch das
       Zeichen ``\texttt{|}'' voneinander getrennt.  Eine einzelne Token-Spezifikationen hat die
@@ -154,19 +154,19 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
       \\[0.2cm]
       Die Bedeutung der einzelnen Komponenten ist wie folgt:
       \begin{enumerate}
-      \item \textsl{Name}\/ steht für den Namen eines Tokens.  Dieser besteht aus
-            Großbuchstaben.  
-      \item \textsl{RegExp}\/ bezeichnet einen regulären Ausdruck.  Die Syntax der
-            regulären Ausdrücke weicht von der bei \textsl{Flex}\/ gebräuchlichen
+      \item \textsl{Name}\/ steht f\"ur den Namen eines Tokens.  Dieser besteht aus
+            Gro{\ss}buchstaben.  
+      \item \textsl{RegExp}\/ bezeichnet einen regul\"aren Ausdruck.  Die Syntax der
+            regul\"aren Ausdr\"ucke weicht von der bei \textsl{Flex}\/ gebr\"auchlichen
             Syntax stark ab.  Insbesondere haben Leerzeichen und Tabulatoren keine
-            Bedeutung, so dass es möglich ist, komplexe reguläre Ausdrücke lesbar zu
-            formatieren.  Wir werden die genaue Syntax regulärer Ausdrücke im nächsten
+            Bedeutung, so dass es m\"oglich ist, komplexe regul\"are Ausdr\"ucke lesbar zu
+            formatieren.  Wir werden die genaue Syntax regul\"arer Ausdr\"ucke im n\"achsten
             Unterabschnitt im Detail diskutieren,
             
             \textsl{Name}\/ und \textsl{RegExp}\/ werden zusammen in spitzen Klammern ``\texttt{<}''
             und ``\texttt{>}'' eingeschlossen und durch einen Doppelpunkt getrennt.
-      \item \textsl{CmdList}\/ steht für eine Liste von Befehlen.  Diese Befehle
-            werden ausgeführt, sobald Text erkannt wird, der von dem regulären Ausdruck
+      \item \textsl{CmdList}\/ steht f\"ur eine Liste von Befehlen.  Diese Befehle
+            werden ausgef\"uhrt, sobald Text erkannt wird, der von dem regul\"aren Ausdruck
             \textsl{RegExp}\/ erkannt wird.  Syntaktisch handelt es sich bei den Befehlen
             um einen in geschweiften Klammern eingeschlossenen Block von \textsl{Java}-Code.
       \end{enumerate}
@@ -180,81 +180,81 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
             \end{verbatim}
             \vspace*{-0.5cm}
 
-            Der reguläre Ausdruck, der in Zeile 24 auf den Doppelpunkt folgt, besteht aus vier
+            Der regul\"are Ausdruck, der in Zeile 24 auf den Doppelpunkt folgt, besteht aus vier
             Komponenten:
             \begin{enumerate}
             \item \texttt{(<LETTER>)+}
               
               Durch die spitzen Klammern wird das Token \texttt{LETTER} referenziert.
-              Dieses Token wird weiter unten in Zeile 47 definiert und steht für einen beliebigen
-              Buchstaben einschließlich eines Umlauts oder ``\texttt{ß}''.  Das Token
+              Dieses Token wird weiter unten in Zeile 47 definiert und steht f\"ur einen beliebigen
+              Buchstaben einschlie{\ss}lich eines Umlauts oder ``\texttt{{\ss}}''.  Das Token
               \texttt{LETTER} ist in runden Klammern eingeschlossen, auf die noch der Operator
-              ``\texttt{+}'' folgt.  Dieser Operator steht genau wie bei \textsl{Flex}\/ für
+              ``\texttt{+}'' folgt.  Dieser Operator steht genau wie bei \textsl{Flex}\/ f\"ur
               eine beliebige positive Anzahl von Wiederholungen.  Im Unterschied zu
               \textsl{Flex}\/ muss das Argument, auf dass sich der Operator ``\texttt{+}''
               bezieht, aber in runden Klammern eingeschlossen sein.  Insgesamt steht der
-              Ausdruck ``\texttt{(<LETTER>)+}'' also für eine beliebige positive Anzahl
+              Ausdruck ``\texttt{(<LETTER>)+}'' also f\"ur eine beliebige positive Anzahl
               von Buchstaben.
             \item \texttt{\symbol{34}:\symbol{34}}
 
                   In doppelten Hochkommata ``\texttt{\symbol{34}}'' eingeschlossener Text
-                  wird wörtlich interpretiert.  Der wesentliche Unterschied zu \textsl{Flex},
-                  der hier sichtbar wird, ist die Tatsache, dass innerhalb regulärer Ausdrücke in
-                  \textsl{JavaCC}\/ Leerzeichen, Tabulatoren und Zeilenumbrüche zulässig sind.
+                  wird w\"ortlich interpretiert.  Der wesentliche Unterschied zu \textsl{Flex},
+                  der hier sichtbar wird, ist die Tatsache, dass innerhalb regul\"arer Ausdr\"ucke in
+                  \textsl{JavaCC}\/ Leerzeichen, Tabulatoren und Zeilenumbr\"uche zul\"assig sind.
                   Diese werden ignoriert.  So wird das Leerzeichen, dass den Ausdruck
                   ``\texttt{\symbol{34}:\symbol{34}}'' von dem Ausdruck
                   ``\texttt{(<LETTER>)+}'' trennt, ignoriert.  Ich habe dieses Leerzeichen
-                  zur Verbesserung der Lesbarkeit eingefügt.  Das wäre bei einer
-                  \textsl{Flex}-Spezifikation so nicht möglich.
+                  zur Verbesserung der Lesbarkeit eingef\"ugt.  Das w\"are bei einer
+                  \textsl{Flex}-Spezifikation so nicht m\"oglich.
             \item \texttt{(\symbol{126}[\symbol{34}\symbol{92}n\symbol{34}])*}
 
                   Dieser Ausdruck beschreibt eine beliebige Anzahl von Zeichen,
                   die von einem Zeilen-Umbruch ``\texttt{\symbol{92}n}'' verschieden sind.
-                  Zunächst haben wir hier den in eckigen Klammern eingeschlossenen
+                  Zun\"achst haben wir hier den in eckigen Klammern eingeschlossenen
                   Ausdruck ``\texttt{\symbol{92}n}''.  Eckige Klammern geben, genau wie bei
                   \textsl{Flex}, eine Menge von Zeichen an.  Im Unterschied zu \textsl{Flex}\/ 
-                  müssen die Zeichen aus dieser Menge allerdings alle in doppelten Hochkommata
+                  m\"ussen die Zeichen aus dieser Menge allerdings alle in doppelten Hochkommata
                   ``\texttt{\symbol{34}}'' eingefasst werden.  
-                  In dem obigen Fall enthält die Menge nur ein einziges
+                  In dem obigen Fall enth\"alt die Menge nur ein einziges
                   Zeichen.  \textbf{Vor} den eckigen Klammern finden wir aber das Zeichen
                   ``\texttt{\symbol{126}}''.  Dieses Zeichen bewirkt eine Komplementbildung:
                   Der Ausdruck ``\texttt{\symbol{126}[\symbol{34}\symbol{92}n\symbol{34}]}''
-                  steht also für alle Zeichen, die von einem Zeilen-Umbruch \textbf{verschieden} sind.
+                  steht also f\"ur alle Zeichen, die von einem Zeilen-Umbruch \textbf{verschieden} sind.
 
-                  Hier weicht die Syntax ebenfalls von der bei \textsl{Flex}\/ gebräuchlichen
+                  Hier weicht die Syntax ebenfalls von der bei \textsl{Flex}\/ gebr\"auchlichen
                   Syntax ab, den bei \textsl{Flex}\/ wird zur Komplementbildung der Operator
                   ``\texttt{\^}'' verwendet und dieser steht dann als erstes Zeichen \textbf{nach} der
-                  öffnenden eckigen Klammer.
+                  \"offnenden eckigen Klammer.
 
                   Der ganze Ausdruck ist dann noch in runden Klammern eingefasst, auf die der
                   Operator ``\texttt{*}'' folgt.  Genau wie bei \textsl{Flex}\/ steht dieser
-                  Operator für eine beliebige Anzahl von Wiederholungen.
+                  Operator f\"ur eine beliebige Anzahl von Wiederholungen.
                   Im Unterschied zu \textsl{Flex}\/ muss das Argument, auf dass sich der
                   Operator ``\texttt{*}'' bezieht, aber in runden Klammern eingeschlossen
                   sein.
             \item \texttt{\symbol{34}\symbol{92}n\symbol{34}}
           
-                  Dieser Ausdruck steht für einen Zeilen-Umbruch.
+                  Dieser Ausdruck steht f\"ur einen Zeilen-Umbruch.
             \end{enumerate}
             Hinter dem Token \texttt{KOPF} steht kein \textsl{Java}-Block.  Daher
             wird der Text, der hier erkannt wurde, einfach ignoriert.  
       \item Die Definition von \texttt{NAME} sagt, dass eine Name aus zwei Gruppen
             von Buchstaben besteht, die durch ein Leerzeichen getrennt werden.
-            Wichtig ist hier, dass das Leerzeichen in dem regulären Ausdruck in
+            Wichtig ist hier, dass das Leerzeichen in dem regul\"aren Ausdruck in
             doppelte Hochkommata ``\texttt{\symbol{34}}'' eingefasst ist, denn (wie oben
-            bereits erwähnt) können reguläre Ausdrücke bei \textsl{JavaCC}\/ durch das
-            Einfügen von Leerzeichen, Tabulatoren und Zeilenumbrüchen zur Verbesserung
+            bereits erw\"ahnt) k\"onnen regul\"are Ausdr\"ucke bei \textsl{JavaCC}\/ durch das
+            Einf\"ugen von Leerzeichen, Tabulatoren und Zeilenumbr\"uchen zur Verbesserung
             der Lesbarkeit formatiert werden.
 
             Wir diskutieren nun den \textsl{Java}-Block in den Zeilen 26 -- 30:
-            Der Text, der durch den regulären Ausdruck erkannt wird, ist in der Variablen
+            Der Text, der durch den regul\"aren Ausdruck erkannt wird, ist in der Variablen
             \texttt{image} abgelegt.  Diese Variable entspricht also der \textsl{Flex}-Variablen 
-            \texttt{yytext}.  Die Variable \texttt{image} hat aus Effizienzgründen den Typ
+            \texttt{yytext}.  Die Variable \texttt{image} hat aus Effizienzgr\"unden den Typ
             \texttt{StringBuffer} und kann mit der Methode $\textsl{toString}()$ in einen
             \texttt{String} umgewandelt werden.  Mit diesem String initialisieren wir die 
             statische Variable \texttt{sName}.  Beachten Sie, dass der Klassenname
             ``\texttt{Klausur}'' der statischen Variablen vorangestellt werden muss,
-            denn der \textsl{Java}-Block  ist später Teil der Klasse
+            denn der \textsl{Java}-Block  ist sp\"ater Teil der Klasse
             \texttt{KlausurTokenManager} und nicht der Klasse \texttt{Klausur}.
             
             
@@ -266,35 +266,35 @@ Wir diskutieren die Eingabe-Spezifikation jetzt Zeile für Zeile.
             \end{verbatim}
             \vspace*{-0.5cm}
 
-            Bei \textsl{JavaCC}\/ müssen die einzelnen Zeichen einer Mengen-Definition
+            Bei \textsl{JavaCC}\/ m\"ussen die einzelnen Zeichen einer Mengen-Definition
             durch Kommata getrennt werden.
-      \item Das Token \texttt{ZAHL} steht für eine ganze Zahl.
+      \item Das Token \texttt{ZAHL} steht f\"ur eine ganze Zahl.
             Dies ist entweder das Zeichen ``\texttt{0}'' oder eine beliebige Folge von
             Ziffern, die nicht mit dem Zeichen ``\texttt{0}'' beginnt.
             
             Dieses Beispiel zeigt, dass auch bei \textsl{JavaCC}\/ innerhalb einer
-            Mengen-Definition Bereiche gebildet werden können.  Dazu wird genau wie bei 
+            Mengen-Definition Bereiche gebildet werden k\"onnen.  Dazu wird genau wie bei 
             \textsl{Flex}\/ das Minus-Zeichen ``\texttt{-}'' verwendet.
-      \item Das Token \texttt{HYPHEN} steht für ein einzelnes Minus-Zeichen ``\texttt{-}''.
-      \item Das Token \texttt{EOL} steht für Leerzeichen und Tabulatoren, die am
-            Zeilenende auftreten.  Der abschließende Zeilenumbruch gehört ebenfalls noch
-            zu dem Token.  Der Name \texttt{EOL} ist als Abkürzung für 
+      \item Das Token \texttt{HYPHEN} steht f\"ur ein einzelnes Minus-Zeichen ``\texttt{-}''.
+      \item Das Token \texttt{EOL} steht f\"ur Leerzeichen und Tabulatoren, die am
+            Zeilenende auftreten.  Der abschlie{\ss}ende Zeilenumbruch geh\"ort ebenfalls noch
+            zu dem Token.  Der Name \texttt{EOL} ist als Abk\"urzung f\"ur 
             \emph{\underline{e}nd \underline{o}f \underline{l}ine} gedacht.
-      \item Das Token \texttt{WHITE} steht für Leerzeichen und Tabulatoren.
+      \item Das Token \texttt{WHITE} steht f\"ur Leerzeichen und Tabulatoren.
       \item Das Token \texttt{LETTER} ist durch das Voranstellen des
             Zeichens ``\texttt{\#}'' als \emph{privat} deklariert worden.
             Ein solches Token kann nur bei der Definition anderer Token verwendet werden,
-            der Scanner gibt später nie ein Token zurück, das als privat deklariert
-            wurde.  Durch die Verwendung privater Token können reguläre Ausdrücke
-            abgekürzt werden.  Die \emph{regulären Definitionen} in \textsl{Flex}\/ haben
+            der Scanner gibt sp\"ater nie ein Token zur\"uck, das als privat deklariert
+            wurde.  Durch die Verwendung privater Token k\"onnen regul\"are Ausdr\"ucke
+            abgek\"urzt werden.  Die \emph{regul\"aren Definitionen} in \textsl{Flex}\/ haben
             dieselbe Funktion.
       \end{enumerate}
 \end{enumerate}
-Um das Beispiel zu übersetzen, geben wir die folgenden Befehle ein:
+Um das Beispiel zu \"ubersetzen, geben wir die folgenden Befehle ein:
 \begin{enumerate}
 \item \texttt{javacc Klausur.jj}
 
-      Dieser Befehl erzeugt die Datei \texttt{Klausur.java}.  Zusätzlich werden noch die
+      Dieser Befehl erzeugt die Datei \texttt{Klausur.java}.  Zus\"atzlich werden noch die
       Dateien  
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -304,41 +304,41 @@ Um das Beispiel zu übersetzen, geben wir die folgenden Befehle ein:
       generiert.
 \item \texttt{javac Klausur.java}      
 
-      Damit werden die erzeugten \textsl{Java}-Dateien übersetzt.
+      Damit werden die erzeugten \textsl{Java}-Dateien \"ubersetzt.
 \item \texttt{java Klausur 60 < ergebnis}
 
       Hierdurch wird der erzeugte Scanner mit dem Argument 60 aufgerufen.
       Als Eingabe verarbeitet der Scanner dann die Datei \texttt{ergebnis}.
 \end{enumerate}
 
-\subsection{Reguläre Ausdrücke in \textsl{JavaCC}}
-Die Syntax der regulären Ausdrücke ist für \textsl{JavaCC}\/ wie folgt:
+\subsection{Regul\"are Ausdr\"ucke in \textsl{JavaCC}}
+Die Syntax der regul\"aren Ausdr\"ucke ist f\"ur \textsl{JavaCC}\/ wie folgt:
 \begin{enumerate}
-\item In doppelten Hochkommata eingeschlossen Strings stehen für sich selbst.
+\item In doppelten Hochkommata eingeschlossen Strings stehen f\"ur sich selbst.
       Beispiel:
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{\symbol{34}else\symbol{34}}
       \\[0.2cm]
-      steht für den String ``\texttt{else}''.  Genau wie bei \textsl{Flex}\/ haben
+      steht f\"ur den String ``\texttt{else}''.  Genau wie bei \textsl{Flex}\/ haben
       Operator-Symbole innerhalb eines solchen Strings keine Bedeutung. 
-\item Bereiche können mit den eckigen Klammern ``\texttt{[}'' und ``\texttt{]}''
-      gebildet werden, im Unterschied zu \textsl{Flex}\/ müssen die einzelnen Zeichen
+\item Bereiche k\"onnen mit den eckigen Klammern ``\texttt{[}'' und ``\texttt{]}''
+      gebildet werden, im Unterschied zu \textsl{Flex}\/ m\"ussen die einzelnen Zeichen
       allerdings in Hochkommata eingeschlossen werden.  Beispiel:
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{[\symbol{34}0\symbol{34} - \symbol{34}9\symbol{34}]}
       \\[0.2cm]
-      Dieser Ausdruck steht für eine beliebige Ziffer.
-\item Die Komplementbildung erfolgt für Bereiche durch das Zeichen
-      ``\texttt{\symbol{126}}'', dass nun \textbf{vor} der öffnenden eckigen Klammer
+      Dieser Ausdruck steht f\"ur eine beliebige Ziffer.
+\item Die Komplementbildung erfolgt f\"ur Bereiche durch das Zeichen
+      ``\texttt{\symbol{126}}'', dass nun \textbf{vor} der \"offnenden eckigen Klammer
       steht.
       Beispiel:
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{\symbol{126}[\symbol{34}a\symbol{34} - \symbol{34}z\symbol{34}]}
       \\[0.2cm]
-      Dieser Ausdruck steht für ein Zeichen, dass \textbf{kein} kleiner Buchstabe ist.
+      Dieser Ausdruck steht f\"ur ein Zeichen, dass \textbf{kein} kleiner Buchstabe ist.
 \item Der Kleene-Abschluss wird mit dem Postfix-Operator ``\texttt{*}'' gebildet.
       Im Unterschied zu \textsl{Flex}\/ muss das Argument allerdings in runden Klammern
       eingeschlossen sein.  Beispiel:
@@ -346,24 +346,24 @@ Die Syntax der regulären Ausdrücke ist für \textsl{JavaCC}\/ wie folgt:
       \hspace*{1.3cm}
       \texttt{([\symbol{34}0\symbol{34}-\symbol{34}9\symbol{34}])*}
       \\[0.2cm]
-      Dieser Ausdruck steht für einen String, der nur aus Ziffern besteht.
+      Dieser Ausdruck steht f\"ur einen String, der nur aus Ziffern besteht.
 \item Genau wie in \textsl{Flex}\/ gibt es die Postfix-Operatoren ``\texttt{?}'' und
-      ``\texttt{+}'', deren Argumente allerdings zusätzlich in runden Klammern
-      eingeschlossen sein müssen.
+      ``\texttt{+}'', deren Argumente allerdings zus\"atzlich in runden Klammern
+      eingeschlossen sein m\"ussen.
 \item Eine Auswahl zwischen verschiedenen Alternativen erfolgt genau wie bei \textsl{Flex}\/
       mit Hilfe des Operators ``\texttt{|}''.  Beispiel:
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{\symbol{34}0\symbol{34} | [\symbol{34}1\symbol{34}-\symbol{34}9\symbol{34}] ([\symbol{34}0\symbol{34}-\symbol{34}9\symbol{34}])*}
       \\[0.2cm]       
-      Dieser Ausdruck steht für eine einzelne 0 oder eine Zahl, die mit einer
-      postiven Ziffer anfängt, auf die dann beliebig viele andere Ziffern folgen.
+      Dieser Ausdruck steht f\"ur eine einzelne 0 oder eine Zahl, die mit einer
+      postiven Ziffer anf\"angt, auf die dann beliebig viele andere Ziffern folgen.
 \end{enumerate}
 Die Operatoren ``\texttt{\symbol{94}}'' und ``\texttt{\symbol{36}}'', mit denen in \textsl{Flex}\/
-der Beginn bzw.~das Ende einer Zeile spezifiziert werden können, gibt es in
+der Beginn bzw.~das Ende einer Zeile spezifiziert werden k\"onnen, gibt es in
 \textsl{JavaCC}\/ nicht.  Auch der Operator ``\texttt{/}'', mit dem \emph{trailing context}
-spezifiziert werden kann, fehlt in \textsl{JavaCC}.  Schließlich ist auch der Punkt
-``\texttt{.}'', der in \textsl{Flex}\/ für ein beliebiges von ``\texttt{\symbol{92}n}''
+spezifiziert werden kann, fehlt in \textsl{JavaCC}.  Schlie{\ss}lich ist auch der Punkt
+``\texttt{.}'', der in \textsl{Flex}\/ f\"ur ein beliebiges von ``\texttt{\symbol{92}n}''
 verschiedenes Zeichen steht, in \textsl{JavaCC}\/ kein Operator.  Um ein beliebiges Zeichen
 zu spezifizieren kann in \textsl{JavaCC}\/ der Ausdruck
 \\[0.2cm]
@@ -373,18 +373,18 @@ zu spezifizieren kann in \textsl{JavaCC}\/ der Ausdruck
 verwendet werden, denn dieser Ausdruck spezifiziert das Komplement eines leeren Bereichs
 und das sind alle Zeichen!
 
-\subsection{Zustände in \textsl{JavaCC}}
-Auch in \textsl{JavaCC}\/ gibt es Zustände.  Abbildung \ref{fig:DeComment.jj} zeigt
+\subsection{Zust\"ande in \textsl{JavaCC}}
+Auch in \textsl{JavaCC}\/ gibt es Zust\"ande.  Abbildung \ref{fig:DeComment.jj} zeigt
 ein \textsl{JavaCC}-Programm, mit dessen Hilfe Kommentare der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{/*} $\cdots$ \texttt{*/}
 \\[0.2cm]
-aus einer \texttt{C}-Datei entfernt werden können.  Im Unterschied zu \textsl{Flex}\/
-werden Zustände in \textsl{JavaCC}\/ nicht deklariert, es gibt also kein Pendant zu
+aus einer \texttt{C}-Datei entfernt werden k\"onnen.  Im Unterschied zu \textsl{Flex}\/
+werden Zust\"ande in \textsl{JavaCC}\/ nicht deklariert, es gibt also kein Pendant zu
 ``\texttt{\%x}'' bzw. ``\texttt{\%s}''.  
-Außerdem sind in \textsl{JavaCC}\/ alle Zustände automatisch exklusiv.  Der Default-Zustand
-heißt jetzt ``\texttt{DEFAULT}''.
+Au{\ss}erdem sind in \textsl{JavaCC}\/ alle Zust\"ande automatisch exklusiv.  Der Default-Zustand
+hei{\ss}t jetzt ``\texttt{DEFAULT}''.
 
 \begin{figure}[!h]
 \centering
@@ -429,7 +429,7 @@ Das Programm in Abbildung \ref{fig:DeComment.jj} ist wie folgt aufgebaut.
 \begin{enumerate}
 \item Nach der Erzeugung eines Token-Managers finden wir in den Zeilen 8 -- 10
       die \emph{Scanner-Schleife}.
-\item Anschließend finden wir in dem Programm zwei Gruppen von Token-Definitionen.
+\item Anschlie{\ss}end finden wir in dem Programm zwei Gruppen von Token-Definitionen.
       \begin{enumerate}
       \item Die Zeilen 15 -- 18 enthalten die Regeln, die im Zustand \texttt{DEFAULT}
             verwendet werden.
@@ -439,9 +439,9 @@ Das Programm in Abbildung \ref{fig:DeComment.jj} ist wie folgt aufgebaut.
                   Diese Regel wechselt in den Zustand \texttt{ML\_COMMENT}.
             \item Die Regel mit dem Namen \texttt{CHAR} erkennt das Komplement
                   der leeren Zeichenmenge, also ein beliebiges Zeichen.
-                  Dieses Zeichen wird unverändert ausgegeben.  Der Folge-Zustand
+                  Dieses Zeichen wird unver\"andert ausgegeben.  Der Folge-Zustand
                   ist wieder der Zustand \texttt{DEFAULT}, es findet also kein
-                  Zustandswechsel statt.  Daher könnten wir bei dieser Regel 
+                  Zustandswechsel statt.  Daher k\"onnten wir bei dieser Regel 
                   den Rest 
                   \\[0.2cm]
                   \hspace*{1.3cm}
@@ -469,12 +469,12 @@ Form hat:
 \\[0.2cm]
 Hierbei gilt:
 \begin{enumerate}
-\item \textsl{Name} ist der Name, unter dem das Token später angesprochen werden kann.
+\item \textsl{Name} ist der Name, unter dem das Token sp\"ater angesprochen werden kann.
       Solange wir \textsl{JavaCC}\/ nur als Scanner verwenden, hat dieser Name keine
       Bedeutung.  Im Allgemeinen wird \textsl{JavaCC}\/ aber als \emph{Parser-Generator}
-      eingesetzt und dann können wir in den Grammatik-Regeln auf die Namen zurück greifen.
-\item \textsl{Regexp} ist der reguläre Ausdruck, der erkannt werden soll.
-\item \textsl{CmdList} ist die Gruppe von Befehlen, die ausgeführt werden, sobald der reguläre
+      eingesetzt und dann k\"onnen wir in den Grammatik-Regeln auf die Namen zur\"uck greifen.
+\item \textsl{Regexp} ist der regul\"are Ausdruck, der erkannt werden soll.
+\item \textsl{CmdList} ist die Gruppe von Befehlen, die ausgef\"uhrt werden, sobald der regul\"are
       Ausdruck erkannt worden ist.
 \item \textsl{State} ist der Zustand, in den der Automat wechseln soll, nachdem die
       Kommandos abgearbeitet sind.  Die Angabe des Folge-Zustands ist optional.
@@ -484,20 +484,20 @@ Hierbei gilt:
 \pagebreak
 
 \exercise
-Entwickeln Sie einen Assembler für die im Rechnertechnik-Skript
-beschriebene Assembler-Sprache.  Das Programm soll eine Assembler-Datei in eine binäre
-Datei übersetzen.
+Entwickeln Sie einen Assembler f\"ur die im Rechnertechnik-Skript
+beschriebene Assembler-Sprache.  Das Programm soll eine Assembler-Datei in eine bin\"are
+Datei \"ubersetzen.
 \vspace*{0.3cm}
 
 \noindent
 \textbf{Hinweise}:  
 \begin{enumerate}
-\item Verwenden Sie verschiedene Zustände um die einzelnen Komponenten eines Assembler-Befehls
+\item Verwenden Sie verschiedene Zust\"ande um die einzelnen Komponenten eines Assembler-Befehls
       zu lesen.
 \item Passen Sie die Klasse \texttt{Assembler}, die in dem
       Rechnertechnik-Skript vorgestellt wird, an Ihren Bedarf an und verwandeln Sie diese Klasse
       in eine konkrete Klasse.  Die abgeleiteten Klassen sind nicht mehr erforderlich.
-\item Um eine 32-Bit-Zahl binär auszugeben, können Sie die folgende Methode verwenden:
+\item Um eine 32-Bit-Zahl bin\"ar auszugeben, k\"onnen Sie die folgende Methode verwenden:
       \begin{verbatim}
 public void writeBinary(OutputStream writer, int code) throws IOException
 {

--- a/Lecture-Notes/jflex.tex
+++ b/Lecture-Notes/jflex.tex
@@ -145,7 +145,7 @@ This separator string has to be positioned at the start of a line.
     .|\R           { /* skip anything else */         }
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Eine einfache Scanner-Spezifikation für \textsl{JFlex}}
+\caption{Eine einfache Scanner-Spezifikation f\"ur \textsl{JFlex}}
 \label{fig:count.jflex}
 \end{figure}
 
@@ -164,7 +164,7 @@ This separator string has to be positioned at the start of a line.
     How many pieces of fruit does this text contain?
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Eine Eingabe-Datei für den in Abbildung \ref{fig:count.jflex} spezifizierten Scanner.}
+\caption{Eine Eingabe-Datei f\"ur den in Abbildung \ref{fig:count.jflex} spezifizierten Scanner.}
 \label{fig:input.txt}
 \end{figure}
 
@@ -1298,13 +1298,13 @@ scanner states.  They are declared via the keyword
     "<"[^>]+">"         { /* skip html tags */     }
     \R+                 { System.out.print("\n");  }
     &nbsp;              { System.out.print(" ");   }
-    &auml;              { System.out.print("ä");   }
-    &ouml;              { System.out.print("ö");   }
-    &uuml;              { System.out.print("ü");   }
-    &Auml;              { System.out.print("Ä");   }
-    &Ouml;              { System.out.print("Ö");   }
-    &Uuml;              { System.out.print("Ü");   }
-    &szlig;             { System.out.print("ß");   }
+    &auml;              { System.out.print("\"a");   }
+    &ouml;              { System.out.print("\"o");   }
+    &uuml;              { System.out.print("\"u");   }
+    &Auml;              { System.out.print("\"A");   }
+    &Ouml;              { System.out.print("\"O");   }
+    &Uuml;              { System.out.print("\"U");   }
+    &szlig;             { System.out.print("{\ss}");   }
     
     <header>"</head>"   { yybegin(YYINITIAL);      }
     <header>.|\R        { /* skip anything else */ }

--- a/Lecture-Notes/keller-automaten.tex
+++ b/Lecture-Notes/keller-automaten.tex
@@ -1,30 +1,30 @@
 \chapter{Keller-Automaten}
 In diesem Kapitel stellen wir die \emph{Keller-Automaten} (engl.~\emph{push-down automata})
 vor.  Wir werden sehen, dass dieses Automaten-Modell zu dem Konzept der kontextfreien Sprachen
-äquivalent ist:  Eine Sprache $L$ ist genau dann kontextfrei, wenn es einen
+\"aquivalent ist:  Eine Sprache $L$ ist genau dann kontextfrei, wenn es einen
 nicht-deterministischen Keller-Automaten gibt, der die Sprache $L$ erkennt.  Insofern verhalten
 sich Keller-Automaten zu den kontextfreien Sprachen genauso, wie sich die endlichen Automaten
-zu den regulären Sprachen verhalten.  Im Vergleich zur Theorie der endlichen Automaten hat die
-Theorie der Keller-Automaten allerdings einen Schönheitsfehler:  Während die deterministischen
-endlichen Automaten zu den nicht-deterministischen endlichen Automaten äquivalent sind, sind
-die nicht-deterministischen Keller-Automaten mächtiger als die deterministischen
+zu den regul\"aren Sprachen verhalten.  Im Vergleich zur Theorie der endlichen Automaten hat die
+Theorie der Keller-Automaten allerdings einen Sch\"onheitsfehler:  W\"ahrend die deterministischen
+endlichen Automaten zu den nicht-deterministischen endlichen Automaten \"aquivalent sind, sind
+die nicht-deterministischen Keller-Automaten m\"achtiger als die deterministischen
 Keller-Automaten, denn es gibt kontextfreie Sprachen, die sich zwar mit einem
-nicht-deterministischen Keller-Automaten erkennen lassen, für die es aber keinen
+nicht-deterministischen Keller-Automaten erkennen lassen, f\"ur die es aber keinen
 deterministischen Keller-Automaten gibt, der diese Sprache erkennt.  Allerdings werden wir
-sehen, dass die meisten für die Praxis interessanten kontextfreien Sprachen bereits von
+sehen, dass die meisten f\"ur die Praxis interessanten kontextfreien Sprachen bereits von
 deterministischen Keller-Automaten erkannt werden.
     
 \section{Definition eines Keller-Automaten}
-Im Allgemeinen werden Keller-Automaten als endliche Automaten definiert, die zusätzlich mit
-einem Kellerspeicher (engl.~\emph{stack}) ausgestattet sind, auf dem Werte abgelegt werden können.  Der
+Im Allgemeinen werden Keller-Automaten als endliche Automaten definiert, die zus\"atzlich mit
+einem Kellerspeicher (engl.~\emph{stack}) ausgestattet sind, auf dem Werte abgelegt werden k\"onnen.  Der
 Zustand eines Automaten setzt sich dann aus zwei Komponenten zusammen:
 \begin{enumerate}
 \item Dem Inhalt des Kellerspeichers und
 \item dem Zustand des zugrunde liegenden endlichen Automaten.
 \end{enumerate}
-Es zeigt sich aber, dass der Kellerspeicher als Gedächtnis bereits ausreichend ist, eine weitere
-Komponente wird nicht benötigt.  Wir werden uns in unseren Betrachtungen zunächst auf diese Art von
-Keller-Automaten beschränken.
+Es zeigt sich aber, dass der Kellerspeicher als Ged\"achtnis bereits ausreichend ist, eine weitere
+Komponente wird nicht ben\"otigt.  Wir werden uns in unseren Betrachtungen zun\"achst auf diese Art von
+Keller-Automaten beschr\"anken.
 
 \begin{Definition}[Keller-Automat]
   Ein \emph{Keller-Automat} $A$ ist ein 4-Tupel
@@ -34,12 +34,12 @@ Keller-Automaten beschränken.
   \\[0.2cm]
   wobei die Komponenten die folgende Bedeutung haben:
   \begin{enumerate}
-  \item $\Sigma$ ist das \emph{Eingabe-Alphabet}, der Keller-Automat verarbeitet also Wörter aus
+  \item $\Sigma$ ist das \emph{Eingabe-Alphabet}, der Keller-Automat verarbeitet also W\"orter aus
         $\Sigma^*$.
   \item $\Gamma$ ist das \emph{Keller-Alphabet}.
 
-        In der Praxis ist $\Gamma$ häufig eine Obermenge von $\Sigma$.
-  \item $\delta$ ist die \emph{Übergangs-Funktion}.  
+        In der Praxis ist $\Gamma$ h\"aufig eine Obermenge von $\Sigma$.
+  \item $\delta$ ist die \emph{\"Ubergangs-Funktion}.  
         Als Argument bekommt diese Funktion entweder einen Buchstaben
         aus dem Eingabe-Alphabet $\Sigma$ und einen Buchstaben aus dem Keller-Alphabet
         $\Gamma$, oder das Zeichen $\varepsilon$ und einen Buchstaben aus $\Gamma$.
@@ -51,7 +51,7 @@ Keller-Automaten beschränken.
         \\[0.2cm]
         Hier bezeichnet $\textsl{Pow}(\Gamma^*)$ die Potenz-Menge von $\Gamma^*$, also die
         Menge aller Teilmengen von $\Gamma^*$ und $\Gamma^*$ bezeichnet die Menge der
-        Wörter über $\Gamma$.
+        W\"orter \"uber $\Gamma$.
   \item $S_0$ ist das Start-Symbol, das ein Element des Keller-Alphabets $\Gamma$ ist:
         \\[0.2cm]
         \hspace*{1.3cm}
@@ -65,9 +65,9 @@ Keller-Automaten beschränken.
 Wie funktioniert nun ein Keller-Automat?  Ein Wort $w \in \Sigma^*$ wird von dem
 Keller-Automaten wie folgt verarbeitet. 
 \begin{enumerate}
-\item Zunächst wird in dem leeren Kellerspeicher das Start-Symbol $S_0$ abgelegt.
-\item Anschließend wird das Wort Buchstabe für Buchstabe gelesen, wobei sich der 
-      Kellerspeicher des Automaten wie folgt verändern kann:
+\item Zun\"achst wird in dem leeren Kellerspeicher das Start-Symbol $S_0$ abgelegt.
+\item Anschlie{\ss}end wird das Wort Buchstabe f\"ur Buchstabe gelesen, wobei sich der 
+      Kellerspeicher des Automaten wie folgt ver\"andern kann:
       \begin{enumerate}
       \item Ist $C$ der Buchstabe, der im Kellerspeicher (also auf dem Stack) ganz oben liegt, 
             und gilt $\alpha \in \delta(\varepsilon, C)$, dann wird der Buchstabe $C$ 
@@ -77,12 +77,12 @@ Keller-Automaten wie folgt verarbeitet.
 
             In diesem Fall wird kein Buchstabe des Wortes $w$ gelesen.
       \item Ist $C$ der Buchstabe, der im Kellerspeicher (also auf dem Stack) ganz oben liegt, ist
-            $b$ der nächste zu lesende Buchstabe aus dem Wort $w$ und gilt
+            $b$ der n\"achste zu lesende Buchstabe aus dem Wort $w$ und gilt
             $\alpha \in \delta(b, C)$, dann wird der Buchstabe $b$ gelesen, der Buchstabe
-            $C$ wird aus dem Kellerspeicher entfernt und anschließend werden die Buchstaben aus
+            $C$ wird aus dem Kellerspeicher entfernt und anschlie{\ss}end werden die Buchstaben aus
             $\alpha$ eingekellert. 
       \end{enumerate}
-      Keller-Automaten sind nicht-deterministisch, denn beispielsweise kann für       
+      Keller-Automaten sind nicht-deterministisch, denn beispielsweise kann f\"ur       
       $\alpha_1 \not= \alpha_2$ sowohl 
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -94,7 +94,7 @@ Keller-Automaten wie folgt verarbeitet.
       \hspace*{1.3cm}
       $\alpha_1 \in \delta(\varepsilon,C)$ \quad und \quad $\alpha_2 \in \delta(b,C)$
       \\[0.2cm]
-      gilt.  In diesem Fall hat der Automat die Möglichkeit, entweder das Zeichen
+      gilt.  In diesem Fall hat der Automat die M\"oglichkeit, entweder das Zeichen
       $C$ im Kellerspeicher durch das Wort $\alpha_1$ zu ersetzen, ohne dabei einen Buchstaben zu lesen, oder
       der Automat kann den Buchstaben $b$ lesen und das Zeichen $C$ durch das Wort $\alpha_2$
       ersetzen.
@@ -109,8 +109,8 @@ $\langle v, \alpha \rangle \in \Sigma^* \times \Gamma^*$,
 \\[0.2cm]
 dass aus einem Wort $v$ des Eingabe-Alphabets und einem weiteren Wort
 $\alpha$  des Keller-Alphabets besteht.  Die Idee ist, dass $v$ den Teil des Eingabewortes
-darstellt, der noch nicht gelesen wurde, während $\alpha$ den Zustand des Kellerspeicher  beschreibt. 
-Wir definieren nun für zwei Konfigurationen $\pair(u,\alpha)$ und $\pair(v,\beta)$ des
+darstellt, der noch nicht gelesen wurde, w\"ahrend $\alpha$ den Zustand des Kellerspeicher  beschreibt. 
+Wir definieren nun f\"ur zwei Konfigurationen $\pair(u,\alpha)$ und $\pair(v,\beta)$ des
 Keller-Automaten $A$ eine
 Relation 
 \\[0.2cm]
@@ -121,14 +121,14 @@ durch die folgenden beiden Klauseln:
 \begin{enumerate}
 \item $\alpha \in \delta(\varepsilon, C) \;\rightarrow\; \pair(w, C\beta) \vdash_A \pair(w,\alpha \beta)$.
 
-      Hier hat der Keller-Automat $A$ einen $\varepsilon$-Übergang,
+      Hier hat der Keller-Automat $A$ einen $\varepsilon$-\"Ubergang,
       bei dem das Stack-Symbol $C$ durch den String $\alpha$ ersetzt wird.
-      Das Wort $w$ bleibt in diesem Fall unverändert.
+      Das Wort $w$ bleibt in diesem Fall unver\"andert.
       
 \item $\alpha \in \delta(b, C) \;\rightarrow\; \pair(bu, C\beta) \vdash_A \pair(u,\alpha \beta)$.
 
-      In diesem Fall hat der Keller-Automat $A$ für den Buchstaben $b$ und das
-      Stack-Symbol einen Übergang, bei dem $b$ gelesen und das Stack-Symbol $C$ durch
+      In diesem Fall hat der Keller-Automat $A$ f\"ur den Buchstaben $b$ und das
+      Stack-Symbol einen \"Ubergang, bei dem $b$ gelesen und das Stack-Symbol $C$ durch
       den String $\alpha$ ersetzt wird. 
 \end{enumerate}
 Wir bezeichnen den transitiven und reflexiven Abschluss der Relation $\vdash_A$ mit
@@ -166,34 +166,34 @@ folgt:
       $\delta(\texttt{b}, \texttt{b}) := \{ \varepsilon \}$, \quad
       $\delta(\texttt{b}, S) := \{ \}$.
 
-      Beachten Sie, dass es einen subtilen Unterschied zwischen den Fällen
+      Beachten Sie, dass es einen subtilen Unterschied zwischen den F\"allen
       \\[0.2cm]
       \hspace*{1.3cm}
       $\delta(\texttt{a}, \texttt{a}) := \{ \varepsilon \}$ \quad und \quad
       $\delta(\texttt{a}, \texttt{b}) := \{ \}$
       \\[0.2cm]
-      gibt:  Falls der nächste Buchstaben des zu verarbeitenden Wortes ein ``\texttt{a}''
-      ist und falls außerdem ein ``\texttt{a}'' oben auf 
+      gibt:  Falls der n\"achste Buchstaben des zu verarbeitenden Wortes ein ``\texttt{a}''
+      ist und falls au{\ss}erdem ein ``\texttt{a}'' oben auf 
       dem Stack liegt, dann wird das ``\texttt{a}'' aus dem Wort gelesen und 
       das ``\texttt{a}'' auf dem Stack wird durch das leere Wort $\varepsilon$ ersetzt 
       und damit entfernt. 
       
-      Ist hingegen  der nächste Buchstaben des zu verarbeitenden Wortes ein ``\texttt{a}''
-      und liegt  ein ``\texttt{b}'' oben auf dem Stack, so gibt es für den Automaten
-      keinen Übergang und damit kann der Buchstabe ``\texttt{a}'' nicht gelesen werden.
+      Ist hingegen  der n\"achste Buchstaben des zu verarbeitenden Wortes ein ``\texttt{a}''
+      und liegt  ein ``\texttt{b}'' oben auf dem Stack, so gibt es f\"ur den Automaten
+      keinen \"Ubergang und damit kann der Buchstabe ``\texttt{a}'' nicht gelesen werden.
       In diesem Fall sagen wir auch, dass der Automat \emph{stirbt}.
 \item Das Start-Symbol ist $S$.
 \end{enumerate}
 Ist $w$ ein Wort, so bezeichnen wir mit $w^r$ das
 Wort, das aus $w$ entsteht, wenn wir $w$ von hinten lesen.  Der erste Buchstabe von $w$
 ist also der letzte Buchstabe von $w^r$, der zweite Buchstabe von $w$ ist der vorletzte
-Buchstabe von $w^r$ und allgemein gilt für ein Wort der Länge $n$
+Buchstabe von $w^r$ und allgemein gilt f\"ur ein Wort der L\"ange $n$
 \\[0.2cm]
 \hspace*{1.3cm}
 $|w| = n \;\rightarrow\; \forall i \in \{1,\cdots,n\}:w^r[i] = w[n + 1 - i]$. 
 \\[0.2cm]
-Hier bezeichnet $|w|$ die Länge des Wortes und $w[i]$ bezeichnet den $i$-ten Buchstaben.
-Wörter, für die $w^r = w$ gilt, werden als \emph{Palindrome} bezeichnet.
+Hier bezeichnet $|w|$ die L\"ange des Wortes und $w[i]$ bezeichnet den $i$-ten Buchstaben.
+W\"orter, f\"ur die $w^r = w$ gilt, werden als \emph{Palindrome} bezeichnet.
 Ein einfaches Beispiel ist das Wort 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -220,7 +220,7 @@ verarbeitet.
       \hspace*{1.3cm}
       $\texttt{a}S\texttt{a} \in \delta(\varepsilon,S)$
       \\[0.2cm]
-      ausnutzen und einen $\varepsilon$-Übergang durchführen.  Dabei wird dann die
+      ausnutzen und einen $\varepsilon$-\"Ubergang durchf\"uhren.  Dabei wird dann die
       folgende Konfiguration erreicht:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -259,7 +259,7 @@ verarbeitet.
 \end{enumerate}
 
 \section{Von  kontextfreien Sprachen zu Keller-Automaten}
-Die Menge $L_P(\Sigma)$ der Palindrome über einem Alphabet $\Sigma$
+Die Menge $L_P(\Sigma)$ der Palindrome \"uber einem Alphabet $\Sigma$
 \\[0.2cm]
 \hspace*{1.3cm}
 $L_P(\Sigma) := \bigl\{ w \in \Sigma^* \mid w^r = w \bigr\}$
@@ -290,15 +290,15 @@ dem letzten Abschnitt, so erkennen wir ein Muster, dass wir jetzt allgemein form
   \hspace*{1.3cm}
   $A(G) = \langle T, V \cup T, \delta, S \rangle$,
   \\[0.2cm]
-  wobei die Übergangs-Funktion $\delta$ durch die folgenden Klauseln definiert wird.
+  wobei die \"Ubergangs-Funktion $\delta$ durch die folgenden Klauseln definiert wird.
   \begin{enumerate}
-  \item Für jede Regel $A \rightarrow \beta$ aus der Grammatik $G$ gilt $\beta \in \delta(\varepsilon, A)$,
+  \item F\"ur jede Regel $A \rightarrow \beta$ aus der Grammatik $G$ gilt $\beta \in \delta(\varepsilon, A)$,
         denn wir definieren
         \\[0.2cm]
         \hspace*{1.3cm}
         $\delta(\varepsilon, A) := \bigl\{ \beta \mid (A \rightarrow \beta) \in R \bigr\}$
-        \quad für alle $A \in V$.
-  \item Für jeden Buchstaben $b \in T$ gilt $\varepsilon \in \delta(b,b)$, denn wir definieren
+        \quad f\"ur alle $A \in V$.
+  \item F\"ur jeden Buchstaben $b \in T$ gilt $\varepsilon \in \delta(b,b)$, denn wir definieren
         \\[0.2cm]
         \hspace*{1.3cm}
         $\delta(b,c) := \left\{
@@ -308,7 +308,7 @@ dem letzten Abschnitt, so erkennen wir ein Muster, dass wir jetzt allgemein form
         \end{array}\right.
         $
         \qed
-  \item In allen anderen Fällen liefert die Funktion $\delta$ als Ergebnis die leere Menge.
+  \item In allen anderen F\"allen liefert die Funktion $\delta$ als Ergebnis die leere Menge.
         \begin{enumerate}
         \item $\forall b \in T: \delta(\varepsilon, b) = \{\}$,
         \item $\forall b \in T, A \in V: \delta(b, A) = \{\}$.
@@ -321,8 +321,8 @@ Der im letzten Abschnitt angegebene Automat $A$ ist genau der von der oben angeg
 Grammatik $G$ erzeugte Automat $A(G)$.
 \vspace*{0.3cm}
 
-Um zeigen zu können, dass der Automat $A(G)$ genau die Sprache akzeptiert, die von der
-Grammatik $G$ beschrieben wird, benötigen wir den Begriff der
+Um zeigen zu k\"onnen, dass der Automat $A(G)$ genau die Sprache akzeptiert, die von der
+Grammatik $G$ beschrieben wird, ben\"otigen wir den Begriff der
 \emph{Links-Ableitung} :  Informal ist das ein Ableitungsschritt, bei dem die
 linkeste Variable durch eine Regel ersetzt wird.  Formal definieren wir diesen Begriff wie
 folgt:  
@@ -339,17 +339,17 @@ $u A \beta \lmderiv u \gamma\beta$.
 \\[0.2cm]
 und  sagen, dass das Wort $u\gamma\beta$ durch einen Schritt
 einer \emph{Links-Ableitung} aus dem Wort $uA\beta$ hervorgegangen ist.
-Der entscheidende Unterschied gegenüber einem normalen Ableitungs-Schritt ist der, dass
-alle Zeichen, die links von der ersetzten Variablen $A$ stehen, Terminale sein müssen: 
+Der entscheidende Unterschied gegen\"uber einem normalen Ableitungs-Schritt ist der, dass
+alle Zeichen, die links von der ersetzten Variablen $A$ stehen, Terminale sein m\"ussen: 
 $u \in T^*$.  Ist allgemein $w$ ein Wort einer Sprache $L(G)$ und ist $S$ das
 Start-Symbol, dann erhalten wir eine \emph{Links-Ableitung} von $w$, wenn wir eine
-Ableitung wählen, bei der in jedem Schritt die linkeste Variable durch die rechte Seite
+Ableitung w\"ahlen, bei der in jedem Schritt die linkeste Variable durch die rechte Seite
 einer Grammatik-Regel ersetzt wird.
 
 \example
 Eine Grammatik 
 $G = \langle \{ E, P, F\}, \{ \squoted{+}, \squoted{*}, \squoted{1}, \squoted{2}, \squoted{3} \}, R, E \rangle$ 
-für arithmetische Ausdrücke habe die folgenden Regeln $R$:
+f\"ur arithmetische Ausdr\"ucke habe die folgenden Regeln $R$:
 \\[0.2cm]
 \hspace*{1.3cm}
 $E \rightarrow E \quoted{+} P \;|\; P$, \quad
@@ -391,7 +391,7 @@ $
 
 \remark
 Falls wir ein Wort $w$ aus dem Start-Symbol $S$ einer Grammatik $G = \langle V, T, R, S \rangle$ ableiten
-können, so können wir die Ableitungs-Schritte immer so umsortieren, dass wir hinterher eine Links-Ableitung 
+k\"onnen, so k\"onnen wir die Ableitungs-Schritte immer so umsortieren, dass wir hinterher eine Links-Ableitung 
 haben. Daher gilt
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -408,12 +408,12 @@ $L(G) = \{ w \in T^* \mid S \;
 \end{Satz}
 
 \noindent
-\textbf{Beweis}:  \ Wir zeigen zunächst, dass
+\textbf{Beweis}:  \ Wir zeigen zun\"achst, dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(G) \subseteq L\bigl(A(G)\bigr)$
 \\[0.2cm]
-gilt.  Wir nehmen also an, dass $w \in L(G)$ ist und müssen zeigen, dass der Automat $A(G)$
+gilt.  Wir nehmen also an, dass $w \in L(G)$ ist und m\"ussen zeigen, dass der Automat $A(G)$
 das Wort $w$ akzeptiert.  Wir nehmen nun eine Ableitung des Wortes $w$, bei der immer die 
 linkeste Variable ersetzt wird.  Eine solche Ableitung hat die Form
 \\[0.2cm]
@@ -423,21 +423,21 @@ $S = u_1A_1\beta_1 \lmderiv u_2A_2\beta_2 \lmderiv \cdots \lmderiv u_nA_n\beta_n
 wobei gilt
 \begin{enumerate}
 \item $u_1 = \varepsilon$, $A_1 = S$, $\beta_1 = \varepsilon$.
-\item $u_i \in T^*$ \quad für alle $i=1,\cdots,n$
+\item $u_i \in T^*$ \quad f\"ur alle $i=1,\cdots,n$
 
       links von den syntaktischen Variablen $A_i$ stehen also nur Terminale.
-\item $A_i \in V$ \quad für alle $i=1,\cdots,n$,
+\item $A_i \in V$ \quad f\"ur alle $i=1,\cdots,n$,
 
       $A_i$ ist also die syntaktische Variable in dem String $u_iA_i\beta_i$, die am
       weitesten links steht. 
 \end{enumerate}
-Wir zeigen nun durch Induktion über $i$, dass es für alle $i=1,\cdots,n$  Strings $v_i \in T^*$ 
+Wir zeigen nun durch Induktion \"uber $i$, dass es f\"ur alle $i=1,\cdots,n$  Strings $v_i \in T^*$ 
 gibt, so dass 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\pair(w,S) \vdash^* \pair(v_i, A_i\beta_i)$ und $u_iv_i = w$
 \\[0.2cm]
-gilt, der String $v_i$ ist also der Rest, der von dem String $w$ übrig bleibt, wenn das Präfix
+gilt, der String $v_i$ ist also der Rest, der von dem String $w$ \"ubrig bleibt, wenn das Pr\"afix
 $u_i$ entfernt wird.
 \begin{enumerate}
 \item[I.A.] $i=1$: Die Start-Konfiguration ist 
@@ -476,13 +476,13 @@ $u_i$ entfernt wird.
               \label{eq:e3}
             u_{i+1}A_{i+1}\beta_{i+1} = u_i\gamma_i\beta_i.              
             \end{equation}
-            Wegen (\ref{eq:e2}) muss $u_i$ ein Präfix von $u_{i+1}$ sein.  Also gibt es einen
+            Wegen (\ref{eq:e2}) muss $u_i$ ein Pr\"afix von $u_{i+1}$ sein.  Also gibt es einen
             String $t_{i+1}\in T^*$, so dass
             \\[0.2cm]
             \hspace*{1.3cm}
             $u_i\, t_{i+1} = u_{i+1}$
             \\[0.2cm]
-            gilt.  Schneiden wir in Gleichung (\ref{eq:e3}) auf beiden Seiten den Präfix
+            gilt.  Schneiden wir in Gleichung (\ref{eq:e3}) auf beiden Seiten den Pr\"afix
             $u_i$ ab, so erhalten wir
             \begin{equation}
               \label{eq:e4}
@@ -493,7 +493,7 @@ $u_i$ entfernt wird.
             \hspace*{1.3cm}
             $S \lmderiv\!\!^* u_{i+1}A_{i+1}\beta_{i+1} \lmderiv\!\!^* w$,
             \\[0.2cm] 
-            muss $u_{i+1}$ ein Präfix von $w$ sein und daher gibt es genau ein $v_{i+1} \in T^*$, so dass
+            muss $u_{i+1}$ ein Pr\"afix von $w$ sein und daher gibt es genau ein $v_{i+1} \in T^*$, so dass
             \\[0.2cm]
             \hspace*{1.3cm}
             $u_{i+1} v_{i+1} = w$ 
@@ -521,12 +521,12 @@ $u_i$ entfernt wird.
             \end{equation}
             Wir haben oben gesehen, dass
             $v_i = t_{i+1}v_{i+1}$ gilt und Gleichung (\ref{eq:e4}) zeigt $\gamma_i \beta_i = t_{i+1}A_{i+1}\beta_{i+1}$.
-            Also können wir  (\ref{eq:e5}) auch als
+            Also k\"onnen wir  (\ref{eq:e5}) auch als
             \begin{equation}
               \label{eq:e6}
               \pair(v_i,A_i \beta_i) \vdash \pair(t_{i+1}v_{i+1},t_{i+1}A_{i+1} \beta_{i+1})
             \end{equation}
-            schreiben.  Nun gilt nach Kunstruktion von $A(G)$ für alle Buchstaben
+            schreiben.  Nun gilt nach Kunstruktion von $A(G)$ f\"ur alle Buchstaben
             $b \in T$
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -542,14 +542,14 @@ $u_i$ entfernt wird.
             \hspace*{1.3cm}
             $\pair(w,S) \vdash^* \pair(v_{i+1},A_{i+1} \beta_{i+1})$,
             \\[0.2cm]
-            was für den Induktions-Schritt zu zeigen war und die Induktion ist abgeschlossen.
+            was f\"ur den Induktions-Schritt zu zeigen war und die Induktion ist abgeschlossen.
 \end{enumerate}
 Setzen wir oben $i=n$, so haben wir gezeigt, dass
 \begin{equation}
   \label{eq:e7}
   \pair(w,S) \vdash^* \pair(v_n, A_n\beta_n) \quad \mbox{und} \quad u_nv_n = w
 \end{equation}
-gilt und wissen außerdem, dass 
+gilt und wissen au{\ss}erdem, dass 
 \\[0.2cm]
 \hspace*{1.3cm}
 $u_n A_n \beta_n \lmderiv w$
@@ -570,7 +570,7 @@ haben
 \hspace*{1.3cm}
 $\pair(v_n, A_n\beta_n) \vdash \pair(v_n, \gamma_n \beta_n) = \pair(v_n, v_n)$.
 \\[0.2cm]
-Da nach Kunstruktion von $A(G)$ für alle Buchstaben
+Da nach Kunstruktion von $A(G)$ f\"ur alle Buchstaben
 $b \in T$ gilt $\varepsilon \in \delta(b,b)$,  haben wir
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -584,7 +584,7 @@ $\pair(w,S) \vdash^* \pair(\varepsilon, [])$
 gezeigt und wir sehen, dass $w \in L\bigl(A(G)\bigr)$ gilt.
 \vspace*{0.3cm}
 
-Um den Beweis abzuschließen, zeigen wir nun die umgekehrte Richtung und weisen 
+Um den Beweis abzuschlie{\ss}en, zeigen wir nun die umgekehrte Richtung und weisen 
 \\[0.2cm]
 \hspace*{1.3cm}
 $L\bigl(A(G)\bigr) \subseteq L(G)$
@@ -598,26 +598,26 @@ L\bigl(A(G)\bigr)$ dass aus
 \hspace*{1.3cm}
 $\pair(w,S) \vdash^* \pair(\varepsilon,[])$ \quad die Konklusion \quad $S \Rightarrow^* w$
 \\[0.2cm]
-folgt.  Wir müssen also die Beziehung
+folgt.  Wir m\"ussen also die Beziehung
 \\[0.2cm]
 \hspace*{1.3cm}
 $\pair(w,S) \vdash^* \pair(\varepsilon,[]) \;\rightarrow\; S \Rightarrow^* w$
 \\[0.2cm]
-nachweisen.  Um diese Behauptung zeigen zu können, verallgemeinern wir sie:  Wir werden
-für jede syntaktische Variable $X$ und jedes Wort $w \in T^*$ zeigen, dass
+nachweisen.  Um diese Behauptung zeigen zu k\"onnen, verallgemeinern wir sie:  Wir werden
+f\"ur jede syntaktische Variable $X$ und jedes Wort $w \in T^*$ zeigen, dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $\pair(w,X) \vdash^* \pair(\varepsilon,[]) \;\rightarrow\; X \Rightarrow^* w$
 \\[0.2cm]
-gilt.  Der Beweis dieser Behauptung erfolgt durch Induktion über die Anzahl $n$ der
+gilt.  Der Beweis dieser Behauptung erfolgt durch Induktion \"uber die Anzahl $n$ der
 Berechnungs-Schritte des Keller-Automaten $A(G)$.
 \begin{enumerate}
 \item[I.A.] $n=1$: $X$ kann sowohl eine syntaktische Variable als auch ein Terminal sein.
-            Wir behandeln diese beiden Fälle getrennt:
+            Wir behandeln diese beiden F\"alle getrennt:
             \begin{enumerate}
             \item $X \in V$, also ist $X$ eine syntaktische Variable.
 
-                  Die Zustands-Übergänge des Keller-Automaten $A(G)$, bei denen ein Buchstabe
+                  Die Zustands-\"Uberg\"ange des Keller-Automaten $A(G)$, bei denen ein Buchstabe
                   des Wortes gelesen wird, setzen alle voraus, dass auf dem Stack 
                   derselbe Buchstabe liegt.
                   Falls der Keller-Automaten nur einen Schritt braucht, um von der
@@ -654,13 +654,13 @@ Berechnungs-Schritte des Keller-Automaten $A(G)$.
             \hspace*{1.3cm}
             $\pair(w,X) \vdash^* \pair(\varepsilon,[])$
             \\[0.2cm]
-            mehr als ein Schritt durchgeführt wird, kann $X$ nur eine syntaktische Variable sein.            
+            mehr als ein Schritt durchgef\"uhrt wird, kann $X$ nur eine syntaktische Variable sein.            
             Wir nehmen also an, dass der Automat die Rechnung
             \\[0.2cm]
             \hspace*{1.3cm}
             $\pair(w,X) \vdash^* \pair(\varepsilon,[])$
             \\[0.2cm]
-            in $n+1$ Schritten durchführt.  Da $X$ eine Variable ist,
+            in $n+1$ Schritten durchf\"uhrt.  Da $X$ eine Variable ist,
             muss der erste Schritt der Rechnung des Keller-Automaten $A(G)$ die Form
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -682,9 +682,9 @@ Berechnungs-Schritte des Keller-Automaten $A(G)$.
             \hspace*{1.3cm}
             $\pair(w,y_1 y_2 \cdots y_k) \vdash^* \pair(\varepsilon, [])$,
             \\[0.2cm]
-            wobei der Keller-Automat insgesamt $n$ Schritte durchführt.  Offenbar entfernt
+            wobei der Keller-Automat insgesamt $n$ Schritte durchf\"uhrt.  Offenbar entfernt
             der Keller-Automat $A(G)$ nacheinander die Zeichen $y_1 y_2 \cdots y_k$ vom
-            Stack und liest dabei das Wort $w$.  Damit können wir die Rechnung des
+            Stack und liest dabei das Wort $w$.  Damit k\"onnen wir die Rechnung des
             Keller-Automaten wie folgt aufspalten:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -693,7 +693,7 @@ Berechnungs-Schritte des Keller-Automaten $A(G)$.
             \\[0.2cm]
             Dabei bezeichnet $w_i$ den Teil des Wortes $w$, der noch nicht gelesen ist,
             wenn die Zeichen $y_1 \cdots y_{i-1}$ vom Stack entfernt worden sind.
-            Offenbar können wir 
+            Offenbar k\"onnen wir 
             das Wort $w$ so in Teilstrings $x_1 \cdots x_k$ zerlegen, dass $x_i$ der
             Teilstring von $w$ ist, der von dem Automaten gelesen wird, um das Zeichen
             $y_i$ vom Stack zu entfernen, es gilt also
@@ -709,16 +709,16 @@ Berechnungs-Schritte des Keller-Automaten $A(G)$.
               \vdash^* \pair(\underbrace{x_{i+1} \cdots x_k}_{w_{i+1}}, y_{i+1} \cdots y_{k})
             \end{equation}
             Da der Keller-Automat immer nur das oberste Zeichen auf dem Stack anschauen
-            kann, können die Zeichen $y_{i+1} \cdots y_{k}$ bei dieser Rechnung keine
+            kann, k\"onnen die Zeichen $y_{i+1} \cdots y_{k}$ bei dieser Rechnung keine
             Rolle spielen, und genauso spielt auch der Teil des Strings, der bei dieser
             Rechnung nicht gelesen wird, keine Rolle.  Damit folgt aus (\ref{eq:e8}), dass 
             \begin{equation}
               \label{eq:e9}
               \pair(x_i, y_i) \vdash^* \pair(\varepsilon, [])                          
             \end{equation}
-            gilt und für diese Rechnung benötigt der Keller-Automat genausoviele
-            Berechnungs-Schritte wie in (\ref{eq:e8}) und das sind höchstens $n$ Schritte.
-            Damit können wir auf (\ref{eq:e9}) die Induktions-Voraussetzung anwenden und es gilt
+            gilt und f\"ur diese Rechnung ben\"otigt der Keller-Automat genausoviele
+            Berechnungs-Schritte wie in (\ref{eq:e8}) und das sind h\"ochstens $n$ Schritte.
+            Damit k\"onnen wir auf (\ref{eq:e9}) die Induktions-Voraussetzung anwenden und es gilt
             \begin{equation}
               \label{eq:e10}
               y_i \Rightarrow^* x_i
@@ -752,15 +752,15 @@ Konstruieren Sie einen Keller-Automaten, der die Sprache $L(G)$ akzeptiert.
 
 \section{Von Keller-Automaten zu kontextfreien Sprachen}
 Nach dem letzten Abschnitt wissen wir, dass das Konzept der Keller-Automaten mindestens so
-mächtig ist, wie das Konzept der kontextfreien Sprachen.
+m\"achtig ist, wie das Konzept der kontextfreien Sprachen.
 Wir zeigen in diesem Abschnitt die umgekehrte Richtung und weisen nach, dass alle
-Sprachen, die von Keller-Automaten erkannt werden können, auch durch eine Grammatik
-beschrieben werden können.
+Sprachen, die von Keller-Automaten erkannt werden k\"onnen, auch durch eine Grammatik
+beschrieben werden k\"onnen.
 
 \begin{Satz} \label{satz:keller2grammar}
   Es sei $A = \langle \Sigma, \Gamma, \delta, S \rangle$ ein Keller-Automat.  Wir nehmen
-  ohne Beschränkung der Allgemeinheit an, dass die Mengen $\Sigma$ und $\Gamma$ disjunkt
-  sind.  Dies können wir immer erreichen, indem wir die Symbole aus $\Gamma$ umbenennen.
+  ohne Beschr\"ankung der Allgemeinheit an, dass die Mengen $\Sigma$ und $\Gamma$ disjunkt
+  sind.  Dies k\"onnen wir immer erreichen, indem wir die Symbole aus $\Gamma$ umbenennen.
   Dann konstruieren wir eine Grammatik 
   \\[0.2cm]
   \hspace*{1.3cm}
@@ -769,12 +769,12 @@ beschrieben werden können.
   indem wir die Menge $R$ der Regeln wie folgt definieren:
   \begin{enumerate}
   \item Ist $b \in \Sigma$, $X \in \Gamma$ und gilt $\gamma \in \delta(b,X)$,
-        dann enthält $R$ die Regel
+        dann enth\"alt $R$ die Regel
         \\[0.2cm]
         \hspace*{1.3cm}
         $X \rightarrow b\gamma$.
   \item Ist $X \in \Gamma$ und gilt $\gamma \in \delta(\varepsilon, X)$,
-        dann enthält $R$ die Regel 
+        dann enth\"alt $R$ die Regel 
         \\[0.2cm]
         \hspace*{1.3cm}
         $X \rightarrow \gamma$.
@@ -793,23 +793,23 @@ beschrieben werden können.
 
 \noindent
 \textbf{Beweis}:
-Wir zerlegen den Beweis in zwei Teile und zeigen zunächst, dass
+Wir zerlegen den Beweis in zwei Teile und zeigen zun\"achst, dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $L\bigl(G(A)\bigr) \subseteq L(A)$
 \\[0.2cm]
-gilt.  Diese Behauptung ist äquivalent zu
+gilt.  Diese Behauptung ist \"aquivalent zu
 \\[0.2cm]
 \hspace*{1.3cm}
 $S \Rightarrow^* w \;\rightarrow\; \pair(w,S) \vdash^* \pair(\varepsilon, [])$
 \\[0.2cm]
 Wir zeigen eine etwas allgemeinere Behauptung.  Wir zeigen durch Induktion nach $n$, dass
-für alle $X \in \Gamma$ und $w \in \Sigma^*$ folgendes gilt:
+f\"ur alle $X \in \Gamma$ und $w \in \Sigma^*$ folgendes gilt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $X \Rightarrow^n w \;\rightarrow\; \pair(w,X) \vdash^* \pair(\varepsilon, [])$
 \\[0.2cm]
-Hier drückt die Notation $X \Rightarrow^n w$ aus, dass das Wort $w$ aus der Variablen $X$ 
+Hier dr\"uckt die Notation $X \Rightarrow^n w$ aus, dass das Wort $w$ aus der Variablen $X$ 
 in $n$ Schritten abgeleitet werden kann.  
 \begin{enumerate}
 \item[I.A.] $n = 1$.  Dann gibt es in der Grammatik $G(A)$ eine Regel der Form 
@@ -817,7 +817,7 @@ in $n$ Schritten abgeleitet werden kann.
             \hspace*{1.3cm}
             $X \rightarrow w$
             \\[0.2cm]
-            Es gibt zwei Möglichkeiten, wie diese Regel entstanden sein kann.
+            Es gibt zwei M\"oglichkeiten, wie diese Regel entstanden sein kann.
             \begin{enumerate}
             \item $w = b \gamma$ mit $b \in \Sigma$ und $\gamma \in \delta(b,X)$.
 
@@ -829,7 +829,7 @@ in $n$ Schritten abgeleitet werden kann.
                   $\gamma \in \Sigma^* \cap \Gamma^*$.
                   \\[0.2cm]
                   Nun haben wir aber vorausgesetzt, dass das Eingabe-Alphabet $\Sigma$ und das
-                  Stack-Alphabet $\Gamma$ disjunkt sind.  Damit ist die obige Gleichung nur möglich,
+                  Stack-Alphabet $\Gamma$ disjunkt sind.  Damit ist die obige Gleichung nur m\"oglich,
                   falls
                   \\[0.2cm]
                   \hspace*{1.3cm}
@@ -848,16 +848,16 @@ in $n$ Schritten abgeleitet werden kann.
 
                   Einerseits gilt dann $w \in \Sigma^*$, andererseits folgt aus 
                   $\gamma \in \delta(\varepsilon,X)$, dass $\gamma \in \Gamma^*$ gelten muss und genau wie im 
-                  ersten Fall können wir daraus auf \\[0.2cm]
+                  ersten Fall k\"onnen wir daraus auf \\[0.2cm]
                   \hspace*{1.3cm}
                   $\gamma = \varepsilon$
                   \\[0.2cm]
-                  schließen. Daraus folgt dann
+                  schlie{\ss}en. Daraus folgt dann
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $\pair(\varepsilon, X) \vdash \pair(\varepsilon, [])$.
             \end{enumerate}
-\item[I.S.] $n \mapsto n+1$.  Wieder gibt es zwei Möglichkeiten für die erste verwendete Regel.
+\item[I.S.] $n \mapsto n+1$.  Wieder gibt es zwei M\"oglichkeiten f\"ur die erste verwendete Regel.
 
             \begin{enumerate}
             \item Die erste bei der Ableitung $X \Rightarrow^{n+1} w$ verwendete Regel hat die Form
@@ -872,12 +872,12 @@ in $n$ Schritten abgeleitet werden kann.
                   Dann haben $\gamma$ und $v$ die Form
                   \\[0.2cm]
                   \hspace*{1.3cm} $\gamma = Y_1 \cdots Y_k$, \quad $v = u_1 \cdots u_k$ \quad und \quad $Y_i
-                  \Rightarrow^* u_i$ \quad für alle $i=1,\cdots,k$.
+                  \Rightarrow^* u_i$ \quad f\"ur alle $i=1,\cdots,k$.
                   \\[0.2cm]
-                  Auf $Y_i \Rightarrow^* u_i$ können wir die Induktions-Voraussetzung anwenden und sehen, dass
+                  Auf $Y_i \Rightarrow^* u_i$ k\"onnen wir die Induktions-Voraussetzung anwenden und sehen, dass
                   \\[0.2cm]
                   \hspace*{1.3cm} 
-                  $\pair(u_i, Y_i) \vdash^* \pair(\varepsilon, [])$ \quad für alle $i=1,\cdots,k$
+                  $\pair(u_i, Y_i) \vdash^* \pair(\varepsilon, [])$ \quad f\"ur alle $i=1,\cdots,k$
                   \\[0.2cm]
                   gilt. Setzen wir diese Rechnungen zusammen, so haben wir
                   \\[0.2cm]
@@ -902,13 +902,13 @@ in $n$ Schritten abgeleitet werden kann.
                   Dann haben $\gamma$ und $w$ die Form
                   \\[0.2cm]
                   \hspace*{1.3cm} $\gamma = Y_1 \cdots Y_k$, \quad $w = u_1 \cdots u_k$ \quad und
-                  \quad $Y_i \Rightarrow^* u_i$ \quad für alle $i=1,\cdots,k$.
+                  \quad $Y_i \Rightarrow^* u_i$ \quad f\"ur alle $i=1,\cdots,k$.
                   \\[0.2cm]
-                  Die Ableitung $Y_i \Rightarrow^* u_i$ kann höchstens aus $n$ Schritten bestehen
-                  und daher können wir die Induktions-Voraussetzung anwenden und sehen, dass
+                  Die Ableitung $Y_i \Rightarrow^* u_i$ kann h\"ochstens aus $n$ Schritten bestehen
+                  und daher k\"onnen wir die Induktions-Voraussetzung anwenden und sehen, dass
                   \\[0.2cm]
                   \hspace*{1.3cm} 
-                  $\pair(u_i, Y_i) \vdash^* \pair(\varepsilon, [])$ \quad für alle $i=1,\cdots,k$
+                  $\pair(u_i, Y_i) \vdash^* \pair(\varepsilon, [])$ \quad f\"ur alle $i=1,\cdots,k$
                   \\[0.2cm]
                   gilt. Setzen wir diese Rechnungen zusammen, so haben wir
                   \\[0.2cm]
@@ -925,20 +925,20 @@ in $n$ Schritten abgeleitet werden kann.
             \end{enumerate}
             Damit ist der Induktions-Beweis abgeschlossen.
 \end{enumerate}
-Um den Beweis abzuschließen, zeigen wir nun, dass
+Um den Beweis abzuschlie{\ss}en, zeigen wir nun, dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(A) \subseteq L\bigl(G(A)\bigr)$
 \\[0.2cm]
-gilt.  Dazu zeigen wir, dass für alle $X \in \Gamma$ folgendes gilt:
+gilt.  Dazu zeigen wir, dass f\"ur alle $X \in \Gamma$ folgendes gilt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\pair(w,X) \vdash^n \pair(\varepsilon, []) \;\rightarrow\; X \Rightarrow^n w$.
 \\[0.2cm]
-Diesen Beweis führen wir durch Induktion nach $n$.
+Diesen Beweis f\"uhren wir durch Induktion nach $n$.
 \begin{enumerate}
 \item[I.A.] $n = 1$.  Dann ist $w$ entweder das leere Wort oder $w$ besteht aus einem einzigen Buchstaben 
-            $b \in \Sigma$.  Wir untersuchen die beiden Fälle getrennt.
+            $b \in \Sigma$.  Wir untersuchen die beiden F\"alle getrennt.
             \begin{enumerate}
             \item $w = b \in \Sigma$.  Dann gilt $\varepsilon \in \delta(b,X)$.
                   Nach Konstruktion der Grammatik $G(A)$ gibt es eine Regel
@@ -955,51 +955,51 @@ Diesen Beweis führen wir durch Induktion nach $n$.
                   \\[0.2cm]
                   Daraus folgt sofort $X \Rightarrow \varepsilon = w$.
             \end{enumerate}
-\item[I.S.] $n \mapsto n+1$.  Wieder gibt es zwei Fälle, die wir getrennt betrachten.
+\item[I.S.] $n \mapsto n+1$.  Wieder gibt es zwei F\"alle, die wir getrennt betrachten.
             \begin{enumerate}
             \item Die Rechnung $\pair(w,X) \vdash^n \pair(\varepsilon, [])$
-                  fängt mit dem Übergang $\gamma \in \delta(b,X)$ an. Dann
+                  f\"angt mit dem \"Ubergang $\gamma \in \delta(b,X)$ an. Dann
                   muss $w = bv$ gelten und wir haben
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $\pair(w, X) = \pair(bv, X) \vdash \pair(v, \gamma) \vdash^n \pair(\varepsilon, [])$.
                   \\[0.2cm]
-                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $v$ lässt sich zerlegen
+                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $v$ l\"asst sich zerlegen
                   als $v = u_1 \cdots u_k$ und es ist $u_i$ gerade der Teil des Wortes $v$, der
                   gelesen wird, um die Variable $Y_i$ vom Stack zu entfernen, es gilt also
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $\pair(u_i, Y_i) \vdash^* \pair(\varepsilon, [])$.
                   \\[0.2cm]
-                  Diese Rechnung kann höchstens $n$ Schritte benötigen.  Also haben wir
+                  Diese Rechnung kann h\"ochstens $n$ Schritte ben\"otigen.  Also haben wir
                   nach Induktions-Voraussetzung
                   \\[0.2cm]
                   \hspace*{1.3cm}
-                  $Y_i \Rightarrow^* u_i$ \quad für alle $i = 1, \cdots, k$.
+                  $Y_i \Rightarrow^* u_i$ \quad f\"ur alle $i = 1, \cdots, k$.
                   \\[0.2cm]
-                  Wegen $\gamma \in \delta(b,X)$ enthält die Grammatik $G(A)$ die Regel $X \rightarrow b \gamma$ und
+                  Wegen $\gamma \in \delta(b,X)$ enth\"alt die Grammatik $G(A)$ die Regel $X \rightarrow b \gamma$ und
                   damit haben wir insgesamt
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $X \Rightarrow b \gamma = bY_1 \cdots Y_k \Rightarrow^* b u_1 \cdots u_k = bv = w$.
             \item Die Rechnung $\pair(w,X) \vdash^n \pair(\varepsilon, [])$
-                  fängt mit dem Übergang $\gamma \in \delta(\varepsilon,X)$ an. Dann
+                  f\"angt mit dem \"Ubergang $\gamma \in \delta(\varepsilon,X)$ an. Dann
                   haben wir
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $\pair(w, X) \vdash \pair(w, \gamma) \vdash^n \pair(\varepsilon, [])$.
                   \\[0.2cm]
-                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $w$ lässt sich zerlegen
+                  Dann hat $\gamma$ die Form $\gamma = Y_1 \cdots Y_k$, $w$ l\"asst sich zerlegen
                   als $w = u_1 \cdots u_k$ und es ist $u_i$ gerade der Teil des Wortes $w$, der
                   gelesen wird, um die Variable $Y_i$ vom Stack zu entfernen, es gilt also
                   \\[0.2cm]
                   \hspace*{1.3cm}
                   $\pair(u_i, Y_i) \vdash^* \pair(\varepsilon, [])$.
                   \\[0.2cm]
-                  Diese Rechnung kann höchstens $n$ Schritte benötigen.  Also haben wir
+                  Diese Rechnung kann h\"ochstens $n$ Schritte ben\"otigen.  Also haben wir
                   nach Induktions-Voraussetzung wieder
-                  $Y_i \Rightarrow^* u_i$  für alle $i = 1, \cdots, k$.
-                  Wegen $\gamma \in \delta(\varepsilon,X)$ enthält die Grammatik $G(A)$ die Regel 
+                  $Y_i \Rightarrow^* u_i$  f\"ur alle $i = 1, \cdots, k$.
+                  Wegen $\gamma \in \delta(\varepsilon,X)$ enth\"alt die Grammatik $G(A)$ die Regel 
                   $X \rightarrow \gamma$ und 
                   damit haben wir insgesamt
                   \\[0.2cm]

--- a/Lecture-Notes/kontextfreie-sprachen.tex
+++ b/Lecture-Notes/kontextfreie-sprachen.tex
@@ -14,50 +14,50 @@ available for parsing a string into a parse tree.
 
 \section{Kontextfreie Grammatiken \label{kontextfreie}}
 Kontextfreie Sprachen dienen zur Beschreibung von Programmier-Sprachen, insofern handelt
-es sich bei den kontextfreien Sprachen genau wie bei den regulären Sprachen ebenfalls um
-formale Sprachen.  Allerdings wollen wir später beim Einlesen eines Programms nicht nur
-entscheiden, ob das Programm korrekt ist, sondern wir wollen darüber hinaus den
+es sich bei den kontextfreien Sprachen genau wie bei den regul\"aren Sprachen ebenfalls um
+formale Sprachen.  Allerdings wollen wir sp\"ater beim Einlesen eines Programms nicht nur
+entscheiden, ob das Programm korrekt ist, sondern wir wollen dar\"uber hinaus den
 Programm-Text \emph{strukturieren}.  Den Vorgang des \emph{Strukturierens} bezeichnen wir
 auch als \emph{parsen} und das Programm, das diese Strukturierung vornimmt, wird als
-\emph{Parser} bezeichnet.  Als Eingabe erhält ein Parser üblicherweise nicht den
+\emph{Parser} bezeichnet.  Als Eingabe erh\"alt ein Parser \"ublicherweise nicht den
 Text eines Programms, sondern statt dessen eine Folge sogenannter \emph{Terminale}, die auch
 als \emph{Token} bezeichnet werden.  Diese 
-Token werden von einem Scanner erzeugt, der mit Hilfe regulärer Ausdrücke den Programmtext
-in einzelne Wörter aufspaltet, die wir in diesem Zusammenhang als Token bezeichnen.
+Token werden von einem Scanner erzeugt, der mit Hilfe regul\"arer Ausdr\"ucke den Programmtext
+in einzelne W\"orter aufspaltet, die wir in diesem Zusammenhang als Token bezeichnen.
 Beispielsweise spaltet der Scanner des \texttt{C}-Compilers ein \texttt{C}-Programm in die
 folgenden Token auf:
 \begin{itemize}
 \item Operator-Symbole wie ``\texttt{+}'', ``\texttt{+=}'', ``\texttt{<}'',
       ``\texttt{<=}'' etc.,
 \item Klammer-Symbole wie ``\texttt{(}'', ``\texttt{[}'', ``\texttt{\{}''  oder
-      die schließenden Klammern ``\texttt{)}'', ``\texttt{]}'', ``\texttt{\}}'',
-\item vordefinierte Schlüsselwörter wie ``\texttt{if}'', ``\texttt{while}'',
+      die schlie{\ss}enden Klammern ``\texttt{)}'', ``\texttt{]}'', ``\texttt{\}}'',
+\item vordefinierte Schl\"usselw\"orter wie ``\texttt{if}'', ``\texttt{while}'',
       ``\texttt{typedef}'', ``\texttt{struct}'', etc.,
 \item Variablen- und Funktions-Namen wie ``\texttt{x}'', ``\texttt{y}'',
       ``\texttt{printf}'', etc.,
-\item Namen für Typen wie ``\texttt{int}'', ``\texttt{char}'' oder auch benutzerdefinierte
+\item Namen f\"ur Typen wie ``\texttt{int}'', ``\texttt{char}'' oder auch benutzerdefinierte
       Typnamen,
 \item Literale zur Bezeichnung von Konstanten, wie ``\texttt{1.23}'', 
       ``\texttt{\symbol{34}hallo\symbol{34}}'' oder ``\texttt{\symbol{96}c\symbol{96}}''
 \item Kommentare,
-\item \emph{White-Space-Zeichen}, (Leerzeichen, Tabulatoren, Zeilenumbrüche).
+\item \emph{White-Space-Zeichen}, (Leerzeichen, Tabulatoren, Zeilenumbr\"uche).
 \end{itemize}
-Der Parser erhält vom Scanner eine Folge solcher Token und hat die Aufgabe, daraus
+Der Parser erh\"alt vom Scanner eine Folge solcher Token und hat die Aufgabe, daraus
 einen sogenannten \emph{Syntax-Baum} zu konstruieren.  Dazu bedient sich der Parser einer
 \emph{Grammatik}, die mit Hilfe von \emph{Grammatik-Regeln} angibt, wie die Eingabe zu
-strukturieren ist.  Betrachten wir als Beispiel das Parsen arithmetischer Ausdrücke.  Die
-Menge \textsl{ArithExpr} der arithmetischen Ausdrücke können wir induktiv definieren.  
-Um die Struktur arithmetischer Ausdrücke korrekt wiedergeben zu können, definieren wir
+strukturieren ist.  Betrachten wir als Beispiel das Parsen arithmetischer Ausdr\"ucke.  Die
+Menge \textsl{ArithExpr} der arithmetischen Ausdr\"ucke k\"onnen wir induktiv definieren.  
+Um die Struktur arithmetischer Ausdr\"ucke korrekt wiedergeben zu k\"onnen, definieren wir
 gleichzeitig die Mengen \textsl{Product} und \textsl{Factor}.  
-Die Menge \textsl{Product} enthält arithmetische
-Ausdrücke, die Produkte und Quotienten darstellen und die Menge \textsl{Factor} enthält
-einzelne Faktoren.  Die Definition dieser zusätzlichen Mengen ist notwendig, um später die
-Präzedenzen der Operatoren korrekt darstellen zu können.
-Die Grundbausteine der arithmetischen Ausdrücke sind Variablen, Zahlen, die
+Die Menge \textsl{Product} enth\"alt arithmetische
+Ausdr\"ucke, die Produkte und Quotienten darstellen und die Menge \textsl{Factor} enth\"alt
+einzelne Faktoren.  Die Definition dieser zus\"atzlichen Mengen ist notwendig, um sp\"ater die
+Pr\"azedenzen der Operatoren korrekt darstellen zu k\"onnen.
+Die Grundbausteine der arithmetischen Ausdr\"ucke sind Variablen, Zahlen, die
 Operator-Symbole 
 ``\texttt{+}'', ``\texttt{-}'', ``\texttt{*}'', ``\texttt{/}'',
 und die Klammer-Symbole ``\texttt{(}'' und ``\texttt{)}''.  Aufbauend auf diesen Symbolen
-verläuft die induktive Definition der Mengen \textsl{Factor}, \textsl{Product} und
+verl\"auft die induktive Definition der Mengen \textsl{Factor}, \textsl{Product} und
 \textsl{ArithExpr} wie folgt:
 \begin{enumerate}
 \item Jede Zahlenkonstante ist ein Faktor:
@@ -68,16 +68,16 @@ verläuft die induktive Definition der Mengen \textsl{Factor}, \textsl{Product} u
       \\[0.2cm]
       \hspace*{1.3cm}
       $V \in \textsl{Variable} \Rightarrow V \in \textsl{Factor}$.
-\item Ist $A$ ein arithmetischer Ausdruck und schließen wir diesen Ausdruck in Klammern
-      ein, so erhalten wir einen Ausdruck, den wir als Faktor benützen können:
+\item Ist $A$ ein arithmetischer Ausdruck und schlie{\ss}en wir diesen Ausdruck in Klammern
+      ein, so erhalten wir einen Ausdruck, den wir als Faktor ben\"utzen k\"onnen:
       \\[0.2cm]
       \hspace*{1.3cm}
       $A \in \textsl{ArithExpr} \Rightarrow \quoted{(}A\quoted{)} \in \textsl{Factor}$. 
       \\[0.2cm] 
-      Ein Wort zur Notation: Während in der obigen Formel $A$ eine Meta-Variable ist, die für
+      Ein Wort zur Notation: W\"ahrend in der obigen Formel $A$ eine Meta-Variable ist, die f\"ur
       einen beliebigen arithmetischen Ausdruck steht, sind die Strings ``\texttt{(}'' 
-      und ``\texttt{)}'' wörtlich zu interpretieren und 
-      deshalb in Gänsefüßchen eingeschlossen.  Die Gänsefüßchen sind natürlich nicht Teil
+      und ``\texttt{)}'' w\"ortlich zu interpretieren und 
+      deshalb in G\"ansef\"u{\ss}chen eingeschlossen.  Die G\"ansef\"u{\ss}chen sind nat\"urlich nicht Teil
       des arithmetischen 
       Ausdrucks sondern dienen lediglich der Notation.
 \item Ist $F$ ein Faktor, so ist $F$ gleichzeitig auch ein Produkt:
@@ -96,7 +96,7 @@ verläuft die induktive Definition der Mengen \textsl{Factor}, \textsl{Product} u
       \hspace*{1.3cm}
       $P \in \textsl{Product} \Rightarrow P \in \textsl{ArithExpr}$.
 \item Ist $A$ ein arithmetischer Ausdruck und ist $P$ ein Produkt, so sind auch
-      die Strings $A \quoted{+} P$ und $A \quoted{-} P$  arithmetische Ausdrücke:
+      die Strings $A \quoted{+} P$ und $A \quoted{-} P$  arithmetische Ausdr\"ucke:
       \\[0.2cm]
       \hspace*{1.3cm}
       $A \in \textsl{ArithExpr} \wedge P \in \textsl{Product} \Rightarrow
@@ -104,7 +104,7 @@ verläuft die induktive Definition der Mengen \textsl{Factor}, \textsl{Product} u
 \end{enumerate}
 Die oben angegebenen Regeln definieren die Mengen \textsl{Factor}, \textsl{Product} und
 \textsl{ArithExpr} durch wechselseitige Rekursion.
-Diese Definition können  wir in Form von sogenannten \emph{Grammatik-Regeln} wesentlich
+Diese Definition k\"onnen  wir in Form von sogenannten \emph{Grammatik-Regeln} wesentlich
 kompakter schreiben:
 \begin{eqnarray*}
   \textsl{arithExpr} & \rightarrow & \textsl{arithExpr} \quoted{+} \textsl{product}  \\
@@ -117,16 +117,16 @@ kompakter schreiben:
   \textsl{factor}    & \rightarrow & \textsc{Variable}                               \\
   \textsl{factor}    & \rightarrow & \textsc{Number} 
 \end{eqnarray*}
-Die Ausdrücke auf der linken Seite einer Grammatik-Regel bezeichnen wir als
+Die Ausdr\"ucke auf der linken Seite einer Grammatik-Regel bezeichnen wir als
 \emph{syntaktische Variablen} oder auch als \emph{Nicht-Terminale}.  
-Wir werden syntaktische Variablen üblicherweise klein schreiben, denn das ist die Konvention
-bei den  Parser-Generatoren \textsc{Antlr} und \textsl{JavaCup}, die wir später vorstellen werden. 
-In der Literatur ist es allerdings oft anders herum.  Dort werden die syntaktischen Variablen groß und
+Wir werden syntaktische Variablen \"ublicherweise klein schreiben, denn das ist die Konvention
+bei den  Parser-Generatoren \textsc{Antlr} und \textsl{JavaCup}, die wir sp\"ater vorstellen werden. 
+In der Literatur ist es allerdings oft anders herum.  Dort werden die syntaktischen Variablen gro{\ss} und
 die \emph{Terminale}  klein geschrieben.  Gelegentlich wird eine
 syntaktische Variable auch als eine \emph{syntaktische Kategorie} bezeichnet.
  
 In dem Beispiel sind \textsl{arithExpr}, \textsl{product} und \textsl{factor} die 
-syntaktischen Variablen.  Die restlichen Ausdrücke, in unserem Fall also \textsc{Number}, \textsc{Variable} und
+syntaktischen Variablen.  Die restlichen Ausdr\"ucke, in unserem Fall also \textsc{Number}, \textsc{Variable} und
 die Zeichen 
 ``\texttt{+}'', ``\texttt{-}'', ``\texttt{*}'', ``\texttt{/}'', ``\texttt{(}'' und ``\texttt{)}''
 bezeichnen wir als \emph{Terminale} oder auch \emph{Token}.  Dies sind also genau die
@@ -136,15 +136,15 @@ Bei den Nicht-Terminalen gibt es zwei Arten:
 \item Operator-Symbole und Trennzeichen wie beispielsweise ``\texttt{/}'' und
       ``\texttt{(}''.  
 
-      Solche Nicht-Terminalen stehen für sich selbst.
-\item Token wie \textsc{Number} oder \textsc{Variable} ist zusätzlich ein Wert zugeordnet.
+      Solche Nicht-Terminalen stehen f\"ur sich selbst.
+\item Token wie \textsc{Number} oder \textsc{Variable} ist zus\"atzlich ein Wert zugeordnet.
       Im Falle von \textsc{Number} ist dies eine Zahl, im Falle von \textsc{Variable}
       ist dies ein String, der den Namen der Variablen wiedergibt.  Diese Art von Token werden wir
-      zur besseren Unterscheidung von den Variablen immer mit Großbuchstaben schreiben.
+      zur besseren Unterscheidung von den Variablen immer mit Gro{\ss}buchstaben schreiben.
       Damit folgen wir der Praxis von Parser-Generatoren wie \textsc{Antlr} und \textsl{JavaCup}.
 \end{enumerate}
-Üblicherweise werden Grammatik-Regeln in einer kompakteren Notation als der oben vorgestellten
-wiedergegeben, indem alle Regeln für ein Nicht-Terminal zusammengefasst werden.  Für unser Beispiel
+\"Ublicherweise werden Grammatik-Regeln in einer kompakteren Notation als der oben vorgestellten
+wiedergegeben, indem alle Regeln f\"ur ein Nicht-Terminal zusammengefasst werden.  F\"ur unser Beispiel
 sieht das dann wie folgt aus:
 \begin{eqnarray*}
   \textsl{arithExpr} & \rightarrow & \textsl{arithExpr} \quoted{+} \textsl{product} \;\mid\;
@@ -157,7 +157,7 @@ sieht das dann wie folgt aus:
                                      \textsc{Number} \;\mid\; \textsc{Variable}
 \end{eqnarray*}
 Hier werden also die einzelnen Alternativen einer Regel durch das Metazeichen \squoted{|}
-getrennt.  Nach dem obigen Beispiel geben wir jetzt die formale Definition für den Begriff der
+getrennt.  Nach dem obigen Beispiel geben wir jetzt die formale Definition f\"ur den Begriff der
 \href{http://en.wikipedia.org/wiki/Context-free_grammar}{kontextfreien Grammatik}.
 
 \begin{Definition}[Kontextfreie Grammatik]
@@ -196,7 +196,7 @@ so dass folgendes gilt:
             \hspace*{1.3cm}
             $\alpha \in (V \cup T)^*$.
       \end{enumerate}
-      Insgesamt gilt  für die Menge der Regeln $R$ damit
+      Insgesamt gilt  f\"ur die Menge der Regeln $R$ damit
       \\[0.2cm]
       \hspace*{1.3cm}
       $R \subseteq V \times (V \cup T)^*$
@@ -211,7 +211,7 @@ so dass folgendes gilt:
       \hspace*{1.3cm}
       $\textsl{arithExpr} \rightarrow \textsl{arithExpr} \quoted{+} \textsl{product}$
       \\[0.2cm]
-      geschrieben.  Formal steht diese Regel für das Paar
+      geschrieben.  Formal steht diese Regel f\"ur das Paar
       \\[0.2cm]
       \hspace*{1.3cm}
       $\bigl\langle \textsl{arithExpr}, [\textsl{arithExpr}, \squoted{+}, \textsl{product}] \bigr\rangle$. 
@@ -222,17 +222,17 @@ so dass folgendes gilt:
 \end{Definition}
 
 \subsection{Ableitungen}
-Als nächstes wollen wir festlegen, welche Sprache durch eine gegebene Grammatik $G$ definiert wird.
-Dazu definieren wir zunächst den Begriff eines \emph{Ableitungs-Schrittes}.  Es sei
+Als n\"achstes wollen wir festlegen, welche Sprache durch eine gegebene Grammatik $G$ definiert wird.
+Dazu definieren wir zun\"achst den Begriff eines \emph{Ableitungs-Schrittes}.  Es sei
 \begin{enumerate}
 \item $G = \langle V, T, R, S \rangle$ eine Grammatik,
 \item $a \in V$ eine syntaktische Variable,
 \item $\alpha a \beta \in (V \cup T)^*$ ein String aus Terminalen und syntaktischen Variablen,
-      der die Variable $a$ enthält,
+      der die Variable $a$ enth\"alt,
 \item $(a \rightarrow \gamma) \in R$ eine Regel.
 \end{enumerate}
 Dann kann der String $\alpha a \beta$ durch einen Ableitungs-Schritt in den String 
-$\alpha \gamma \beta$ überführt werden, wir ersetzen also ein Auftreten der syntaktische Variable
+$\alpha \gamma \beta$ \"uberf\"uhrt werden, wir ersetzen also ein Auftreten der syntaktische Variable
 $a$ durch die rechte Seite der Regel $a \rightarrow \gamma$.  Diesen Ableitungs-Schritt schreiben
 wir als
 \\[0.2cm]
@@ -240,9 +240,9 @@ wir als
 $\alpha a \beta \Rightarrow_G \alpha \gamma \beta$.
 \\[0.2cm]
 Geht die verwendete Grammatik $G$ aus dem Zusammenhang klar hervor, so wird der Index $_G$
-weggelassen und wir schreiben kürzer $\Rightarrow$ an Stelle von $\Rightarrow_G$.
+weggelassen und wir schreiben k\"urzer $\Rightarrow$ an Stelle von $\Rightarrow_G$.
 Der transitive und reflexive Abschluss der Relation $\Rightarrow_G$ wird mit $\Rightarrow_G^*$
-bezeichnet.  Wollen wir ausdrücken, dass die Ableitung des Strings $w$ aus dem
+bezeichnet.  Wollen wir ausdr\"ucken, dass die Ableitung des Strings $w$ aus dem
 Nicht-Terminal $a$ aus $n$ Ableitungs-Schritten
 besteht, so schreiben wir 
 \\[0.2cm]
@@ -306,13 +306,13 @@ $\textsl{s} \rightarrow \quoted{(} \textsl{s} \quoted{)}  \mid  \varepsilon$.
 
 
 \proof
-Wir zeigen zunächst, dass sich jedes Wort $w \in L$ aus dem
-Start-Symbol $\textsl{s}$ ableiten lässt:
+Wir zeigen zun\"achst, dass sich jedes Wort $w \in L$ aus dem
+Start-Symbol $\textsl{s}$ ableiten l\"asst:
 \\[0.2cm]
 \hspace*{1.3cm}
 $w \in L \;\Longrightarrow\; \textsl{s} \Rightarrow^* w$.
 \\[0.2cm]
-Es sei also $w_n = (^n)^n$.  Wir zeigen durch Induktion über $n \in \mathbb{N}_0$, dass $w_n \in L(G)$ ist.
+Es sei also $w_n = (^n)^n$.  Wir zeigen durch Induktion \"uber $n \in \mathbb{N}_0$, dass $w_n \in L(G)$ ist.
 \begin{enumerate}
 \item[I.A.:] $n=0$.
   
@@ -321,12 +321,12 @@ Es sei also $w_n = (^n)^n$.  Wir zeigen durch Induktion über $n \in \mathbb{N}_0
             \hspace*{1.3cm}
             $\textsl{s} \Rightarrow \varepsilon$,
             \\[0.2cm]
-            denn die Grammatik enthält die Regel $s \rightarrow \varepsilon$.
+            denn die Grammatik enth\"alt die Regel $s \rightarrow \varepsilon$.
             Also gilt $w_0 \in L(G)$.
 \item[I.S.:] $n \mapsto n + 1$. 
 
             Der String $w_{n+1}$ hat die Form $w_{n+1} = \quoted{(}w_n\quoted{)}$, wobei
-            der String $w_n$ natürlich ebenfalls in $L$ liegt.
+            der String $w_n$ nat\"urlich ebenfalls in $L$ liegt.
             Also gibt es nach I.V. eine Ableitung von $w_n$:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -339,8 +339,8 @@ Es sei also $w_n = (^n)^n$.  Wir zeigen durch Induktion über $n \in \mathbb{N}_0
             \\[0.2cm]
             Also gilt  $w_{n+1} \in L(G)$.
 \end{enumerate}
-Als nächstes zeigen wir, dass jedes Wort $w$, das sich aus $\textsl{s}$ ableiten lässt, ein Element
-der Sprache $L$ ist.  Wir führen den Beweis durch Induktion über die Anzahl $n \in \mathbb{N}$ der
+Als n\"achstes zeigen wir, dass jedes Wort $w$, das sich aus $\textsl{s}$ ableiten l\"asst, ein Element
+der Sprache $L$ ist.  Wir f\"uhren den Beweis durch Induktion \"uber die Anzahl $n \in \mathbb{N}$ der
 Ableitungs-Schritte:
 \begin{enumerate}
 \item[I.A.:] $n = 1$.
@@ -376,12 +376,12 @@ Ableitungs-Schritte:
 
 
 \exercise
-Wir definieren für $w \in \Sigma^*$ und $c \in \Sigma$ die Funktion
+Wir definieren f\"ur $w \in \Sigma^*$ und $c \in \Sigma$ die Funktion
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{count}(w,c)$,
 \\[0.2cm]
-die zählt, wie oft der Buchstabe $c$ in dem Wort $w$ vorkommt, durch Induktion über $w$.
+die z\"ahlt, wie oft der Buchstabe $c$ in dem Wort $w$ vorkommt, durch Induktion \"uber $w$.
 \begin{enumerate}
 \item[I.A.:] $w = \varepsilon$.  
 
@@ -402,8 +402,8 @@ die zählt, wie oft der Buchstabe $c$ in dem Wort $w$ vorkommt, durch Induktion ü
             $ \eox
 \end{enumerate}
 Wir setzen nun $\Sigma = \{ \squoted{A}, \squoted{B} \}$ und definieren die Sprache $L$ als die
-Menge der Wörter $w\in\Sigma^*$, in denen die Buchstaben \squoted{A} und \squoted{B} mit der
-selben Häufigkeit vorkommen:
+Menge der W\"orter $w\in\Sigma^*$, in denen die Buchstaben \squoted{A} und \squoted{B} mit der
+selben H\"aufigkeit vorkommen:
 \\[0.2cm]
 \hspace*{1.3cm}
 $L := \bigl\{ w \in \Sigma^* \mid \textsl{count}(w,\squoted{A}) = \textsl{count}(w,\squoted{B})\bigr\}$
@@ -457,30 +457,30 @@ Geben Sie eine kontextfreie Grammatik $G$ an, die diese Sprache erzeugt.
 \eox
 
 \solution 
-Die Lösung dieser Aufgabe ist so umfangreich, dass wir unsere Überlegungen in vier Teile aufspalten.
+Die L\"osung dieser Aufgabe ist so umfangreich, dass wir unsere \"Uberlegungen in vier Teile aufspalten.
 \vspace{0.2cm}
 
 \noindent
-\textbf{Vorüberlegung \texttt{I}}: String-Notationen \\
-Für einen String $s$ bezeichnen wir mit $s[i]$ den $i$-ten Buchstaben und mit
-$s[i\!:\!j]$ den Teilstring, der sich vom $i$-ten Buchstaben bis zum $j$-ten Buchstaben einschließlich
+\textbf{Vor\"uberlegung \texttt{I}}: String-Notationen \\
+F\"ur einen String $s$ bezeichnen wir mit $s[i]$ den $i$-ten Buchstaben und mit
+$s[i\!:\!j]$ den Teilstring, der sich vom $i$-ten Buchstaben bis zum $j$-ten Buchstaben einschlie{\ss}lich
 erstreckt.  Bei der Nummerierung beginnen wir mit 1.
 Dann gilt
 \begin{enumerate}
 \item $|s[i\!:\!j]| = j - i + 1$
 
-      Von der Notwendigkeit, hier eine 1 zu addieren, können wir uns dadurch überzeugen, wenn wir den
+      Von der Notwendigkeit, hier eine 1 zu addieren, k\"onnen wir uns dadurch \"uberzeugen, wenn wir den
       Fall $i = j$ betrachten, denn $s[i\!:\!i]$ ist der Teilstring, der nur aus dem $i$-ten
-      Buchstaben besteht und der hat natürlich die Länge 1.
+      Buchstaben besteht und der hat nat\"urlich die L\"ange 1.
 \item $s[i\!:\!j][k] = s[i + k - 1]$.
 
       Dass in diesem Fall 1 subtrahiert werden muss, sehen Sie, wenn Sie den Fall $k=1$ betrachten,
-      denn der erste Buchstabe des Teilstrings $s[i\!:\!j]$ ist natürlich der $i$-te
+      denn der erste Buchstabe des Teilstrings $s[i\!:\!j]$ ist nat\"urlich der $i$-te
       Buchstabe von $s$.
-\item Hat ein Wort $s \in \Sigma^*$ eine ungerade Länge, gilt also
+\item Hat ein Wort $s \in \Sigma^*$ eine ungerade L\"ange, gilt also
       \\[0.2cm]
       \hspace*{1.3cm}
-      $|s| = 2 \cdot n +1$ \quad für ein $n \in \mathbb{N}_0$,
+      $|s| = 2 \cdot n +1$ \quad f\"ur ein $n \in \mathbb{N}_0$,
       \\[0.2cm]
       so liegt der Buchstabe $s[n + 1]$ in der Mitte von $s$.  Um dies einzusehen,
       betrachten wir die Teilstrings $s[1:n]$ und $s[n+2:2\cdot n+1]$, die links und rechts
@@ -495,9 +495,9 @@ Dann gilt
       \hspace*{1.3cm}
       $|s[1:n]| = n$ \quad und \quad $|s[n+2:2\cdot n+1]| = 2 \cdot n + 1 - (n+2) + 1 = n$.
       \\[0.2cm]
-      Also liegt der Buchstabe $s[n+1]$ tatsächlich in der Mitte von $s$.  
+      Also liegt der Buchstabe $s[n+1]$ tats\"achlich in der Mitte von $s$.  
 
-      Für einen String $s$ ungerader Länge definieren wir $\hat{s}$ als den Buchstaben,
+      F\"ur einen String $s$ ungerader L\"ange definieren wir $\hat{s}$ als den Buchstaben,
       der in der Mitte von $s$ liegt:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -505,17 +505,17 @@ Dann gilt
 \end{enumerate}
 
 \noindent
-\textbf{Vorüberlegung \texttt{II}}:
-Zunächst ist klar, dass alle Strings deren Längen ungerade sind, in der Sprache $L$ liegen,
-denn jeder String der Form $s=ww$ hat offenbar die Länge 
+\textbf{Vor\"uberlegung \texttt{II}}:
+Zun\"achst ist klar, dass alle Strings deren L\"angen ungerade sind, in der Sprache $L$ liegen,
+denn jeder String der Form $s=ww$ hat offenbar die L\"ange 
 \\[0.2cm]
 \hspace*{1.3cm}
 $|s| = |w| + |w| = 2\cdot |w|$
 \\[0.2cm]
 und das ist eine gerade Zahl.
 
-Gilt nun $s \in L$ mit $|s| = 2 \cdot n$, so lässt sich $s$ in zwei Teile $u$ und $v$ gleicher
-Länge zerlegen:
+Gilt nun $s \in L$ mit $|s| = 2 \cdot n$, so l\"asst sich $s$ in zwei Teile $u$ und $v$ gleicher
+L\"ange zerlegen:
 \\[0.2cm]
 \hspace*{1.3cm}
 $s = uv \quad \mbox{mit} \quad u = s[1\!:\!n], \quad v = s[n+1\!:\!2 \cdot n]
@@ -530,13 +530,13 @@ $u[k] \not= v[k]$.
 \\[0.2cm]
 Der Trick besteht jetzt darin, den String $s$ in zwei Teilstrings $x$ und $y$ aufzuteilen,
 von denen der eine 
-Teilstring in der Mitte den Buchstaben $u[k]$ enthält, während der andere Teilstring in der Mitte den
-Buchstaben $v[k]$ enthält.  Wir definieren
+Teilstring in der Mitte den Buchstaben $u[k]$ enth\"alt, w\"ahrend der andere Teilstring in der Mitte den
+Buchstaben $v[k]$ enth\"alt.  Wir definieren
 \\[0.2cm]
 \hspace*{1.3cm}
 $x := s[1\!:\!2 \cdot k - 1] \quad \mbox{und} \quad y := s[2 \cdot k\!:\! 2 \cdot n]$.
 \\[0.2cm]
-Für die Längen von $x$ und $y$ folgt daraus
+F\"ur die L\"angen von $x$ und $y$ folgt daraus
 \\[0.2cm]
 \hspace*{1.3cm}
 $|x| = 2 \cdot k - 1 \quad \mbox{und} \quad |y| = 2 \cdot (n - k) + 1$. 
@@ -559,12 +559,12 @@ $
 \end{array}
 $
 \\[0.2cm]
-Die beiden Buchstaben $u[k]$ und $v[k]$, die dafür verantwortlich sind, dass $u$ und $v$ verschieden
+Die beiden Buchstaben $u[k]$ und $v[k]$, die daf\"ur verantwortlich sind, dass $u$ und $v$ verschieden
 sind, befinden sich also genau in der Mitte der Strings $x$ und $y$.
 \vspace{0.3cm}
 
 \noindent
-\textbf{Bemerkung}: Wir haben soeben Folgendes gezeigt:  Falls $s \in L$ mit $|s| = 2 \cdot n$ ist, so lässt
+\textbf{Bemerkung}: Wir haben soeben Folgendes gezeigt:  Falls $s \in L$ mit $|s| = 2 \cdot n$ ist, so l\"asst
 sich $s$ so in zwei Strings $x$ und $y$ aufspalten, dass die Buchstaben, die jeweils in
 der Mitte von $x$ und $y$ liegen, unterschiedlich sind:
 \\[0.2cm]
@@ -574,9 +574,9 @@ $s \in L \wedge |s| = 2 \cdot n \rightarrow \exists x,y \in \Sigma^*: \bigl(
 \vspace{0.3cm}
 
 \noindent
-\textbf{Vorüberlegung \texttt{III}}:
-Wir überlegen uns nun, dass auch die Umkehrung des in der letzten Bemerkung angegebenen
-Zusammenhangs gilt:  Sind $x, y \in \Sigma^*$ mit ungerader Länge und gilt 
+\textbf{Vor\"uberlegung \texttt{III}}:
+Wir \"uberlegen uns nun, dass auch die Umkehrung des in der letzten Bemerkung angegebenen
+Zusammenhangs gilt:  Sind $x, y \in \Sigma^*$ mit ungerader L\"ange und gilt 
 $\hat{x} \not= \hat{y}$, so liegt der String $xy$ in der Sprache $L$:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -586,7 +586,7 @@ $x, y \in \Sigma^* \wedge |x| = 2 \cdot m + 1 \wedge |y| = 2 \cdot n + 1 \wedge 
 
 \noindent
 \textbf{Beweis}: Wir definieren $s$ als die Konkatenation von $x$ und $y$, also $s := xy$.
-Für die Länge von $s$ gilt dann
+F\"ur die L\"ange von $s$ gilt dann
 \\[0.2cm]
 \hspace*{1.3cm}
 $|s| = 2 \cdot (m + n + 1)$.
@@ -630,9 +630,9 @@ Damit ist der Beweis der Behauptung $(*)$ abgeschlossen.
 
 \noindent
 \textbf{Aufstellen der Grammatik}:
-Fassen wir die letzten beiden Vorüberlegungen zusammen, so stellen wir fest, dass die
-Sprache $L$ aus genau den Wörtern besteht, die entweder 
-eine ungerade Länge haben, oder die aus Paaren von Strings ungerader Länge bestehen, die
+Fassen wir die letzten beiden Vor\"uberlegungen zusammen, so stellen wir fest, dass die
+Sprache $L$ aus genau den W\"ortern besteht, die entweder 
+eine ungerade L\"ange haben, oder die aus Paaren von Strings ungerader L\"ange bestehen, die
 in der Mitte unterschiedliche Buchstaben haben:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -643,7 +643,7 @@ $\begin{array}[t]{lcl}
                                     \wedge |y| \,\texttt{\%}\, 2 = 1  \wedge \hat{x} \not= \hat{y} \bigr\} 
  \end{array}$
 \\[0.2cm]
-Damit lässt sich die Menge $L$ durch die folgende Grammatik beschreiben
+Damit l\"asst sich die Menge $L$ durch die folgende Grammatik beschreiben
 \\[0.2cm]
 \hspace*{1.3cm}
 $G = \langle \{ s, a, b, x, u \}, \{ \squoted{A}, \squoted{B} \}, R, s \rangle$,
@@ -665,12 +665,12 @@ Wir diskutieren die verschiedenen syntaktischen Variablen.
 \item $L(x) = \{ \squoted{A}, \squoted{B} \}$.
 \item $L(u) = \{ w \in \Sigma^* \mid \;|w| \,\texttt{\%}\, 2 = 1 \}$,
 
-      denn ein String ungerader Länge hat entweder die Länge 1 oder er kann aus einem String ungerader Länge
-      durch Anfügen zweier Buchstaben erzeugt werden.
+      denn ein String ungerader L\"ange hat entweder die L\"ange 1 oder er kann aus einem String ungerader L\"ange
+      durch Anf\"ugen zweier Buchstaben erzeugt werden.
 \item $L(a) = \{ w \in \Sigma^* \mid\; \exists k \in \mathbb{N}: |w| = 2 \cdot k - 1 \wedge w[k] = \squoted{A} \}$,
   
       denn wenn wir an einen String, bei dem der Buchstabe $\squoted{A}$ in der Mitte steht, vorne
-      und hinten jeweils einen Buchstaben anfügen, erhalten wir wieder einen String, in
+      und hinten jeweils einen Buchstaben anf\"ugen, erhalten wir wieder einen String, in
       dessen Mitte der Buchstabe $\squoted{A}$ steht
 \item $L(b) = \{ w \in \Sigma^* \mid\; \exists k \in \mathbb{N}: |w| = 2 \cdot k - 1 \wedge w[k] = \squoted{B} \}$,
 
@@ -687,21 +687,21 @@ L(s) & = & \quad \bigl\{ w \in \Sigma^* \big|\; |w| \,\texttt{\%}\, 2 = 1 \bigr\
 $
       \\[0.2cm]
       denn wir haben oben argumentiert, dass alle Strings der Sprache $L$ entweder eine
-      ungerade Länge haben oder in zwei Teile ungerader Länge zerlegt werden können, so dass in der Mitte
+      ungerade L\"ange haben oder in zwei Teile ungerader L\"ange zerlegt werden k\"onnen, so dass in der Mitte
       dieser Teile verschiedene Buchstaben stehen: Entweder steht im ersten Teil ein $\squoted{A}$
       und im zweiten Teil steht ein $\squoted{B}$ oder es ist umgekehrt.
 \end{enumerate}
-Um die obigen Behauptungen formal zu beweisen müssten wir nun einerseits noch durch eine Induktion
-nach der Länge der Herleitung zeigen, dass die von den Grammatik-Symbolen erzeugten
-Strings tatsächlich in den oben angegebenen Mengen liegen.  Andererseits müssten wir für
-die oben angegebenen Mengen zeigen, dass sich jeder String der jeweiligen Menge auch tatsächlich mit den
-angegebenen Grammatik-Regeln erzeugen lässt.  Dieser Nachweis würde dann durch Induktion über die Länge der
-einzelnen Strings geführt werden.  Da diese Nachweise einfach sind und keine
-Überraschungen mehr bieten, verzichten wir hier darauf.
+Um die obigen Behauptungen formal zu beweisen m\"ussten wir nun einerseits noch durch eine Induktion
+nach der L\"ange der Herleitung zeigen, dass die von den Grammatik-Symbolen erzeugten
+Strings tats\"achlich in den oben angegebenen Mengen liegen.  Andererseits m\"ussten wir f\"ur
+die oben angegebenen Mengen zeigen, dass sich jeder String der jeweiligen Menge auch tats\"achlich mit den
+angegebenen Grammatik-Regeln erzeugen l\"asst.  Dieser Nachweis w\"urde dann durch Induktion \"uber die L\"ange der
+einzelnen Strings gef\"uhrt werden.  Da diese Nachweise einfach sind und keine
+\"Uberraschungen mehr bieten, verzichten wir hier darauf.
 \qed
 
 \remark
-Wir werden später sehen, dass das Komplement der in der letzten Aufgabe definierten Sprache $L$,
+Wir werden sp\"ater sehen, dass das Komplement der in der letzten Aufgabe definierten Sprache $L$,
 also die Sprache
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -710,46 +710,46 @@ $L^\mathtt{c} := \Sigma^* \backslash L = \bigl\{ ww \mid  w\in\Sigma^* \bigr\}$
 keine kontextfreie Sprache ist.  Damit sehen wir dann, dass die Menge der kontextfreien Sprachen
 nicht unter Komplementbildung abgeschlossen ist. \eox
 
-\subsection{Parse-Bäume}
-Mit Hilfe einer Grammatik $G$ können wir nicht nur erkennen, ob ein gegebener String $s$ ein
-Element der von der Grammatik erzeugten Sprache $L(G)$ ist, wir können den String auch
+\subsection{Parse-B\"aume}
+Mit Hilfe einer Grammatik $G$ k\"onnen wir nicht nur erkennen, ob ein gegebener String $s$ ein
+Element der von der Grammatik erzeugten Sprache $L(G)$ ist, wir k\"onnen den String auch
 \emph{strukturieren} indem wir einen \emph{Parse-Baum} aufbauen.  Ist eine Grammatik
 \\[0.2cm]
 \hspace*{1.3cm}
 $G = \langle V, T, R, S \rangle$
 \\[0.2cm]
-gegeben, so ist ein Parse-Baum für diese Grammatik ein Baum, der den folgenden 
-Bedingungen genügt:
+gegeben, so ist ein Parse-Baum f\"ur diese Grammatik ein Baum, der den folgenden 
+Bedingungen gen\"ugt:
 \begin{enumerate}
 \item Jeder innere Knoten (also jeder Knoten, der kein Blatt ist),
       ist mit einer Variablen beschriftet.
 \item Jedes Blatt ist mit einem Terminal oder mit einer Variablen beschriftet.
-\item Falls ein Blatt mit einer Variablen $a$ beschriftet ist, dann enthält die Grammatik eine 
+\item Falls ein Blatt mit einer Variablen $a$ beschriftet ist, dann enth\"alt die Grammatik eine 
       Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $a \rightarrow \varepsilon$.
 \item Ist ein innerer Knoten mit einer Variablen $a$ beschriftet und sind die Kinder
       dieses Knotens mit den Symbolen $X_1$, $X_2$, $\cdots$, $X_n$ beschriftet, so
-      enthält die Grammatik $G$ eine Regel der Form 
+      enth\"alt die Grammatik $G$ eine Regel der Form 
       \\[0.2cm]
       \hspace*{1.3cm}
       $a \rightarrow X_1 X_2 \cdots X_n$.
 \end{enumerate}
-Die Blätter des Parse-Baums ergeben dann, wenn wir sie von links nach rechts lesen, ein Wort,
+Die Bl\"atter des Parse-Baums ergeben dann, wenn wir sie von links nach rechts lesen, ein Wort,
 das von der Grammatik $G$ abgeleitet wird.  Abbildung \ref{fig:parse-tree.dot} zeigt einen
-Parse-Baum für das Wort ``\texttt{2*3+4}'', der mit der oben angegebenen Grammatik für
-arithmetische Ausdrücke abgeleitet worden ist.
+Parse-Baum f\"ur das Wort ``\texttt{2*3+4}'', der mit der oben angegebenen Grammatik f\"ur
+arithmetische Ausdr\"ucke abgeleitet worden ist.
 
 \begin{figure}[!ht]
   \centering
       \epsfig{file=Abbildungen/parse-tree.eps, scale=0.7}
-  \caption{Ein Parse-Baum für den String ``\texttt{2*3+4}''.}
+  \caption{Ein Parse-Baum f\"ur den String ``\texttt{2*3+4}''.}
   \label{fig:parse-tree.dot}
 \end{figure}
 
-Da Bäume der in Abbildung \ref{fig:parse-tree.dot} gezeigten Art sehr schnell zu groß
-werden, vereinfachen wir diese Bäume mit Hilfe der folgenden Regeln:
+Da B\"aume der in Abbildung \ref{fig:parse-tree.dot} gezeigten Art sehr schnell zu gro{\ss}
+werden, vereinfachen wir diese B\"aume mit Hilfe der folgenden Regeln:
 \begin{enumerate}
 \item Ist $n$ ein innerer Knoten, der mit der Variablen $A$ beschriftet ist
       und gibt es unter den Kindern dieses Knotens genau ein Kind, dass mit einem Terminal $o$
@@ -762,19 +762,19 @@ Abbildung \ref{fig:abstract-syntax-tree.dot} zeigt den abstrakten Syntax-Baum de
 erhalten, wenn wir den in Abbildung \ref{fig:parse-tree.dot} gezeigten Parse-Baum nach
 diesen Regeln vereinfachen.  Die in diesem Baum gespeicherte Struktur ist genau das, was
 wir brauchen um den arithmetischen Ausdruck ``\texttt{2*3+4}'' auszuwerten, denn der Baum zeigt uns,
-in welcher Reihenfolge die Operatoren ausgewertet werden müssen.
+in welcher Reihenfolge die Operatoren ausgewertet werden m\"ussen.
 
 \begin{figure}[!ht]
   \centering
       \epsfig{file=Abbildungen/abstract-syntax-tree.eps, scale=0.7}
-  \caption{Ein abstrakter Syntax-Baum für den String ``\texttt{2*3+4}''.}
+  \caption{Ein abstrakter Syntax-Baum f\"ur den String ``\texttt{2*3+4}''.}
   \label{fig:abstract-syntax-tree.dot}
 \end{figure}
 
 \subsection{Mehrdeutige Grammatiken}
 Die zu Anfang des Abschnitts \ref{kontextfreie} angegebene Grammatik zur Beschreibung arithmetischer
-Ausdrücke erscheint durch ihre Unterscheidung der syntaktischen Kategorien \textsl{arithExpr},
-\textsl{product} und \textsl{factor} unnötig kompliziert.  Wir stellen eine einfachere Grammatik $G$
+Ausdr\"ucke erscheint durch ihre Unterscheidung der syntaktischen Kategorien \textsl{arithExpr},
+\textsl{product} und \textsl{factor} unn\"otig kompliziert.  Wir stellen eine einfachere Grammatik $G$
 vor, welche dieselbe Sprache beschreibt:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -812,31 +812,31 @@ gezeigt ist.  Es gibt aber noch eine andere Ableitung des Strings ``\texttt{2*3+
 Dieser Ableitung entspricht der abstrakte Syntax-Baum, der in Abbildung
 \ref{fig:abstract-syntax-tree-prod.dot} gezeigt ist.
 Bei dieser Ableitung wird der String ``\texttt{2*3+4}'' offenbar als Produkt aufgefasst,
-was der Konvention widerspricht, dass der Operator ``\texttt{*}'' stärker bindet als der Operator
-``\texttt{+}''.  Würden wir den String anhand des letzten Syntax-Baums auswerten, würden wir
+was der Konvention widerspricht, dass der Operator ``\texttt{*}'' st\"arker bindet als der Operator
+``\texttt{+}''.  W\"urden wir den String anhand des letzten Syntax-Baums auswerten, w\"urden wir
 offenbar ein falsches Ergebnis bekommen! 
 \begin{figure}[!ht]
   \centering
       \epsfig{file=Abbildungen/abstract-syntax-tree-prod.eps, scale=0.6}
-  \caption{Ein anderer abstrakter Syntax-Baum für den String ``\texttt{2*3+4}''.}
+  \caption{Ein anderer abstrakter Syntax-Baum f\"ur den String ``\texttt{2*3+4}''.}
   \label{fig:abstract-syntax-tree-prod.dot}
 \end{figure}
 Die Ursache dieses Problems ist die Tatsache, dass die zuletzt angegebene Grammatik \underline{mehrdeuti}g ist.
 Eine solche Grammatik ist zum Parsen ungeeignet.  Leider ist die Frage, ob eine gegebene
 Grammatik mehrdeutig ist, im Allgemeinen nicht
 \href{http://en.wikipedia.org/wiki/Ambiguous_grammar#Recognizing_ambiguous_grammars}{entscheidbar}:
-Es lässt sich zeigen, dass diese Frage zum
+Es l\"asst sich zeigen, dass diese Frage zum
 \href{http://en.wikipedia.org/wiki/Post_correspondence_problem}{\emph{Postschen Korrespondenz-Problem}} 
-äquivalent ist.  Da das Postsche Korrespondenz-Problem als unlösbar nachgewiesen wurde, ist auch die
-Frage, ob eine Grammatik mehrdeutig ist, unlösbar.
+\"aquivalent ist.  Da das Postsche Korrespondenz-Problem als unl\"osbar nachgewiesen wurde, ist auch die
+Frage, ob eine Grammatik mehrdeutig ist, unl\"osbar.
 Ein Beweis dieser Behauptungen findet sich beispielsweise in dem Buch von Hopcroft, Motwani und
 Ullman \cite{hopcroft:06}. 
 
 
 \example
-Es sei $\Sigma = \{ \squoted{A}, \squoted{B} \}$.  Die Sprache $L$ enthalte alle die Wörter
+Es sei $\Sigma = \{ \squoted{A}, \squoted{B} \}$.  Die Sprache $L$ enthalte alle die W\"orter
 aus $\Sigma^*$, bei denen die Buchstaben \squoted{A} and \squoted{B} mit der gleichen
-Häufigkeit auftreten, es gilt also
+H\"aufigkeit auftreten, es gilt also
 \\[0.2cm]
 \hspace*{1.3cm}
 $L = \bigl\{ w \in \Sigma^* \mid \textsl{count}(w, \squoted{A}) = \textsl{count}(w, \squoted{B}) \bigr\}$.
@@ -850,11 +850,11 @@ $\textsl{s} \;\rightarrow\; \quoted{A} s \quoted{B} s \;\mid\; \quoted{B} s \quo
 Der Grund ist, dass ein String $w \in L$ entweder mit einem \squoted{A} oder mit einem \squoted{B}
 beginnt.  Im ersten Fall muss es zu diesem \squoted{A} ein korrespondierendes \squoted{B} geben, denn
 die Anzahl der Auftreten von \squoted{A} und \squoted{B} sind gleich.  Fassen wir den Buchstaben
-\squoted{A} wie eine öffnende Klammer auf und interpretieren den Buchstaben \squoted{B} als die zu
-\squoted{A} korrespondierende schließende Klammer, so ist klar, dass der String, der zwischen diesen
+\squoted{A} wie eine \"offnende Klammer auf und interpretieren den Buchstaben \squoted{B} als die zu
+\squoted{A} korrespondierende schlie{\ss}ende Klammer, so ist klar, dass der String, der zwischen diesen
 beiden Auftreten von \squoted{A} und \squoted{B} liegt, ebenfalls gleich viele Auftreten von
-\squoted{A} wie von \squoted{B} hat.  Genauso muss dies dann für den Rest des Strings gelten, der nach
-dem \squoted{B} folgt.  Diese Überlegung erklärt die Regel
+\squoted{A} wie von \squoted{B} hat.  Genauso muss dies dann f\"ur den Rest des Strings gelten, der nach
+dem \squoted{B} folgt.  Diese \"Uberlegung erkl\"art die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{s} \;\rightarrow\; \quoted{A} s \quoted{B} s$
@@ -864,11 +864,11 @@ Die Regel
 \hspace*{1.3cm}
 $\textsl{s} \;\rightarrow\; \quoted{B} s \quoted{A} s$
 \\[0.2cm]
-lässt sich in analoger Weise erklären,  wenn wir den Buchstaben \squoted{B} als öffnende Klammer und
-\squoted{A} als schließende Klammer interpretieren. 
+l\"asst sich in analoger Weise erkl\"aren,  wenn wir den Buchstaben \squoted{B} als \"offnende Klammer und
+\squoted{A} als schlie{\ss}ende Klammer interpretieren. 
 
 Diese Grammatik ist allerdings mehrdeutig: Betrachten wir beispielsweise den String 
-``\texttt{abab}'', so stellen wir fest, dass sich dieser prinzipiell auf zwei Arten ableiten lässt:
+``\texttt{abab}'', so stellen wir fest, dass sich dieser prinzipiell auf zwei Arten ableiten l\"asst:
 \begin{eqnarray*}
   s & \Rightarrow &\quoted{A} s \quoted{B} s                       \\
     & \Rightarrow &\quoted{A} \quoted{B} s                         \\
@@ -885,16 +885,16 @@ $s$ durch $\varepsilon$ ersetzen sondern statt dessen das zweite $s$ durch $\var
     & \Rightarrow &\quoted{A} \quoted{B}\quoted{A} s \quoted{B}   \\
     & \Rightarrow &\quoted{A} \quoted{B}\quoted{A} \quoted{B}     \\
 \end{eqnarray*}
-Abbildung \ref{fig:ambiguous-a.dot} zeigt die Parse-Bäume, die sich aus den beiden Ableitungen ergeben.
-Wir können erkennen, dass die Struktur dieser Bäume unterschiedlich ist:  Im ersten Fall gehört das erste
-``\texttt{A}'' zu dem ersten ``\texttt{B}'', im zweiten Fall gehört das erste ``\texttt{A}'' zu dem letzten
+Abbildung \ref{fig:ambiguous-a.dot} zeigt die Parse-B\"aume, die sich aus den beiden Ableitungen ergeben.
+Wir k\"onnen erkennen, dass die Struktur dieser B\"aume unterschiedlich ist:  Im ersten Fall geh\"ort das erste
+``\texttt{A}'' zu dem ersten ``\texttt{B}'', im zweiten Fall geh\"ort das erste ``\texttt{A}'' zu dem letzten
 ``\texttt{B}''.
 
 \begin{figure}[!ht]
       \epsfig{file=Abbildungen/ambiguous-a.eps, scale=0.6}
 \quad
       \epsfig{file=Abbildungen/ambiguous-b.eps, scale=0.6}
-  \caption{Zwei strukturell verschiedene Parse-Bäume für den String ``\texttt{ABAB}''.}
+  \caption{Zwei strukturell verschiedene Parse-B\"aume f\"ur den String ``\texttt{ABAB}''.}
   \label{fig:ambiguous-a.dot}
 \end{figure}
 
@@ -909,8 +909,8 @@ deren Regeln wie folgt gegeben sind:
 \textsl{y} & \rightarrow & \textsl{v} \textsl{y} \;\mid\; \varepsilon          
 \end{eqnarray*}
 Um die Sprachen, die von den einzelnen Variablen erzeugt werden, klarer beschreiben zu
-können, definieren wir für zwei Strings $\sigma$ und $\omega$ die Relation $\sigma \preceq \omega$ (lese: $\sigma$ ist ein
-Präfix von $\omega$) wie folgt:
+k\"onnen, definieren wir f\"ur zwei Strings $\sigma$ und $\omega$ die Relation $\sigma \preceq \omega$ (lese: $\sigma$ ist ein
+Pr\"afix von $\omega$) wie folgt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\sigma \preceq \omega \quad \stackrel{\rm{def}}{\Longleftrightarrow} \exists \tau \in \Sigma^*: \sigma \tau = \omega$
@@ -928,43 +928,43 @@ $L(y) = \bigl\{ \omega \in \Sigma^* \mid \omega \in L \;\wedge\; \forall \sigma 
 \\[0.2cm]
 Ist $w \in L(x)$, so gibt es zu jedem Auftreten des Buchstabens ``\texttt{B}'' in dem String $w$ ein
 dazu korrespondierendes Auftreten des Buchstabens ``\texttt{A}'', das dem Auftreten des Buchstabens
-``\texttt{B}'' vorangeht.  Würden wir den Buchstaben
-``\texttt{A}'' durch eine öffnende Klammer und den Buchstaben ``\texttt{B}'' durch eine schließende
-Klammer ersetzen, so wird also niemals eine Klammer geschlossen, die nicht vorher geöffnet wurde.
+``\texttt{B}'' vorangeht.  W\"urden wir den Buchstaben
+``\texttt{A}'' durch eine \"offnende Klammer und den Buchstaben ``\texttt{B}'' durch eine schlie{\ss}ende
+Klammer ersetzen, so wird also niemals eine Klammer geschlossen, die nicht vorher ge\"offnet wurde.
 Damit ist klar, dass in einem String der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 ``\texttt{A}'' $w$ ``\texttt{B}'' \quad mit $w \in L(x)$ 
 \\[0.2cm]
 das zu dem ersten ``\texttt{A}'' korrespondierende ``\texttt{B}'' nur das letzte ``\texttt{B}'' sein kann.
-Analog können wir sehen, dass in einem String der Form
+Analog k\"onnen wir sehen, dass in einem String der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 ``\texttt{B}'' $w$ ``\texttt{A}'' \quad mit $w \in L(Y)$ 
 \\[0.2cm]
 das zu dem ersten ``\texttt{B}'' korrespondierende ``\texttt{A}'' nur das letzte ``\texttt{A}'' sein kann.
 
-Ein String der Sprache $L$ fängt nun entweder mit ``\texttt{A}'' oder mit ``\texttt{B}''
-an.  Im ersten Fall interpretieren wir das ``\texttt{A}'' als öffnende Klammer und 
-das ``\texttt{B}'' als schließende Klammer und suchen nun das ``\texttt{B}'', das dem
+Ein String der Sprache $L$ f\"angt nun entweder mit ``\texttt{A}'' oder mit ``\texttt{B}''
+an.  Im ersten Fall interpretieren wir das ``\texttt{A}'' als \"offnende Klammer und 
+das ``\texttt{B}'' als schlie{\ss}ende Klammer und suchen nun das ``\texttt{B}'', das dem
 ``\texttt{A}'' am Anfang des Strings zugeordnet ist.  Der String, der mit dem
-``\texttt{A}'' anfängt und dem ``\texttt{B}'' endet, liegt in der Sprache $L(u)$.
+``\texttt{A}'' anf\"angt und dem ``\texttt{B}'' endet, liegt in der Sprache $L(u)$.
 Auf dieses ``\texttt{B}'' kann dann noch ein weiterer Teilstring folgen, der
-gleich viele ``\texttt{A}''s und ``\texttt{B}''s enthält.  Ein solcher Teilstring liegt
+gleich viele ``\texttt{A}''s und ``\texttt{B}''s enth\"alt.  Ein solcher Teilstring liegt
 offensichtlich ebenfalls in der Sprache $L$ und kann daher von $s$ mittels der Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{s} \rightarrow \textsl{u}\textsl{s}$
 \\[0.2cm]
 erzeugt werden.
-Im zweiten Fall fängt der String mit einem ``\texttt{B}'' an.  Dieser Fall ist
+Im zweiten Fall f\"angt der String mit einem ``\texttt{B}'' an.  Dieser Fall ist
 analog zum ersten Fall.    \qed
 \vspace*{0.3cm}
 
-In dem obigen Beispiel hatten wir Glück und konnten eine Grammatik finden, mit der sich
-die Sprache eindeutig parsen lässt.  Es  gibt allerdings auch kontextfreie Sprachen, die 
-\href{http://en.wikipedia.org/wiki/Ambiguous_grammar#Inherently_ambiguous_languages}{inhärent mehrdeutig}
-sind: Es lässt sich beispielsweise zeigen, dass für das Alphabet 
+In dem obigen Beispiel hatten wir Gl\"uck und konnten eine Grammatik finden, mit der sich
+die Sprache eindeutig parsen l\"asst.  Es  gibt allerdings auch kontextfreie Sprachen, die 
+\href{http://en.wikipedia.org/wiki/Ambiguous_grammar#Inherently_ambiguous_languages}{inh\"arent mehrdeutig}
+sind: Es l\"asst sich beispielsweise zeigen, dass f\"ur das Alphabet 
 $\Sigma =  \{ \squoted{A}, \squoted{B}, \squoted{C}, \squoted{D} \}$
 die Sprache
 \\[0.2cm]
@@ -974,13 +974,13 @@ $L =  \bigl\{ \mathtt{A}^m \mathtt{B}^m \mathtt{C}^n \mathtt{D}^n \mid m, n \in 
 $
 \\[0.2cm]
 kontextfrei ist, aber jede Grammatik $G$ mit der Eigenschaft $L = L(G)$ ist
-notwendigerweise mehrdeutig.  Das Problem ist, dass für gewisse große Zahlen $n\in \mathbb{N}$ ein
+notwendigerweise mehrdeutig.  Das Problem ist, dass f\"ur gewisse gro{\ss}e Zahlen $n\in \mathbb{N}$ ein
 String der Form 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\mathtt{A}^n \mathtt{B}^n \mathtt{C}^n \mathtt{D}^n$
 \\[0.2cm]
-immer zwei strukturell verschiedene Parse-Bäume besitzen muss.  Ein Beweis dieser Behaupung
+immer zwei strukturell verschiedene Parse-B\"aume besitzen muss.  Ein Beweis dieser Behaupung
 findet sich in der ersten Auflage des Buchs von  Hopcroft und Ullman auf Seite 100 \cite{hopcroft:79}.   
 
 \section{Top-Down-Parser}
@@ -991,28 +991,28 @@ Hilfe einer Grammatik-Regel der Form
 \hspace*{1.3cm}
 $\textsl{a} \rightarrow \textsl{X}_1 \textsl{X}_2 \cdots \textsl{X}_n$
 \\[0.2cm]
-zu parsen, versuchen wir, zunächst ein $X_1$ zu parsen.  Dabei zerlegen wir den String $w$ in die
+zu parsen, versuchen wir, zun\"achst ein $X_1$ zu parsen.  Dabei zerlegen wir den String $w$ in die
 Form
 $w = w_1 r_1$ so, dass $w_1 \in L(X_1)$ gilt.  Dann versuchen wir, in dem Rest-String
 $r_1$ ein $X_2$ zu parsen und zerlegen dabei $r_1$ so, dass $r_1 = w_2 r_2$ mit 
 $w_2 \in L(X_2)$ gilt.  Setzen wir diesen Prozess fort, so haben wir zum Schluss den String $w$ in
 \\[0.2cm]
 \hspace*{1.3cm}
-$w = w_1 w_2 \cdots w_n$ \quad mit $w_i \in L(X_i)$ für alle $i=1,\cdots,n$
+$w = w_1 w_2 \cdots w_n$ \quad mit $w_i \in L(X_i)$ f\"ur alle $i=1,\cdots,n$
 \\[0.2cm]
 aufgespaltet.  Leider funktioniert dieses Verfahren dann nicht, wenn die Grammatik
-\emph{links-rekursiv} ist, dass heißt, dass eine Regel die Form
+\emph{links-rekursiv} ist, dass hei{\ss}t, dass eine Regel die Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{a} \rightarrow \textsl{a} \beta$
 \\[0.2cm]
-hat, denn dann würden wir um ein $\textsl{a}$ zu parsen sofort wieder rekursiv versuchen, 
-ein $a$ zu parsen und wären damit in einer Endlos-Schleife.  Es gibt mehrere Möglichkeiten, um mit
+hat, denn dann w\"urden wir um ein $\textsl{a}$ zu parsen sofort wieder rekursiv versuchen, 
+ein $a$ zu parsen und w\"aren damit in einer Endlos-Schleife.  Es gibt mehrere M\"oglichkeiten, um mit
 diesem Problem umzugehen:
 \begin{enumerate}
-\item Wir können die Grammatik so umschreiben, dass sie danach nicht mehr links-rekursiv
+\item Wir k\"onnen die Grammatik so umschreiben, dass sie danach nicht mehr links-rekursiv
       ist.
-\item Wir können versuchen, den String \emph{rückwärts} zu parsen, d.h.~bei einer
+\item Wir k\"onnen versuchen, den String \emph{r\"uckw\"arts} zu parsen, d.h.~bei einer
       Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -1020,22 +1020,22 @@ diesem Problem umzugehen:
       \\[0.2cm]
       versuchen wir als erstes, ein $X_n$ am Ende eines zu parsenden Strings $w$ zu
       entdecken und arbeiten dann den String $w$ von hinten  nach vorne ab.  
-\item Die einfachste Lösung erhalten wir, wenn wir uns klar machen, dass kontextfreie
+\item Die einfachste L\"osung erhalten wir, wenn wir uns klar machen, dass kontextfreie
       Grammatiken nicht unbedingt die bequemste Art darstellen, eine Sprache 
       zu beschreiben.  Wir werden daher den Begriff der \emph{erweiterten Backus-Naur-Form}-Grammatik
-      (abgekürzt \textsc{Ebnf}-Grammatik) einführen.  Hierbei handelt es sich um eine Verallgemeinerung des
-      Begriffs der kontextfreien Grammatik.  Theoretisch ist die Ausdrucksstärke der
-      \textsc{Ebnf}-Grammatiken dieselbe wie die Ausdrucksstärke der kontextfreien Grammatiken.
-      In der Praxis zeigt sich aber, dass die Konstruktion von Top-Down-Parsern für
+      (abgek\"urzt \textsc{Ebnf}-Grammatik) einf\"uhren.  Hierbei handelt es sich um eine Verallgemeinerung des
+      Begriffs der kontextfreien Grammatik.  Theoretisch ist die Ausdrucksst\"arke der
+      \textsc{Ebnf}-Grammatiken dieselbe wie die Ausdrucksst\"arke der kontextfreien Grammatiken.
+      In der Praxis zeigt sich aber, dass die Konstruktion von Top-Down-Parsern f\"ur
       \textsc{Ebnf}-Grammatiken einfacher ist, weil dort die Links-Rekursion durch eine Iteration ersetzt
       werden kann.
 \end{enumerate}
-Im Rahmen dieses Kapitels werden wir alle oben genannten Verfahren anhand der Grammatik für
-arithmetische Ausdrücke ausführlich diskutieren.  
+Im Rahmen dieses Kapitels werden wir alle oben genannten Verfahren anhand der Grammatik f\"ur
+arithmetische Ausdr\"ucke ausf\"uhrlich diskutieren.  
 
 \subsection{Umschreiben der Grammatik$^*$ \label{links-rekursion}}
 In der folgenden Grammatik ist $a$ eine syntaktische Variable und die griechischen Buchstaben $\beta$ und
-$\gamma$ stehen für irgendwelche Strings, die aus syntaktischen Variablen und Tokens bestehen.
+$\gamma$ stehen f\"ur irgendwelche Strings, die aus syntaktischen Variablen und Tokens bestehen.
 Wird die syntaktische Variable $a$ durch die beiden Regeln
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1046,7 +1046,7 @@ a & \rightarrow & a \beta \\
 \end{array}
 $
 \\[0.2cm]
-definiert, so hat eine Ableitung von $a$, bei der zunächst immer die syntaktische Variable $a$ ersetzt
+definiert, so hat eine Ableitung von $a$, bei der zun\"achst immer die syntaktische Variable $a$ ersetzt
 wird, die Form 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1059,7 +1059,7 @@ Strings besteht, die sich aus dem Ausdruck $\gamma \beta^n$ ableiten lassen:
 \hspace*{1.3cm}
 $L(a) = \bigl\{ w \in \Sigma^* \mid \exists n \in \mathbb{N}_0: \gamma \beta^n \Rightarrow^* w \bigr\}$.
 \\[0.2cm]
-Diese Sprache kann offenbar auch durch die folgenden Regeln für $a$ beschrieben werden:
+Diese Sprache kann offenbar auch durch die folgenden Regeln f\"ur $a$ beschrieben werden:
 \\[0.2cm]
 \hspace*{1.3cm}
 $
@@ -1070,7 +1070,7 @@ b & \rightarrow & \beta b  \\
 \end{array}
 $
 \\[0.2cm]
-Hier haben wir die Hilfs-Variable $b$ eingeführt.  Die Ableitungen, die von dem Nicht-Terminal $b$
+Hier haben wir die Hilfs-Variable $b$ eingef\"uhrt.  Die Ableitungen, die von dem Nicht-Terminal $b$
 ausgehen, haben die Form
 \\[0.2cm]
 \hspace*{1.3cm} $b \Rightarrow \beta b \Rightarrow \beta \beta b \Rightarrow \cdots \Rightarrow
@@ -1087,7 +1087,7 @@ Damit ist klar, dass auch mit der oben angegeben Grammatik
 \Rightarrow^* w \bigr\}$
 \\[0.2cm]
 gilt.  Um die Links-Rekursion aus der in Abbildung \ref{fig:Expr} auf Seite \pageref{fig:Expr}
-gezeigten Grammatik zu entfernen, müssen wir das obige Beispiel verallgemeinern.  Wir betrachten
+gezeigten Grammatik zu entfernen, m\"ussen wir das obige Beispiel verallgemeinern.  Wir betrachten
 jetzt den allgemeinen Fall und nehmen an, dass ein Nicht-Terminal $a$ durch Regeln der Form
 \\[0.2cm]
 \hspace*{1.3cm} $
@@ -1102,8 +1102,8 @@ a & \rightarrow & a \beta_1 \\
 \end{array}
 $
 \\[0.2cm]
-beschrieben wird.  Wir können diesen Fall durch Einführung zweier Hilfs-Variablen $b$ und $c$ auf
-den ersten Fall zurückführen:
+beschrieben wird.  Wir k\"onnen diesen Fall durch Einf\"uhrung zweier Hilfs-Variablen $b$ und $c$ auf
+den ersten Fall zur\"uckf\"uhren:
 \\[0.2cm]
 \hspace*{1.3cm}
 $
@@ -1114,8 +1114,8 @@ c & \rightarrow & \gamma_1 \mid \cdots \mid \gamma_l
 \end{array}
 $
 \\[0.2cm]
-Dann können wir die Grammatik umschreiben, indem wir eine neue Hilfs-Variable, nennen wir sie $l$
-für Liste, einführen und erhalten
+Dann k\"onnen wir die Grammatik umschreiben, indem wir eine neue Hilfs-Variable, nennen wir sie $l$
+f\"ur Liste, einf\"uhren und erhalten
 \\[0.2cm]
 \hspace*{1.3cm}
 $
@@ -1125,7 +1125,7 @@ l & \rightarrow & b\;l \mid \varepsilon.
 \end{array}
 $
 \\[0.2cm]
-Die Hilfs-Variablen $b$ und $c$ können nun wieder eliminiert werden und dann bekommen wir die folgende
+Die Hilfs-Variablen $b$ und $c$ k\"onnen nun wieder eliminiert werden und dann bekommen wir die folgende
 Grammatik: 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1153,14 +1153,14 @@ $
   \vspace*{-0.5cm}
   \end{minipage}}}
   \end{center}
-  \caption{Links-rekursive Grammatik für arithmetische Ausdrücke.}
+  \caption{Links-rekursive Grammatik f\"ur arithmetische Ausdr\"ucke.}
   \label{fig:Expr}
 \end{figure}
 \vspace*{0.3cm}
 
 \noindent
-Wenden wir dieses Verfahren auf die in Abbildung \ref{fig:Expr} gezeigte Grammatik für arithmetische
-Ausdrücke an, so erhalten wir die in Abbildung \ref{fig:Expr2} gezeigte Grammatik.
+Wenden wir dieses Verfahren auf die in Abbildung \ref{fig:Expr} gezeigte Grammatik f\"ur arithmetische
+Ausdr\"ucke an, so erhalten wir die in Abbildung \ref{fig:Expr2} gezeigte Grammatik.
 
 \begin{figure}[htbp]
   \begin{center}    
@@ -1182,12 +1182,12 @@ Ausdrücke an, so erhalten wir die in Abbildung \ref{fig:Expr2} gezeigte Grammati
   \vspace*{-0.5cm}
   \end{minipage}}}
   \end{center}
-  \caption{Grammatik für arithmetische Ausdrücke ohne Links-Rekursion.}
+  \caption{Grammatik f\"ur arithmetische Ausdr\"ucke ohne Links-Rekursion.}
   \label{fig:Expr2}
 \end{figure}
 
 \noindent
-Die Variablen \textsl{exprRest} und \textsl{productRest} können wie folgt interpretiert werden:
+Die Variablen \textsl{exprRest} und \textsl{productRest} k\"onnen wie folgt interpretiert werden:
 \begin{enumerate}
 \item \textsl{exprRest} beschreibt eine Liste der Form
       \\[0.2cm]
@@ -1206,7 +1206,7 @@ Die Variablen \textsl{exprRest} und \textsl{productRest} können wie folgt interp
 
 \exercise
 \begin{enumerate}
-\item[(a)] Die folgende Grammatik beschreibt reguläre Ausdrücke:
+\item[(a)] Die folgende Grammatik beschreibt regul\"are Ausdr\"ucke:
       \begin{center}    
           \framebox{
             \begin{minipage}[t]{9cm}
@@ -1228,9 +1228,9 @@ Die Variablen \textsl{exprRest} und \textsl{productRest} können wie folgt interp
       \\[0.2cm]
       Da die Grammatik mehrdeutig ist, ist diese Grammatik zum Parsen ungeeignet.
       Transformieren Sie diese Grammatik in eine eindeutige Grammatik, bei welcher der
-      Postfix-Operator ``\texttt{*}'' stärker bindet als die Konkatenation zweier regulärer
-      Ausdrücke, während der Operator ``\texttt{+}'' schwächer bindet als die Konkatenation. 
-      Orientieren Sie sich dabei an der Grammatik für arithmetische Ausdrücke und führen
+      Postfix-Operator ``\texttt{*}'' st\"arker bindet als die Konkatenation zweier regul\"arer
+      Ausdr\"ucke, w\"ahrend der Operator ``\texttt{+}'' schw\"acher bindet als die Konkatenation. 
+      Orientieren Sie sich dabei an der Grammatik f\"ur arithmetische Ausdr\"ucke und f\"uhren
       Sie geeignete neue syntaktische Variablen ein.
 \item[(b)] Entfernen Sie die Links-Rekursion aus der in Teil (a) dieser Aufgabe erstellten
       Grammatik. \eox
@@ -1256,10 +1256,10 @@ Die Variablen \textsl{exprRest} und \textsl{productRest} können wie folgt interp
 \end{figure}
 
 Bei den bisher diskutierten Beispielen war die Links-Rekursion der Grammatik unmittelbar anzusehen.
-Es gibt allerdings Fälle, in denen die Links-Rekursion ihren Ursprung in 
+Es gibt allerdings F\"alle, in denen die Links-Rekursion ihren Ursprung in 
 \emph{wechselseitiger Rekursion} hat.
 Abbildung \ref{fig:mutual-left-recursion} auf Seite \pageref{fig:mutual-left-recursion} zeigt ein
-solches Beispiel: Bei der dort angegebenen Grammatik erstreckt sich die Links-Rekursion über drei Stufen:
+solches Beispiel: Bei der dort angegebenen Grammatik erstreckt sich die Links-Rekursion \"uber drei Stufen:
 Ein $s$ kann mit einem $a$ beginnen, das mit einem $b$ beginnen kann, welches dann wieder mit einem
 $s$ beginnt.  Eine Links-Rekursion der Form
 \\[0.2cm]
@@ -1270,14 +1270,14 @@ bezeichnen wir als \emph{unmittelbare Links-Rekursion},  jede kompliziertere For
 Links-Rekursion wird als \emph{allgemeine Links-Rekursion} bezeichnet.
 Um allgemeine Links-Rekursion zu eliminieren, gehen wir wie folgt vor:
 \begin{enumerate}
-\item Zunächst nummerieren wir die syntaktischen Variablen der Grammatik in willkürlicher Weise durch.
+\item Zun\"achst nummerieren wir die syntaktischen Variablen der Grammatik in willk\"urlicher Weise durch.
       Im Folgenden seien die Variablen mit $a_1$, $\cdots$, $a_n$ bezeichnet.  Durch diese
       Nummerierung wird implizit eine Ordnung $\succ$ auf den syntaktischen Variablen
       definiert, wir setzen
       \\[0.2cm]
       \hspace*{1.3cm}
       $a_1 \succ a_2 \succ \cdots \succ a_i \succ a_{i+1} \succ \cdots \succ a_n$.
-\item Das Ziel ist nun, die Grammatik so umzuschreiben, dass für jede
+\item Das Ziel ist nun, die Grammatik so umzuschreiben, dass f\"ur jede
       Grammatik-Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -1304,43 +1304,43 @@ Um allgemeine Links-Rekursion zu eliminieren, gehen wir wie folgt vor:
       \hspace*{1.3cm} 
       \texttt{\}}  
 \end{enumerate}
-Um den Algorithmus zu verstehen, führen wir zunächst einen neuen Begriff ein:  Falls die Grammatik
+Um den Algorithmus zu verstehen, f\"uhren wir zun\"achst einen neuen Begriff ein:  Falls die Grammatik
 eine Regel der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $a \rightarrow b \gamma$
 \\[0.2cm]
-enthält, wobei $b$ eine syntaktische Variable ist, dann sagen wir, dass $a$ unmittelbar von $b$
-abhängt.  Die Idee bei dem oben angegebenen Algorithmus ist nun, dass nach dem $i$-ten
-Durchlaufen der äußeren \texttt{for}-Schleife die Variablen $a_1$, $\cdots$, $a_i$ nur noch unmittelbar
-von solchen Variablen abhängen, die in der Aufzählung $a_1$, $\cdots$, $a_n$ auf diese  Variablen
-folgen.  Formal gilt nach dem $i$-ten Durchlauf der äußeren \texttt{for}-Schleife für alle Indizes 
+enth\"alt, wobei $b$ eine syntaktische Variable ist, dann sagen wir, dass $a$ unmittelbar von $b$
+abh\"angt.  Die Idee bei dem oben angegebenen Algorithmus ist nun, dass nach dem $i$-ten
+Durchlaufen der \"au{\ss}eren \texttt{for}-Schleife die Variablen $a_1$, $\cdots$, $a_i$ nur noch unmittelbar
+von solchen Variablen abh\"angen, die in der Aufz\"ahlung $a_1$, $\cdots$, $a_n$ auf diese  Variablen
+folgen.  Formal gilt nach dem $i$-ten Durchlauf der \"au{\ss}eren \texttt{for}-Schleife f\"ur alle Indizes 
 $k \in \{ 1, \cdots, i \}$:  Falls die Grammatik eine Regel der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $a_k \rightarrow a_l \beta$ 
 \\[0.2cm]
-enthält, dann muss $l > k$ gelten.  Es ist leicht zu sehen, dass diese Invariante tatsächlich gilt:
-Vor dem $i$-ten Durchlauf gilt die Invariante für die Indizes der Menge $\{1, \cdots, i-1\}$.  Die
-Variable $a_i$ selber kann dann noch unmittelbar von den Variablen $a_1$, $\cdots$, $a_n$ abhängen.
+enth\"alt, dann muss $l > k$ gelten.  Es ist leicht zu sehen, dass diese Invariante tats\"achlich gilt:
+Vor dem $i$-ten Durchlauf gilt die Invariante f\"ur die Indizes der Menge $\{1, \cdots, i-1\}$.  Die
+Variable $a_i$ selber kann dann noch unmittelbar von den Variablen $a_1$, $\cdots$, $a_n$ abh\"angen.
 In der inneren \texttt{for}-Schleife erreichen wir, dass nacheinander die unmittelbaren
-Abhängigkeiten von $a_1$, $\cdots$, $a_{i-1}$ aufgelöst werden.  Anschließend kann $a_i$ höchstens
-noch unmittelbar von $a_i$ abhängen.  Um diese Abhängigkeit gegebenenfalls aufzulösen, führen wir
-die bereits früher diskutierte Transformation zur Elimination unmittelbarer Links-Rekursion durch.
-Anschließend hängt $a_i$ höchstens noch 
-unmittelbar von $a_{i+1}$, $\cdots$, $a_n$ ab.  Läuft die Schleife bis zum Ende durch, ist damit
-die Links-Rekursion vollständig eliminiert, denn dann kann jede Variable nur von solchen
-Variablen abhängen, die in der Aufzählung $a_1$ $\cdots$, $a_n$ hinter ihr stehen.  Folglich ist 
+Abh\"angigkeiten von $a_1$, $\cdots$, $a_{i-1}$ aufgel\"ost werden.  Anschlie{\ss}end kann $a_i$ h\"ochstens
+noch unmittelbar von $a_i$ abh\"angen.  Um diese Abh\"angigkeit gegebenenfalls aufzul\"osen, f\"uhren wir
+die bereits fr\"uher diskutierte Transformation zur Elimination unmittelbarer Links-Rekursion durch.
+Anschlie{\ss}end h\"angt $a_i$ h\"ochstens noch 
+unmittelbar von $a_{i+1}$, $\cdots$, $a_n$ ab.  L\"auft die Schleife bis zum Ende durch, ist damit
+die Links-Rekursion vollst\"andig eliminiert, denn dann kann jede Variable nur von solchen
+Variablen abh\"angen, die in der Aufz\"ahlung $a_1$ $\cdots$, $a_n$ hinter ihr stehen.  Folglich ist 
 kein Zyklus der Form 
 \\[0.2cm]
 \hspace*{1.3cm}
 $a_i \Rightarrow a_j\beta \Rightarrow \cdots \Rightarrow a_i\gamma$
 \\[0.2cm]
-mehr möglich.
+mehr m\"oglich.
 
 \example
 Wir demonstrieren das Verfahren an der in Abbildung \ref{fig:mutual-left-recursion} gezeigten
-Grammatik.  Dazu ordnen wir zunächst die Variablen in der Form
+Grammatik.  Dazu ordnen wir zun\"achst die Variablen in der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $s, a, b$
@@ -1349,39 +1349,39 @@ an, mit der Notation des oben angegebenen Algorithmus gilt also $a_1 := s$, $a_2
 $a_3 := b$.
 \begin{enumerate}
 \item $i = 1$:  Da $\{1, \cdots, i-1 \} = \{\}$ gilt,  wird in diesem Fall die innere
-      \texttt{for}-Schleife nicht ausgeführt.  Wir müssen lediglich
-      die unmittelbare Links-Rekursion in der Variablen $s$ entfernen.  Da die Grammatik aber für
-      $s$ keine unmittelbare Links-Rekursion enthält, ist in diesem Fall nichts zu tun.
-\item $i = 2$:  In diesem Schritt müssen wir in der inneren \texttt{for}-Schleife sicherstellen,
-      dass $a$ nicht unmittelbar von $s$ abhängt.  da $a$ in der gegebenen Grammatik nicht
-      unmittelbar von $s$ abhängt, ist bei der inneren \texttt{for}-Schleife wieder nichts zu tun.
+      \texttt{for}-Schleife nicht ausgef\"uhrt.  Wir m\"ussen lediglich
+      die unmittelbare Links-Rekursion in der Variablen $s$ entfernen.  Da die Grammatik aber f\"ur
+      $s$ keine unmittelbare Links-Rekursion enth\"alt, ist in diesem Fall nichts zu tun.
+\item $i = 2$:  In diesem Schritt m\"ussen wir in der inneren \texttt{for}-Schleife sicherstellen,
+      dass $a$ nicht unmittelbar von $s$ abh\"angt.  da $a$ in der gegebenen Grammatik nicht
+      unmittelbar von $s$ abh\"angt, ist bei der inneren \texttt{for}-Schleife wieder nichts zu tun.
 
-      Weiter müssen wir die unmittelbare Rekursion aus allen Regeln für $a$ eliminieren.  Da 
-      es für die Variable $a$ keine unmittelbare Rekursion gibt, ist an dieser Stelle ebenfalls nichts
+      Weiter m\"ussen wir die unmittelbare Rekursion aus allen Regeln f\"ur $a$ eliminieren.  Da 
+      es f\"ur die Variable $a$ keine unmittelbare Rekursion gibt, ist an dieser Stelle ebenfalls nichts
       zu tun.
-\item $i = 3$:  In diesem Fall kommen für die innere \texttt{for}-Schleife zwei Werte von $j$
-      in Frage, die wir nacheinander behandeln müssen:
+\item $i = 3$:  In diesem Fall kommen f\"ur die innere \texttt{for}-Schleife zwei Werte von $j$
+      in Frage, die wir nacheinander behandeln m\"ussen:
       \begin{enumerate}
-      \item $j = 1$:  Hier müssen wir sicherstellen, dass $b$ nicht unmittelbar von $s$ abhängt.
+      \item $j = 1$:  Hier m\"ussen wir sicherstellen, dass $b$ nicht unmittelbar von $s$ abh\"angt.
             Bei der Regel
             \\[0.2cm]
             \hspace*{1.3cm}
             $b \rightarrow s \quoted{Z}$
             \\[0.2cm]
             ist dies aber der Fall.  Wir ersetzen daher das $s$ auf der rechten Seite dieser Regel
-            durch die beiden rechten Seiten der Regeln für $s$ und erhalten für $b$ nun die Regeln
+            durch die beiden rechten Seiten der Regeln f\"ur $s$ und erhalten f\"ur $b$ nun die Regeln
             \\[0.2cm]
             \hspace*{1.3cm}
             $b \rightarrow a \quoted{X} \squoted{Z}$ \quad und \quad
             $b \rightarrow \quoted{Y} \squoted{Z}$.
-      \item $j = 2$:  Nun müssen wir sicherstellen, dass $b$ nicht unmittelbar von $a$ abhängt.
+      \item $j = 2$:  Nun m\"ussen wir sicherstellen, dass $b$ nicht unmittelbar von $a$ abh\"angt.
             Bei der Regel
             \\[0.2cm]
             \hspace*{1.3cm}
             $b \rightarrow a \quoted{X} \squoted{Z}$ 
             \\[0.2cm]
             ist dies aber der Fall.  Wir ersetzen daher das $a$ auf der rechten Seite dieser Regel
-            durch die beiden rechten Seiten der Regeln für $a$ und erhalten für $b$ nun insgesamt
+            durch die beiden rechten Seiten der Regeln f\"ur $a$ und erhalten f\"ur $b$ nun insgesamt
             die folgenden Regeln:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -1389,14 +1389,14 @@ $a_3 := b$.
             $b \rightarrow \quoted{X} \squoted{X}\; \squoted{Z}$ \quad und \quad
             $b \rightarrow \quoted{Y} \squoted{Z}$.
       \end{enumerate}
-      Diese Regeln enthalten nun nur noch ummittelbare Links-Rekursion, die wir mit dem früher
-      beschriebenen Verfahren eliminieren.  Wir erhalten dann für $b$ die Regeln
+      Diese Regeln enthalten nun nur noch ummittelbare Links-Rekursion, die wir mit dem fr\"uher
+      beschriebenen Verfahren eliminieren.  Wir erhalten dann f\"ur $b$ die Regeln
       \\[0.2cm]
       \hspace*{1.3cm}
       $b \rightarrow \quoted{X} \squoted{X} \; \squoted{Z}\; l$ \quad und \quad
       $b \rightarrow \squoted{Y} \quoted{Z} l$,
       \\[0.2cm]
-      wobei die neu eingeführte Variable $l$ durch die Regeln
+      wobei die neu eingef\"uhrte Variable $l$ durch die Regeln
       \\[0.2cm]
       \hspace*{1.3cm}
       $l \rightarrow \quoted{Y} \squoted{X}\; \squoted{Z}\; l$ \quad und \quad 
@@ -1430,9 +1430,9 @@ Abbildung \ref{fig:mutual-left-recursion-2} zeigt die resultierende Grammatik.
 \end{figure}
 
 Das letzte Beispiel zeigt, dass sich eine Grammatik durch die Elimination indirekter Links-Rekursion
-stark aufblähen kann.  Zwar sind viele Grammatiken links-rekursiv, aber in der Regel
+stark aufbl\"ahen kann.  Zwar sind viele Grammatiken links-rekursiv, aber in der Regel
 handelt es sich dabei um direkte Links-Rekursion.  Wechselseitige Links-Rekursion ist in den
-Grammatiken, die Ihnen in der Praxis begegnen werden, ein eher seltenes Phänomen.
+Grammatiken, die Ihnen in der Praxis begegnen werden, ein eher seltenes Ph\"anomen.
 
 
 \subsection{Implementing a Top Down Parser in \textsc{SetlX}}

--- a/Lecture-Notes/lalr-bison.tex
+++ b/Lecture-Notes/lalr-bison.tex
@@ -1,10 +1,10 @@
 \section{Erzeugung von LALR-Parsern mit \textsl{Bison}}
 Die von dem Parser-Generator \textsl{Bison} erzeugten Parser sind LALR-Parser.
-\textsl{Bison} bietet die Möglichkeit, die erzeugten Mengen von e.m.R.s textuell oder
+\textsl{Bison} bietet die M\"oglichkeit, die erzeugten Mengen von e.m.R.s textuell oder
 grafisch darzustellen.  Abbildung \ref{fig:cc.y} zeigt, wie die Grammatik aus Abbildung
-\ref{fig:dragon-book.grammar} als Eingabe-Datei für \textsl{Bison} formatiert werden kann.
-Da es uns hier nur um die Erzeugung der Zustands-Mengen geht, enthält die Datei weder
-Deklarationen, die zur Anbindung eines Scanners erfoderlich wären, noch semantische Aktionen.
+\ref{fig:dragon-book.grammar} als Eingabe-Datei f\"ur \textsl{Bison} formatiert werden kann.
+Da es uns hier nur um die Erzeugung der Zustands-Mengen geht, enth\"alt die Datei weder
+Deklarationen, die zur Anbindung eines Scanners erfoderlich w\"aren, noch semantische Aktionen.
 
 \begin{figure}[!ht]
 \centering
@@ -30,25 +30,25 @@ Deklarationen, die zur Anbindung eines Scanners erfoderlich wären, noch semantis
 \end{figure}
 
 \noindent
-Übersetzen wir die in Abbildung \ref{fig:cc.y} gezeigte Datei mit dem Befehl
+\"Ubersetzen wir die in Abbildung \ref{fig:cc.y} gezeigte Datei mit dem Befehl
 \[ \texttt{bison -v -g cc.y} \]
 so werden von \textsl{Bison} zwei Dateien erzeugt:
 \begin{enumerate}
 \item Die Option ``\texttt{-v}'' (\emph{verbose}) bewirkt, dass die Datei
-      \texttt{cc.output} erzeugt wird.  Diese Datei enthält die Zustände des
+      \texttt{cc.output} erzeugt wird.  Diese Datei enth\"alt die Zust\"ande des
       LALR-Parsers und wird in Abbildung \ref{fig:cc.output} gezeigt.
 \item Die Option ``\texttt{-g}'' (\emph{graphic}) erzeugt die Datei
-      \texttt{cc.vcg}.  Die Datei-Endung \texttt{.vcg} steht als Abkürzung für 
+      \texttt{cc.vcg}.  Die Datei-Endung \texttt{.vcg} steht als Abk\"urzung f\"ur 
       \emph{visualization of compiler graphs}.
       Diese Datei stellt den Goto-Graphen der Grammatik im
-      \emph{VCG-Format} dar und lässt sich mit Hilfe geeigneter Werkzeuge grafisch
+      \emph{VCG-Format} dar und l\"asst sich mit Hilfe geeigneter Werkzeuge grafisch
       darstellen.  
       Ein solches Werkzeug ist \texttt{aiSee}, dass Sie im Internet unter der Adresse
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{http://www.aisee.com/}
       \\[0.2cm]
-      finden.  Dort können Sie eine Demoversion kostenlos herunterladen.
+      finden.  Dort k\"onnen Sie eine Demoversion kostenlos herunterladen.
 \end{enumerate}
 
 \begin{figure}[!ht]
@@ -117,7 +117,7 @@ so werden von \textsl{Bison} zwei Dateien erzeugt:
 \end{figure} 
 
 Wir diskutieren nun die in Abbildung \ref{fig:cc.output} gezeigte Datei \texttt{cc.output}
-Zeile für Zeile.
+Zeile f\"ur Zeile.
 \begin{enumerate}
 \item Die Zeilen 1 -- 5 zeigen die zu Grunde liegende Grammatik.  Die 0-te Regel hat hier
       die Form
@@ -132,7 +132,7 @@ Zeile für Zeile.
       \\[0.2cm]
       wobei der String ``\texttt{\$end}''
       %\$
-      für das Ende der Eingabe steht.  Bei Bison wird also das Datei-Ende-Zeichen
+      f\"ur das Ende der Eingabe steht.  Bei Bison wird also das Datei-Ende-Zeichen
       \textsc{Eof} mit zu der Regel hinzugenommen.
 
       Wie Sie sehen, sind die einzelnen Grammatik-Regeln mit 0 beginnend numeriert.
@@ -150,15 +150,15 @@ Zeile für Zeile.
       \item dieses Terminal tritt in der Regel 2 auf.
       \end{enumerate}
       Neben den vom Benutzer in der Grammatik definierten Terminalen ``\texttt{x}'' und
-      ``\texttt{y}'' führt \textsl{Bison} noch die beiden Terminale
+      ``\texttt{y}'' f\"uhrt \textsl{Bison} noch die beiden Terminale
       ``\texttt{\symbol{36}end}'' und ``\texttt{error}'' ein.  Ersteres bezeichnet das
-      Ende der Eingabe, letzteres steht für ein Token, dass nicht in der Eingabe-Sprache vorkommt.
+      Ende der Eingabe, letzteres steht f\"ur ein Token, dass nicht in der Eingabe-Sprache vorkommt.
 \item Die Zeilen 11 -- 17 listen die syntaktischen Variable, die hier als Nicht-Terminale
       bezeichnet werden, auf und geben die Regeln an, wo diese Variablen auftreten.
       Auch den Variablen werden Zahlen zugeordnet.  Diese Zahlen spielen jedoch nur
       in dem Code des von Bison erzeugten Parsers eine Rolle.
-\item Der Rest der Datei zeigt die Zustände und spezifiziert gleichzeitig die Funktionen
-      $\textsl{goto}()$ und $\textsl{action}()$.  Bei den Zuständen wird allerdings nicht
+\item Der Rest der Datei zeigt die Zust\"ande und spezifiziert gleichzeitig die Funktionen
+      $\textsl{goto}()$ und $\textsl{action}()$.  Bei den Zust\"anden wird allerdings nicht
       die gesamte Menge der e.m.R. angegeben, sondern es wird nur eine Menge
       $\textsc{M}^-$ angegeben, aus der sich mit Hilfe der Funktion $\textsl{closure}()$
       die gesamte Menge nach der Formel
@@ -166,8 +166,8 @@ Zeile für Zeile.
       \hspace*{1.3cm}
       $\textsc{M} = \textsl{closure}(\textsc{M}^-)$
       \\[0.2cm]
-      berechnen lässt.  Außerdem werden die Mengen der Folge-Token nicht angegeben.
-      Wir betrachten nun zwei der Zustände im Detail:
+      berechnen l\"asst.  Au{\ss}erdem werden die Mengen der Folge-Token nicht angegeben.
+      Wir betrachten nun zwei der Zust\"ande im Detail:
       \begin{enumerate}
       \item Der Zustand ``\texttt{state 1}'', der in der Zeile 25 spezifiziert
             wird, entspricht der Menge
@@ -205,13 +205,13 @@ Zeile für Zeile.
             \\[0.2cm]
             \hspace*{1.3cm}
             $\textsl{action}(s_2,t) = \langle \texttt{reduce}, C \rightarrow \quoted{x} C \rangle$ 
-            \quad für alle Token $t$
+            \quad f\"ur alle Token $t$
             \\[0.2cm]
             zu lesen.
       \end{enumerate}
 \end{enumerate}
-Neben der eben diskutierten textuellen Darstellung bietet \textsl{Bison} noch die Option, die Zustände des
-LALR-Parsers grafisch darzustellen.  Dazu erzeugt \textsl{Bison} zunächst die Datei \texttt{cc.vcg}, die dann
+Neben der eben diskutierten textuellen Darstellung bietet \textsl{Bison} noch die Option, die Zust\"ande des
+LALR-Parsers grafisch darzustellen.  Dazu erzeugt \textsl{Bison} zun\"achst die Datei \texttt{cc.vcg}, die dann
 beispielsweise mit dem Werkzeug \texttt{aisee} visualsiert werden kann.  Abbildung
 \ref{fig:bison-goto-graph.eps} zeigt diese Visualisierung. 
 
@@ -227,11 +227,11 @@ beispielsweise mit dem Werkzeug \texttt{aisee} visualsiert werden kann.  Abbildu
 \pagebreak
 
 \section{Die Behandlung von Konflikten mit \textsl{Bison}}
-\textsl{Bison} kann auch dann noch Grammatiken erzeugen, wenn bei der Konstruktion der Zustände Shift-Reduce-
+\textsl{Bison} kann auch dann noch Grammatiken erzeugen, wenn bei der Konstruktion der Zust\"ande Shift-Reduce-
 oder Reduce-Reduce-Konflikte auftreten.  Wir besprechen anhand zweier typischer Situationen, wie
-\textsl{Bison} in solchen Fällen vorgeht.
+\textsl{Bison} in solchen F\"allen vorgeht.
 
-\subsection{Operator-Präzedenzen}
+\subsection{Operator-Pr\"azedenzen}
 \begin{figure}[!ht]
 \centering
 \begin{Verbatim}[ frame         = lines, 
@@ -257,10 +257,10 @@ oder Reduce-Reduce-Konflikte auftreten.  Wir besprechen anhand zweier typischer 
 \end{figure}
 
 \noindent
-Wir beginnen mit der in Abbildung \ref{fig:shift-reduce-conflict.grammar} gezeigten Grammatik für
-arithmetische Ausdrücke.  Abbildung \ref{fig:conflict.y} zeigt, wie diese Grammatik sich für \textsl{Bison}
-darstellen lässt.   Hier haben wir in Zeile 1 festgelegt, dass ``\texttt{N}'' als Nicht-Terminal zu
-interpretieren ist.  Übersetzen wir diese Grammatik mit dem Befehl
+Wir beginnen mit der in Abbildung \ref{fig:shift-reduce-conflict.grammar} gezeigten Grammatik f\"ur
+arithmetische Ausdr\"ucke.  Abbildung \ref{fig:conflict.y} zeigt, wie diese Grammatik sich f\"ur \textsl{Bison}
+darstellen l\"asst.   Hier haben wir in Zeile 1 festgelegt, dass ``\texttt{N}'' als Nicht-Terminal zu
+interpretieren ist.  \"Ubersetzen wir diese Grammatik mit dem Befehl
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{bison -v conflict.y},
@@ -270,7 +270,7 @@ so erhalten wir die Warnung
 \hspace*{1.3cm}
 \texttt{conflict.y: conflicts: 4 shift/reduce}.
 \\[0.2cm]
-Bei der Übersetzung dieser Grammatik sind also insgesamt 4 Shift-Reduce-Konflikte aufgetreten.
+Bei der \"Ubersetzung dieser Grammatik sind also insgesamt 4 Shift-Reduce-Konflikte aufgetreten.
 Wir wollen diese Konflikte jetzt genauer analysieren und inspizieren zu diesem Zweck die von \textsl{Bison}
 erzeugte Datei \texttt{conflict.output}.  Die relevanten Teile dieser Datei sind in Abbildung
 \ref{fig:conflict.output} wiedergegeben.  Wir diskutieren diese Datei jetzt im Detail.
@@ -322,7 +322,7 @@ erzeugte Datei \texttt{conflict.output}.  Die relevanten Teile dieser Datei sind
 \end{figure}
 \begin{enumerate}
 \item Am Anfang der Datei werden alle Konflikte aufgelistet.
-      Bei der von \textsl{Bison} übersetzten Grammatik gibt es in den Zuständen ``\texttt{state 6}'' 
+      Bei der von \textsl{Bison} \"ubersetzten Grammatik gibt es in den Zust\"anden ``\texttt{state 6}'' 
       und ``\texttt{state 7}'' jeweils zwei 
       Shift-Reduce-Konflikte.
 \item Zustand ``\texttt{state 6}'' besteht aus den Regeln 
@@ -335,52 +335,52 @@ erzeugte Datei \texttt{conflict.output}.  Die relevanten Teile dieser Datei sind
       \begin{enumerate}
       \item Bei der Berechnung von $\textsl{action}(\texttt{state 6}, \squoted{+})$ gibt es einen
             Shift-Reduce-Konflikt, denn die markierte Regel $E \rightarrow E \bullet \quoted{+} E$
-            verlangt, dass das Token $\squoted{+}$ auf den Stack geschoben wird, während die markierte
+            verlangt, dass das Token $\squoted{+}$ auf den Stack geschoben wird, w\"ahrend die markierte
             Regel $E \rightarrow E \quoted{+} E \bullet$ fordert, dass der Symbolstack mit der Grammatik-Regel 
             $E \rightarrow E \quoted{+} E$ reduziert wird.
 
             Leider werden die Mengen der Folge-Token bei \textsl{Bison} nicht mit ausgegeben, so dass
-            die Tatsache, dass das Token $\squoted{+}$ tatsächlich ein Folge-Token der markierten Regel
+            die Tatsache, dass das Token $\squoted{+}$ tats\"achlich ein Folge-Token der markierten Regel
             $E \rightarrow E \quoted{+} E$ ist, aus der von \textsl{Bison} produzierten Ausgabe nicht
             ersichtlich ist.
       \item Bei der Berechnung von $\textsl{action}(\texttt{state 6}, \squoted{*})$ gibt es einen
             Shift-Reduce-Konflikt, denn die markierte Regel $E \rightarrow E \bullet \quoted{*} E$
-            verlangt, dass das Token $\squoted{*}$ auf den Stack geschoben wird, während die markierte
+            verlangt, dass das Token $\squoted{*}$ auf den Stack geschoben wird, w\"ahrend die markierte
             Regel $E \rightarrow E \quoted{+} E \bullet$ fordert, dass der Symbolstack mit der Grammatik-Regel 
             $E \rightarrow E \quoted{+} E$ reduziert wird.
       \end{enumerate}
-      In den Zeilen 16 -- 19 sehen wir, wie diese Konflikte aufgelöst werden:  \textsl{Bison}
-      bevorzugt bei Shift-Reduce-Konflikten einen Shift.  Die auch möglichen Reduktionen sind daher
+      In den Zeilen 16 -- 19 sehen wir, wie diese Konflikte aufgel\"ost werden:  \textsl{Bison}
+      bevorzugt bei Shift-Reduce-Konflikten einen Shift.  Die auch m\"oglichen Reduktionen sind daher
       in den Zeilen 18 und 19 mit den eckigen Klammern ``\texttt{[}'' und ``\texttt{]}'' eingefasst worden um
       kenntlich zu machen, dass diese Reduktionen nicht angewendet werden.
 \item Die Shift-Reduce-Konflikte, die in dem Zustand ``\texttt{state 7}'' auftreten, sind analog
       zu den Konflikten im Zustand ``\texttt{state 6}'' und werden daher nicht im Detail diskutiert.
 \end{enumerate}
-Es ist in \textsl{Bison} möglich, Shift-Reduce-Konflikte durch die Angabe von \emph{Operator-Präzedenzen}
-aufzulösen.  Abbildung \ref{fig:calc-precedence.y} zeigt die \textsl{Bison}-Spezifikation einer Grammatik zur
-Erkennung arithmetischer Ausdrücke, die aus Zahlen und den binären Operatoren ``\texttt{+}'',
+Es ist in \textsl{Bison} m\"oglich, Shift-Reduce-Konflikte durch die Angabe von \emph{Operator-Pr\"azedenzen}
+aufzul\"osen.  Abbildung \ref{fig:calc-precedence.y} zeigt die \textsl{Bison}-Spezifikation einer Grammatik zur
+Erkennung arithmetischer Ausdr\"ucke, die aus Zahlen und den bin\"aren Operatoren ``\texttt{+}'',
 ``\texttt{-}'', ``\texttt{*}'', ``\texttt{/}'' und ``\texttt{\^}'' aufgebaut sind.   Mit Hilfe der
-Schlüsselwörter ``\texttt{\%left}'' und ``\texttt{\%right}'' 
+Schl\"usselw\"orter ``\texttt{\%left}'' und ``\texttt{\%right}'' 
 haben wir festgelegt, dass die Operatoren ``\texttt{+}'',
 ``\texttt{-}'', ``\texttt{*}'' und ``\texttt{/}'' \emph{links-assoziativ} sind, ein Ausdruck der Form
 \[ 3 - 2 - 1 \quad \mbox{wird also als} \quad (3 - 2) - 1 \quad \mbox{und nicht als} \quad 3 - (2-1) \]
-gelesen.  Demgegenüber ist der Operator ``\texttt{\^}'', der die Potenzbildung bezeichnet,
+gelesen.  Demgegen\"uber ist der Operator ``\texttt{\^}'', der die Potenzbildung bezeichnet,
 \emph{rechts-assoziativ}, der Ausdruck 
 \[ 4 \texttt{\symbol{94}} 3 \texttt{\symbol{94}} 2 \quad \mbox{wird also als} \quad 4^{(3^2)} \quad 
    \mbox{und nicht als} \quad (4^3)^2
 \]
-interpretiert.   Die Reihenfolge, in der die Assoziativität der Operatoren spezifiziert werden, legt die
-\emph{Präzedenzen}, die auch als \emph{Bindungsstärken} bezeichnet werden, fest.  Dabei ist die
-Bindungsstärke umso größer, je später der Operator spezifiziert wird.  In unserem konkreten Beispiel bindet
-der Exponentiations-Operator ``\texttt{\^}'' also am stärksten, während die Operatoren ``\texttt{+}'' und
-``\texttt{-}'' am schwächsten binden.  Bei der in Abbildung \ref{fig:calc-precedence.y} gezeigten Grammatik
-ordnet \textsl{Bison} den Operatoren die Bindungsstärke nach der folgenden Tabelle zu:
+interpretiert.   Die Reihenfolge, in der die Assoziativit\"at der Operatoren spezifiziert werden, legt die
+\emph{Pr\"azedenzen}, die auch als \emph{Bindungsst\"arken} bezeichnet werden, fest.  Dabei ist die
+Bindungsst\"arke umso gr\"o{\ss}er, je sp\"ater der Operator spezifiziert wird.  In unserem konkreten Beispiel bindet
+der Exponentiations-Operator ``\texttt{\^}'' also am st\"arksten, w\"ahrend die Operatoren ``\texttt{+}'' und
+``\texttt{-}'' am schw\"achsten binden.  Bei der in Abbildung \ref{fig:calc-precedence.y} gezeigten Grammatik
+ordnet \textsl{Bison} den Operatoren die Bindungsst\"arke nach der folgenden Tabelle zu:
 
 
 \begin{center}
 \begin{tabular}[t]{|c|c|}
 \hline
-Operator       & Bindungsstärke \\
+Operator       & Bindungsst\"arke \\
 \hline
 \hline
 ``\texttt{+}''  & 1              \\
@@ -426,23 +426,23 @@ Operator       & Bindungsstärke \\
 \end{Verbatim}
 %$
 \vspace*{-0.3cm}
-\caption{Auflösung der Shift-Reduce-Konflikte durch Operator-Präzedenzen.}
+\caption{Aufl\"osung der Shift-Reduce-Konflikte durch Operator-Pr\"azedenzen.}
 \label{fig:calc-precedence.y}
 \end{figure}
 
-Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Konflikte aufzulösen.
-\textsl{Bison} geht folgendermaßen vor:
+Wie erl\"autern nun, wie diese Bindungsst\"arken benutzt werden, um Shift-Reduce-Konflikte aufzul\"osen.
+\textsl{Bison} geht folgenderma{\ss}en vor:
 \begin{enumerate}
-\item Zunächst wird jeder Grammatik-Regel eine \emph{Präzedenz} zugeordnet.
-      Die Präzedenz ist dabei die Bindungsstärke des letzten in der Regel auftretenden Operators.
-      Für den Fall, dass eine Regel mehrere Operatoren enthält, für die eine Bindungsstärke spezifiziert
-      wurde, wird zur Festlegung der Bindungsstärke also der Operator herangezogen, der in
+\item Zun\"achst wird jeder Grammatik-Regel eine \emph{Pr\"azedenz} zugeordnet.
+      Die Pr\"azedenz ist dabei die Bindungsst\"arke des letzten in der Regel auftretenden Operators.
+      F\"ur den Fall, dass eine Regel mehrere Operatoren enth\"alt, f\"ur die eine Bindungsst\"arke spezifiziert
+      wurde, wird zur Festlegung der Bindungsst\"arke also der Operator herangezogen, der in
       der Regel am weitesten 
-      rechts steht.  In unserem Beispiel haben die einzelnen Regeln damit die folgenden Präzedenzen:
+      rechts steht.  In unserem Beispiel haben die einzelnen Regeln damit die folgenden Pr\"azedenzen:
       \begin{center}
         \begin{tabular}[t]{|l|c|}
           \hline
-          Regel                          & Präzedenz  \\
+          Regel                          & Pr\"azedenz  \\
           \hline
           \hline
           $E \rightarrow E \quoted{+} E$ & 1          \\
@@ -461,8 +461,8 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
           \hline
         \end{tabular}
       \end{center}
-      Für die Regeln, die keinen Operator enthalten, für den eine Bindungsstärke spezifiziert ist,
-      bleibt die Präzedenz unspezifiziert.
+      F\"ur die Regeln, die keinen Operator enthalten, f\"ur den eine Bindungsst\"arke spezifiziert ist,
+      bleibt die Pr\"azedenz unspezifiziert.
 \item Ist nun $s$ ein Zustand, in dem zwei Regeln $r_1$ und $r_2$ der Form
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -474,12 +474,12 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
       \hspace*{1.3cm}
       $\textsl{action}(s, o)$
       \\[0.2cm]
-      zunächst einen Shift-Reduce-Konflikt.  Ist nun $o$ ein Operator, für den eine Präzedenz $p(o)$
-      festgelegt worden ist und hat außerdem die Regel $r_2$, mit der reduziert werden würde, die Präzedenz
-      $p(r_2)$ so wird der Shift-Reduce-Konflikt in Abhängigkeit von der relativen Größe 
-      dieser beiden Zahlen aufgelöst.  Hier werden drei Fälle unterschieden:
+      zun\"achst einen Shift-Reduce-Konflikt.  Ist nun $o$ ein Operator, f\"ur den eine Pr\"azedenz $p(o)$
+      festgelegt worden ist und hat au{\ss}erdem die Regel $r_2$, mit der reduziert werden w\"urde, die Pr\"azedenz
+      $p(r_2)$ so wird der Shift-Reduce-Konflikt in Abh\"angigkeit von der relativen Gr\"o{\ss}e 
+      dieser beiden Zahlen aufgel\"ost.  Hier werden drei F\"alle unterschieden:
       \begin{enumerate}
-      \item $p(o) > p(r_2)$: In diesem Fall bindet der Operator $o$ stärker.  Daher wird das Token $o$ 
+      \item $p(o) > p(r_2)$: In diesem Fall bindet der Operator $o$ st\"arker.  Daher wird das Token $o$ 
             in diesem Fall auf den Stack geschoben:
             \hspace*{1.3cm}
             \\[0.2cm]
@@ -496,7 +496,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             $E \rightarrow E \quoted{+} E \mid E \quoted{*} E \mid \textsc{Number}$
             \\[0.2cm]
             parsen.  Betrachten wir die Situation, bei der der Teilstring ``\texttt{1+2}''
-            bereits gelesen wurde und nun als nächstes das Token ``\texttt{*}''
+            bereits gelesen wurde und nun als n\"achstes das Token ``\texttt{*}''
             verarbeitet werden soll.  Der LALR-Parser ist dann in dem folgenden Zustand:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -512,13 +512,13 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             \end{array}
             $
             \\[0.2cm]
-            Wenn in diesem Zustand als nächstes Zeichen ein ``\texttt{*}'' gelesen wird, so darf der
+            Wenn in diesem Zustand als n\"achstes Zeichen ein ``\texttt{*}'' gelesen wird, so darf der
             bisher gelesene String ``\texttt{1+2}'' nicht mit der Regel 
-            $E \rightarrow E \squoted{+} E$ reduziert werden, denn wir wollen die 2 ja zunächst mit 3 
+            $E \rightarrow E \squoted{+} E$ reduziert werden, denn wir wollen die 2 ja zun\"achst mit 3 
             multiplizieren.  Statt dessen muss das Zeichen 
             ``\texttt{*}'' auf den Stack geschoben werden.
-      \item $p(o) < p(r_2)$: Jetzt bindet der Operator, der in der Regel $r_2$ auftritt, stärker als der
-            Operator $o$.  Daher wird in diesem Fall zunächst mit der Regel $r_2$ reduziert, wir haben 
+      \item $p(o) < p(r_2)$: Jetzt bindet der Operator, der in der Regel $r_2$ auftritt, st\"arker als der
+            Operator $o$.  Daher wird in diesem Fall zun\"achst mit der Regel $r_2$ reduziert, wir haben 
             also 
             \\[-0.2cm]
             \hspace*{1.3cm}
@@ -535,7 +535,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             $E \rightarrow E \quoted{+} E \mid E \quoted{*} E \mid \textsc{Number}$
             \\[0.2cm]
             parsen.  Betrachten wir die Situation, bei der der Teilstring ``\texttt{1*2}''
-            bereits gelesen wurde und nun als nächstes das Token ``\texttt{+}''
+            bereits gelesen wurde und nun als n\"achstes das Token ``\texttt{+}''
             verarbeitet werden soll.  Der LALR-Parser ist dann in dem folgenden Zustand:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -551,12 +551,12 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             \end{array}
             $
             \\[0.2cm]
-            Wenn in diesem Zustand als nächstes Zeichen ein ``\texttt{+}'' gelesen wird, so soll
+            Wenn in diesem Zustand als n\"achstes Zeichen ein ``\texttt{+}'' gelesen wird, so soll
             der bisher gelesene String ``\texttt{1*2}''  mit der Regel 
-            $E \rightarrow E \squoted{*} E$ reduziert werden, denn wir wollen die 1 ja zunächst mit 2 
+            $E \rightarrow E \squoted{*} E$ reduziert werden, denn wir wollen die 1 ja zun\"achst mit 2 
             multiplizieren.  
       \item $p(o) = p(r_2)$ und der Operator $o$ ist links-assoziativ:
-            Dann wird zunächst mit der Regel $r_2$ reduziert, wir haben
+            Dann wird zun\"achst mit der Regel $r_2$ reduziert, wir haben
             also 
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -573,7 +573,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             $E \rightarrow E \quoted{+} E \mid E \quoted{*} E \mid \textsc{Number}$
             \\[0.2cm]
             parsen.  Betrachten wir die Situation, bei der der Teilstring ``\texttt{1*2}''
-            bereits gelesen wurde und nun als nächstes das Token ``\texttt{*}''
+            bereits gelesen wurde und nun als n\"achstes das Token ``\texttt{*}''
             verarbeitet werden soll.  Der LALR-Parser ist dann in dem folgenden Zustand:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -589,9 +589,9 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             \end{array}
             $
             \\[0.2cm]
-            Wenn in diesem Zustand als nächstes Zeichen ein ``\texttt{*}'' gelesen wird, so soll
+            Wenn in diesem Zustand als n\"achstes Zeichen ein ``\texttt{*}'' gelesen wird, so soll
             der bisher gelesene String ``\texttt{1*2}'' mit der Regel 
-            $E \rightarrow E \squoted{*} E$ reduziert werden, denn wir wollen die 1 ja zunächst mit 2 
+            $E \rightarrow E \squoted{*} E$ reduziert werden, denn wir wollen die 1 ja zun\"achst mit 2 
             multiplizieren.  
       \item $p(o) = p(r_2)$ und der Operator $o$ ist rechts--assoziativ:
             In diesem Fall wird $o$ auf den
@@ -611,9 +611,9 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             $E \rightarrow E \texttt{\symbol{94}} E  \mid \textsc{Number}$
             \\[0.2cm]
             zu parsen und die Situation zu betrachten, bei der der Teilstring
-            ``\texttt{1\symbol{94}2}'' bereits verarbeitet wurde und als nächstes Zeichen nun
+            ``\texttt{1\symbol{94}2}'' bereits verarbeitet wurde und als n\"achstes Zeichen nun
             der Operator ``\texttt{\symbol{94}}'' gelesen wird.
-      \item $p(o) = p(r_2)$ und der Operator $o$ hat keine Assoziativität-assoziativ:
+      \item $p(o) = p(r_2)$ und der Operator $o$ hat keine Assoziativit\"at-assoziativ:
             In diesem Fall liegt ein Syntax-Fehler vor:
             $\textsl{action}(s,o) = \textsl{error}$.
             \\[0.2cm]
@@ -629,7 +629,7 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             \\[0.2cm]
             %$
             zu parsen.  In dem Moment, in dem Sie den Teilstring ``\texttt{1<1}'' gelesen haben
-            und nun das nächste Token das Zeichen ``\texttt{<}'' ist, erkennen Sie, 
+            und nun das n\"achste Token das Zeichen ``\texttt{<}'' ist, erkennen Sie, 
             dass es ein Problem gibt.
 
             Um in \textsl{Bison} einen Operator $o$ als nicht-assoziativ zu deklarieren, 
@@ -638,24 +638,24 @@ Wie erläutern nun, wie diese Bindungsstärken benutzt werden, um Shift-Reduce-Kon
             \hspace*{1.3cm}
             \texttt{\symbol{37}nonassoc $o$}
       \end{enumerate}
-      In den Fällen, in denen ein Shift-Reduce-Konflikt nicht mit den oben angegebenen Regeln aufgelöst
-      werden kann, wird eine Warung ausgegeben.  In diesem Fall wird der Konflikt dann dadurch aufgelöst, 
+      In den F\"allen, in denen ein Shift-Reduce-Konflikt nicht mit den oben angegebenen Regeln aufgel\"ost
+      werden kann, wird eine Warung ausgegeben.  In diesem Fall wird der Konflikt dann dadurch aufgel\"ost, 
       dass das betreffende Token auf den Stack geschoben wird.
 \end{enumerate}
 Die von \textsl{Bison} erzeugt Datei ``\texttt{calc-precedence.output}'' zeigt im Detail, wie die
-Shift-Reduce-Konflikt Konflikte aufgelöst worden sind.  Wir betrachten exemplarisch zwei Zustände in dieser
+Shift-Reduce-Konflikt Konflikte aufgel\"ost worden sind.  Wir betrachten exemplarisch zwei Zust\"ande in dieser
 Datei.
 \begin{enumerate}
 \item Der Zustand ``\texttt{state 12}'' hat die in Abbildung \ref{fig:state12} gezeigte Form.
-      Hier gibt es zunächst einen Shift-Reduce-Konflikt zwischen den beiden markierten Regeln
+      Hier gibt es zun\"achst einen Shift-Reduce-Konflikt zwischen den beiden markierten Regeln
       \\[0.2cm]
       \hspace*{1.3cm}
       $E \rightarrow E \bullet \quoted{+} E$ \quad und \quad
       $E \rightarrow E \quoted{+} E \bullet$, 
       \\[0.2cm]
-      denn die erste Regel verlangt nach einem Shift, während die zweite Regel eine Reduktion fordert.
-      Da die Regel $E \rightarrow E \quoted{+} E$ dieselbe Präzedenz wie der Operator ``\texttt{+}''
-      hat, spielt nun die Assoziativität eine Rolle.  Da dieser Operator links-assoziativ ist, 
+      denn die erste Regel verlangt nach einem Shift, w\"ahrend die zweite Regel eine Reduktion fordert.
+      Da die Regel $E \rightarrow E \quoted{+} E$ dieselbe Pr\"azedenz wie der Operator ``\texttt{+}''
+      hat, spielt nun die Assoziativit\"at eine Rolle.  Da dieser Operator links-assoziativ ist, 
       wird mit dieser Regel reduziert.  Dies ist Teil des in Zeile 14 spezifizierten Falls.
 
     \begin{figure}[!ht]
@@ -688,7 +688,7 @@ Datei.
     \caption{Der Zustand ``\texttt{state 12}''}
     \label{fig:state12}
   \end{figure}
-        Der Zustand ``\texttt{state 12}'' enthält noch weitere Shift-Reduce-Konflikte.
+        Der Zustand ``\texttt{state 12}'' enth\"alt noch weitere Shift-Reduce-Konflikte.
         Beispielsweise besteht zwischen den beiden Regeln
         \\[0.2cm]
         \hspace*{1.3cm}
@@ -696,17 +696,17 @@ Datei.
         $E \rightarrow E \quoted{+} E \bullet$, 
         \\[0.2cm]
         ein Shift-Reduce-Konflikt bei der Berechnung von $\textsl{action}(\texttt{state 12}, \squoted{*})$.
-        Da der Operator ``\texttt{*}'' die Priorität 2 hat, während die Regel $E \rightarrow E \quoted{+} E$
-        nur die Priorität 1 hat, wird dieser Konflikt wie in Zeile 10 gezeigt durch einen Shift aufgelöst.
+        Da der Operator ``\texttt{*}'' die Priorit\"at 2 hat, w\"ahrend die Regel $E \rightarrow E \quoted{+} E$
+        nur die Priorit\"at 1 hat, wird dieser Konflikt wie in Zeile 10 gezeigt durch einen Shift aufgel\"ost.
 \item Der Zustand ``\texttt{state 16}'' hat die in Abbildung \ref{fig:state16} gezeigte Form.
-      Zunächst gibt es hier einen Shift-Reduce-Konflikt zwischen den Regeln
+      Zun\"achst gibt es hier einen Shift-Reduce-Konflikt zwischen den Regeln
       \\[0.2cm]
       \hspace*{1.3cm}
       $E \rightarrow E \bullet \quoted{\symbol{94}} E$ \quad und \quad
       $E \rightarrow E \quoted{\symbol{94}} E  \bullet$,
       \\[0.2cm]
-      wenn das nächste Token der Operator ``\texttt{\symbol{94}}'' ist.  Da der Operator dieselbe Präzedenz
-      hat wie die Regel, entscheidet wieder die Assoziativität.  Nun ist der Operator
+      wenn das n\"achste Token der Operator ``\texttt{\symbol{94}}'' ist.  Da der Operator dieselbe Pr\"azedenz
+      hat wie die Regel, entscheidet wieder die Assoziativit\"at.  Nun ist der Operator
       ``\texttt{\symbol{94}}'' rechts-assoziativ, daher wird in diesem Fall geshiftet.
 
     \begin{figure}[!ht]
@@ -745,9 +745,9 @@ Datei.
       $E \rightarrow E \bullet \quoted{+} E$ \quad und \quad
       $E \rightarrow E \quoted{\symbol{94}} E  \bullet$,
       \\[0.2cm]
-      der auftritt, wenn das nächste Token ein ``\texttt{+}'' ist.  Da die Regel 
-      $E \rightarrow E \quoted{\symbol{94}} E$ die Präzedenz 3 hat, die größer ist als die Präzedenz 1 des
-      Operators ``\texttt{+}'' wird dieser Konflikt dadurch aufgelöst, dass mit der Regel 
+      der auftritt, wenn das n\"achste Token ein ``\texttt{+}'' ist.  Da die Regel 
+      $E \rightarrow E \quoted{\symbol{94}} E$ die Pr\"azedenz 3 hat, die gr\"o{\ss}er ist als die Pr\"azedenz 1 des
+      Operators ``\texttt{+}'' wird dieser Konflikt dadurch aufgel\"ost, dass mit der Regel 
       $E \rightarrow E \quoted{\symbol{94}} E$ reduziert wird. 
 \end{enumerate}    
 \pagebreak
@@ -778,7 +778,7 @@ Datei.
                   ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Fragment einer Grammatik für die Sprache \texttt{C}}
+\caption{Fragment einer Grammatik f\"ur die Sprache \texttt{C}}
 \label{fig:dangling-else.y}
 \end{figure}
 
@@ -787,11 +787,11 @@ Bei der syntaktischen Beschreibung von Befehlen der Sprache \texttt{C}
 tritt bei der Behandlung
 von \emph{if-then-else} Konstrukten ein Shift-Reduce-Konflikt auf, den wir jetzt analysieren wollen.
 Abbildung \ref{fig:dangling-else.y} zeigt eine Grammatik, die einen Teil der Syntax von Befehlen der
-Sprache \texttt{C} beschreibt.  Um uns auf das wesentliche konzentrieren zu können, habe ich dort
-``\texttt{EXPR}'' als Terminal definiert, denn wie arithmetische Ausdrücke mit Hilfe von \textsl{Bison}
-behandelt werden können, haben wir ja schon im letzten Abschnitt gesehen.  Das Token ``\texttt{ID}'' steht
-für eine Variable, die Grammatik beschreibt also Befehle, die aus Zuweisungen, \emph{If-Abfragen},
-\emph{If-Else-Abfragen} und \emph{While-Schleifen} aufgebaut sind.  Übersetzen wir diese Grammatik mit
+Sprache \texttt{C} beschreibt.  Um uns auf das wesentliche konzentrieren zu k\"onnen, habe ich dort
+``\texttt{EXPR}'' als Terminal definiert, denn wie arithmetische Ausdr\"ucke mit Hilfe von \textsl{Bison}
+behandelt werden k\"onnen, haben wir ja schon im letzten Abschnitt gesehen.  Das Token ``\texttt{ID}'' steht
+f\"ur eine Variable, die Grammatik beschreibt also Befehle, die aus Zuweisungen, \emph{If-Abfragen},
+\emph{If-Else-Abfragen} und \emph{While-Schleifen} aufgebaut sind.  \"Ubersetzen wir diese Grammatik mit
 \textsl{Bison}, so erhalten wir den in Abbildung \ref{fig:dangling-else.output} ausschnittsweise gezeigten
 Shift-Reduce-Konflikt. 
 
@@ -854,8 +854,8 @@ kann auf die folgenden beiden Arten gelesen werden:
       \end{verbatim}
       \vspace*{-0.7cm}
 \item Die zweite Interpretation, die nach der in Abbildung
-      \ref{fig:dangling-else.y} gezeigten Grammatik ebenfalls zulässig wäre,
-      würde den Befehl in der folgenden Form interpretieren:
+      \ref{fig:dangling-else.y} gezeigten Grammatik ebenfalls zul\"assig w\"are,
+      w\"urde den Befehl in der folgenden Form interpretieren:
       \begin{verbatim}
       if (a = b) {
           if (c = d) {
@@ -869,19 +869,19 @@ kann auf die folgenden beiden Arten gelesen werden:
 
       Diese Interpretation entspricht nicht der Spezifikation der Sprache \texttt{C}.
 \end{enumerate}
-Es gibt drei Möglichkeiten, das Problem zu lösen.
+Es gibt drei M\"oglichkeiten, das Problem zu l\"osen.
 \begin{enumerate}
-\item Tritt ein Shift-Reduce-Konflikt auf, der nicht durch Operator-Präzedenzen gelöst wird,
-      so ist der Default, dass das nächste Token auf den Stack geschoben wird.  In dem konkreten
+\item Tritt ein Shift-Reduce-Konflikt auf, der nicht durch Operator-Pr\"azedenzen gel\"ost wird,
+      so ist der Default, dass das n\"achste Token auf den Stack geschoben wird.  In dem konkreten
       Fall ist dies genau das, was wir wollen, weil dadurch das \texttt{else} immer mit dem letzten
-      \texttt{if} assoziert wird.  Das einzige, was dann noch stört, ist von dem
+      \texttt{if} assoziert wird.  Das einzige, was dann noch st\"ort, ist von dem
       Shift-Reduce-Konflikt erzeugte Warnung.  Diese kann mit Hilfe der Option
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{\symbol{37}expect $n$}
       \\[0.2cm]
-      mit der angegeben wird, dass wir genau $n$ Konflikte erwarten, unterdrückt werden.
-      Das führt zu der in Abbildung \ref{fig:dangling-else-expect.y} gezeigten Grammatik.
+      mit der angegeben wird, dass wir genau $n$ Konflikte erwarten, unterdr\"uckt werden.
+      Das f\"uhrt zu der in Abbildung \ref{fig:dangling-else-expect.y} gezeigten Grammatik.
 
       \begin{figure}[!ht]
 \centering
@@ -909,23 +909,23 @@ Es gibt drei Möglichkeiten, das Problem zu lösen.
                   ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Unterdrückung von Warnungen durch \texttt{expect}.}
+\caption{Unterdr\"uckung von Warnungen durch \texttt{expect}.}
 \label{fig:dangling-else-expect.y}
 \end{figure}
-\item Die zweite Möglichkeit besteht darin, die Grammatik so umzuschreiben, dass die Mehrdeutigkeit
-      verschwindet.   Die grundsätzliche Idee ist hier, zwischen zwei Arten von Befehlen zu
+\item Die zweite M\"oglichkeit besteht darin, die Grammatik so umzuschreiben, dass die Mehrdeutigkeit
+      verschwindet.   Die grunds\"atzliche Idee ist hier, zwischen zwei Arten von Befehlen zu
       unterscheiden.
       \begin{enumerate}
       \item Einerseits gibt es Befehle, bei denen jedem ``\texttt{if}'' auch ein ``\texttt{else}''
-            zugeordnet ist.  Zwischen einem ``\texttt{if}'' und einem ``\texttt{else}'' dürfen nur
+            zugeordnet ist.  Zwischen einem ``\texttt{if}'' und einem ``\texttt{else}'' d\"urfen nur
             solche Befehle auftreten.
       \item Andererseits gibt es Befehle, bei denen dem letzten ``\texttt{if}'' kein
-            ``\texttt{else}'' zugeordnet ist.  solche Befehle dürfen nicht zwischen einem
+            ``\texttt{else}'' zugeordnet ist.  solche Befehle d\"urfen nicht zwischen einem
             ``\texttt{if}'' und einem ``\texttt{else}'' auftreten.
       \end{enumerate}
       Abbildung \ref{fig:dangling-else-correct.y} zeigt die Umsetzung dieser Idee.
       Die syntaktische Kategorie \textsl{MatchedStmnt} beschreibt dabei die Befehle, 
-      bei denen jedem ``\texttt{if}'' ein ``\texttt{else}'' zugeordnet ist, während die Kategorie 
+      bei denen jedem ``\texttt{if}'' ein ``\texttt{else}'' zugeordnet ist, w\"ahrend die Kategorie 
       \textsl{UnMatchedStmnt} die restlichen Befehle erfasst.
 
 \begin{figure}[!ht]
@@ -961,7 +961,7 @@ Es gibt drei Möglichkeiten, das Problem zu lösen.
                    ;
     \end{Verbatim}
     \vspace*{-0.3cm}
-    \caption{Eine eindeutige Grammatik für \texttt{C}-Befehle.}
+    \caption{Eine eindeutige Grammatik f\"ur \texttt{C}-Befehle.}
     \label{fig:dangling-else-correct.y}
 \end{figure}
 
@@ -973,16 +973,16 @@ Es gibt drei Möglichkeiten, das Problem zu lösen.
       \hspace*{1.3cm}
       \texttt{http://java.sun.com/docs/books/jls/first\_edition/html/19.doc.html}
       \\[0.2cm]
-      Der Nachteil ist allerdings, dass bei diesem Vorgehen die Grammatik stark aufgebläht wird. 
+      Der Nachteil ist allerdings, dass bei diesem Vorgehen die Grammatik stark aufgebl\"aht wird. 
       Vermutlich aus diesem Grunde findet sich in der zweiten Auflage der Sprach-Spezifikation eine
       Grammatik, bei der das \emph{Dangling-Else}-Problem wieder auftritt. 
 
-\item Die letzte Möglichkeit um das \emph{Dangling-Else}-Problem zu lösen, besteht darin, dass
-      wir ``\texttt{if}'' und ``\texttt{else}'' als Operatoren auffassen, denen wir eine Präzedenz
+\item Die letzte M\"oglichkeit um das \emph{Dangling-Else}-Problem zu l\"osen, besteht darin, dass
+      wir ``\texttt{if}'' und ``\texttt{else}'' als Operatoren auffassen, denen wir eine Pr\"azedenz
       zuordenen.  Abbildung \ref{fig:dangling-else-precedence.y} zeigt die Umsetzung dieser Idee.
       \begin{enumerate}
-      \item Zunächst haben wir in den Zeilen 3 und 4 ``\texttt{if}'' und ``\texttt{else}'' als
-            nicht-assoziative Operatoren deklariert, wobei ``\texttt{else}'' die höhere Präzedenz
+      \item Zun\"achst haben wir in den Zeilen 3 und 4 ``\texttt{if}'' und ``\texttt{else}'' als
+            nicht-assoziative Operatoren deklariert, wobei ``\texttt{else}'' die h\"ohere Pr\"azedenz
             hat.  Dadurch erreichen wir, dass ein ``\texttt{else}'' auf den Stack geschoben wird,
             wenn der Parser in dem in Abbildung \ref{fig:dangling-else.output} gezeigten Zustand ist.
       \item In Zeile 8 haben wir der Regel
@@ -995,17 +995,17 @@ Es gibt drei Möglichkeiten, das Problem zu lösen.
             \hspace*{1.3cm}
             \texttt{\symbol{37}prec \symbol{34}if\symbol{34}}
             \\[0.2cm]
-            die Präzedenz des Operators ``\texttt{if}'' zugewiesen.  Dies ist notwendig, weil 
-            der letzte Operator, der in dieser Regel auftritt, die schließende runde Klammer
-            ``\texttt{)}'' ist, der wir keine Priorität zugewiesen haben.  Der Klammer eine Priorität
-            zuzuweisen wäre einerseits kontraintuitiv, andererseits problematisch, da die Klammer ja
+            die Pr\"azedenz des Operators ``\texttt{if}'' zugewiesen.  Dies ist notwendig, weil 
+            der letzte Operator, der in dieser Regel auftritt, die schlie{\ss}ende runde Klammer
+            ``\texttt{)}'' ist, der wir keine Priorit\"at zugewiesen haben.  Der Klammer eine Priorit\"at
+            zuzuweisen w\"are einerseits kontraintuitiv, andererseits problematisch, da die Klammer ja
             auch noch an anderen Stellen verwendet werden kann.  Mit Hilfe der
-            \texttt{\symbol{37}prec}-Deklaration können wir einer Regel unmittelbar die Präzedenz
+            \texttt{\symbol{37}prec}-Deklaration k\"onnen wir einer Regel unmittelbar die Pr\"azedenz
             eines Operators zuweisen und so das Problem umgehen.
 
-            In dem vorliegenden Fall ist die Präzedenz des Operators ``\texttt{else}''
-            höher als die Präzedenz von ``\texttt{if}'', so dass der Shift-Reduce-Konflikt
-            dadurch aufgelöst wird, dass das Token ``\texttt{else}'' auf den Stack
+            In dem vorliegenden Fall ist die Pr\"azedenz des Operators ``\texttt{else}''
+            h\"oher als die Pr\"azedenz von ``\texttt{if}'', so dass der Shift-Reduce-Konflikt
+            dadurch aufgel\"ost wird, dass das Token ``\texttt{else}'' auf den Stack
             geschoben wird.
       \end{enumerate}
 
@@ -1038,7 +1038,7 @@ Es gibt drei Möglichkeiten, das Problem zu lösen.
                   ;
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Auflösung des Shift-Reduce-Konflikts mit Hilfe von Operator-Präzedenzen.}
+\caption{Aufl\"osung des Shift-Reduce-Konflikts mit Hilfe von Operator-Pr\"azedenzen.}
 \label{fig:dangling-else-precedence.y}
 \end{figure}
       

--- a/Lecture-Notes/lex.tex
+++ b/Lecture-Notes/lex.tex
@@ -1,9 +1,9 @@
 \chapter{Die Werkzeuge \textsl{Flex}\/ und \textsl{JFlex}}
 Ein \emph{Scanner} ist ein Werkzeug, das einen gegebenen Text in Gruppen einzelner
-\emph{Token} aufspaltet.  Beispielsweise spaltet der Scanner, der für einen
+\emph{Token} aufspaltet.  Beispielsweise spaltet der Scanner, der f\"ur einen
 \texttt{C}-Compiler eingesetzt wird, den Programmtext in die folgenden Token auf:
 \begin{enumerate}
-\item Schlüsselwörter wie ``\texttt{if}'', ``\texttt{while}'', etc.
+\item Schl\"usselw\"orter wie ``\texttt{if}'', ``\texttt{while}'', etc.
 \item Operator-Symbole wie ``\texttt{+}'', ``\texttt{+=}'', ``\texttt{<}'',
       ``\texttt{<=}'', etc.
 \item Konstanten, wobei es in der Sprache \texttt{C} drei Arten von Konstanten gibt:
@@ -12,33 +12,33 @@ Ein \emph{Scanner} ist ein Werkzeug, das einen gegebenen Text in Gruppen einzeln
       \item Strings, beispielsweise \texttt{\symbol{34}hallo\symbol{34}},
       \item einzelne Buchstaben, beispielsweise \texttt{\symbol{39}a\symbol{39}}.
       \end{enumerate}
-\item Namen, die als Bezeichner für Variablen, Funktionen, oder Typ-Definitionen
+\item Namen, die als Bezeichner f\"ur Variablen, Funktionen, oder Typ-Definitionen
       fungieren.
 \item Kommentare
-\item Sogenannte \emph{White-Space-Zeichen}.  Hierzu gehören Leerzeichen, horizontale und
-      vertikale Tabulatoren, Zeilenumbrüche und Seitenvorschübe.
+\item Sogenannte \emph{White-Space-Zeichen}.  Hierzu geh\"oren Leerzeichen, horizontale und
+      vertikale Tabulatoren, Zeilenumbr\"uche und Seitenvorsch\"ube.
 \end{enumerate}
 \textsl{Flex}\/ ist ein sogenannter Scanner-Generator, also ein Werkzeug, das aus einer
 Spezifikation verschiedener Token automatisch einen Scanner generiert.  Die einzelnen
-Token werden dabei durch reguläre Ausdrücke definiert.  
+Token werden dabei durch regul\"are Ausdr\"ucke definiert.  
 
-In nächsten Abschnitt besprechen wir die Struktur einer \textsl{Flex}-Eingabe-Datei und
-zeigen wie \textsl{Flex}\/ aufgerufen wird.  Anschließend zeigen wir, wie reguläre Ausdrücke
-in der Eingabe-Sprache von \textsl{Flex}\/ spezifiziert werden können.  Das Kapitel wird
+In n\"achsten Abschnitt besprechen wir die Struktur einer \textsl{Flex}-Eingabe-Datei und
+zeigen wie \textsl{Flex}\/ aufgerufen wird.  Anschlie{\ss}end zeigen wir, wie regul\"are Ausdr\"ucke
+in der Eingabe-Sprache von \textsl{Flex}\/ spezifiziert werden k\"onnen.  Das Kapitel wird
 durch ein Beispiel abgerundet, bei dem wir mit Hilfe von \textsl{Flex}\/ ein Programm
-erzeugen, mit dessen Hilfe die Ergebnisse einer Klausur ausgewertet werden können.
+erzeugen, mit dessen Hilfe die Ergebnisse einer Klausur ausgewertet werden k\"onnen.
 
-Die von \textsl{Flex}\/ erzeugten Scanner sind \texttt{C}-Programme.  Für das
-\textsl{Java}-Umfeld gibt es ein Äquivalent unter dem Namen \textsl{JFlex}.
+Die von \textsl{Flex}\/ erzeugten Scanner sind \texttt{C}-Programme.  F\"ur das
+\textsl{Java}-Umfeld gibt es ein \"Aquivalent unter dem Namen \textsl{JFlex}.
 
 \section{Das Werkzeug \textsl{Flex}}
-Wir beginnen mit einem einfachen Beispiel und diskutieren anschließend einige Fallstricke
-von \textsl{Flex}, über die Anfänger häufig stolpern.
+Wir beginnen mit einem einfachen Beispiel und diskutieren anschlie{\ss}end einige Fallstricke
+von \textsl{Flex}, \"uber die Anf\"anger h\"aufig stolpern.
 \subsection{Ein einfaches Beispiel}
-Eine Eingabe-Datei für \textsl{Flex}\/ besteht aus vier Abschnitten, die aufeinander folgen.
+Eine Eingabe-Datei f\"ur \textsl{Flex}\/ besteht aus vier Abschnitten, die aufeinander folgen.
 \begin{enumerate}
-\item Der \emph{Deklarations-Abschnitt} enthält die Deklarationen von Variablen und Hilfsfunktionen.
-      Zusätzlich kann dieser Teil auch Kommentare und \texttt{include}-Anweisungen
+\item Der \emph{Deklarations-Abschnitt} enth\"alt die Deklarationen von Variablen und Hilfsfunktionen.
+      Zus\"atzlich kann dieser Teil auch Kommentare und \texttt{include}-Anweisungen
       enthalten.  Der Deklarations-Abschnitt wird durch den String ``\texttt{\symbol{37}\{}''
       eingeleitet und durch den String ``\texttt{\symbol{37}\}}'' ausgeleitet.
       In dem in Abbildung \ref{fig:change.l} gezeigten Beispiel erstreckt sich der
@@ -46,13 +46,13 @@ Eine Eingabe-Datei für \textsl{Flex}\/ besteht aus vier Abschnitten, die aufeina
 
       Die von \textsl{Flex}\/ erzeugten Scanner sind \texttt{C}-Programme.  Bei der Sprache
       \texttt{C} ist es erforderlich, dass Funktionen und Variablen vor ihrer Benutzung
-      deklariert werden.  Daher werden Variablen, die später im Regel-Abschnitt benutzt
+      deklariert werden.  Daher werden Variablen, die sp\"ater im Regel-Abschnitt benutzt
       werden sollen, im Deklarations-Abschnitt deklariert.
 
       Der Deklarations-Abschnitt ist optional: Falls im Regel-Abschnitt keine Variablen
       verwendet werden, dann kann der Deklarations-Abschnitt auch entfallen.
-\item Der \emph{Definitions-Abschnitt} enthält die Definitionen von sogenannten \emph{regulären Definitionen}.
-      Hierbei handelt es sich um Abkürzungen für komplexere reguläre Ausdrücke.
+\item Der \emph{Definitions-Abschnitt} enth\"alt die Definitionen von sogenannten \emph{regul\"aren Definitionen}.
+      Hierbei handelt es sich um Abk\"urzungen f\"ur komplexere regul\"are Ausdr\"ucke.
       Der Definitions-Abschnitt beginnt hinter dem Deklarationsteil und erstreckt sich bis zum
       ersten Auftreten des Strings ``\texttt{\symbol{37}\symbol{37}}''.
       Der Definitions-Abschnitt kann leer sein.  In dem in Abbildung \ref{fig:change.l}
@@ -63,17 +63,17 @@ Eine Eingabe-Datei für \textsl{Flex}\/ besteht aus vier Abschnitten, die aufeina
       \\[0.2cm]
       \hspace*{1.3cm} \textsl{regexp} \texttt{\{}\textsl{cmds}\texttt{\}}
       \\[0.2cm]
-      Hier steht \textsl{regexp}\/ für einen regulären Ausdruck. Dieser muss am Zeilenanfang
+      Hier steht \textsl{regexp}\/ f\"ur einen regul\"aren Ausdruck. Dieser muss am Zeilenanfang
       stehen.  Jedesmal, wenn der generierte Scanner in seiner Eingabe einen String
-      erkennt, der diesem regulären Ausdruck entspricht, werden die in \textsl{cmds}\/
-      angegebenen \emph{Aktionen} ausgeführt.  Genauer handelt es sich bei \texttt{cmds} um eine
+      erkennt, der diesem regul\"aren Ausdruck entspricht, werden die in \textsl{cmds}\/
+      angegebenen \emph{Aktionen} ausgef\"uhrt.  Genauer handelt es sich bei \texttt{cmds} um eine
       oder mehrere Anweisungen der Sprache \texttt{C}.
 
       Der Regel-Abschnitt wird durch ein Auftreten des Strings
       ``\texttt{\symbol{37}\symbol{37}}''
       beendet.  In dem in Abbildung \ref{fig:change.l}
       gezeigten Beispiel erstreckt sich der Regel-Abschnitt von Zeile 9 bis Zeile 11.
-\item Der \emph{Programm-Abschnitt} enthält die Definition der Funktion $\texttt{main}()$,
+\item Der \emph{Programm-Abschnitt} enth\"alt die Definition der Funktion $\texttt{main}()$,
       sowie eventuell die Definition weiterer Hilfsfunktionen.
       In Abbildung \ref{fig:change.l} erstreckt sich der Programm-Abschnitt von Zeile 13
       bis Zeile 18.
@@ -115,31 +115,31 @@ Eine Eingabe-Datei für \textsl{Flex}\/ besteht aus vier Abschnitten, die aufeina
 
 Wir diskutieren jetzt das in Abbildung \ref{fig:change.l} gezeigte Beispiel im Detail.
 In diesem Beispiel wird ein Scanner spezifiziert, dessen Aufgabe es ist, alle Auftreten des
-Strings ``\texttt{Stephan}'' durch ``\texttt{Stefan}'' zu ersetzen.  Zusätzlich
-gibt der Scanner am Ende aus, wieviele Ersetzungen tatsächlich durchgeführt worden sind.
+Strings ``\texttt{Stephan}'' durch ``\texttt{Stefan}'' zu ersetzen.  Zus\"atzlich
+gibt der Scanner am Ende aus, wieviele Ersetzungen tats\"achlich durchgef\"uhrt worden sind.
 \begin{enumerate}
-\item Im Deklarations-Abschnitt binden wir die Datei ``\texttt{stdio.h}'' ein, damit wir später
-      die Funktion $\texttt{printf}()$ benutzen können.
-      Zusätzlich deklarieren wir die Variable \texttt{numberChanges} und initialisieren
-      sie mit dem Wert 0.  In dieser Variable zählen wir die Anzahl der durchgeführten
+\item Im Deklarations-Abschnitt binden wir die Datei ``\texttt{stdio.h}'' ein, damit wir sp\"ater
+      die Funktion $\texttt{printf}()$ benutzen k\"onnen.
+      Zus\"atzlich deklarieren wir die Variable \texttt{numberChanges} und initialisieren
+      sie mit dem Wert 0.  In dieser Variable z\"ahlen wir die Anzahl der durchgef\"uhrten
       Ersetzungen.  
-\item Da die in diesem Beispiel verwendeten regulären Ausdrücke trivial sind,
-      enthält das Beispiel keinen Definitions-Abschnitt.
-\item Das Beispiel enthält in Zeile 10 und 11 jeweils eine Regel:
+\item Da die in diesem Beispiel verwendeten regul\"aren Ausdr\"ucke trivial sind,
+      enth\"alt das Beispiel keinen Definitions-Abschnitt.
+\item Das Beispiel enth\"alt in Zeile 10 und 11 jeweils eine Regel:
       \begin{enumerate}
-      \item In Zeile 10 ist der reguläre Ausdruck durch den String ``\texttt{Stephan}''
-            gegeben.  Da dieser Ausdruck keinerlei Operatoren enthält, besteht die dadurch
+      \item In Zeile 10 ist der regul\"are Ausdruck durch den String ``\texttt{Stephan}''
+            gegeben.  Da dieser Ausdruck keinerlei Operatoren enth\"alt, besteht die dadurch
             spezifizierte Sprache genau aus dem String ``\texttt{Stephan}''.  Die
-            ausgeführte Aktion besteht aus zwei Kommandos:
+            ausgef\"uhrte Aktion besteht aus zwei Kommandos:
             \begin{enumerate}
-            \item Zunächst geben wir den String ``\texttt{Stefan}'' aus, denn wir wollen
+            \item Zun\"achst geben wir den String ``\texttt{Stefan}'' aus, denn wir wollen
                   den String ``\texttt{Stephan}'' durch den String ``\texttt{Stefan}'' 
                   ersetzen.
-            \item Anschließend wird der Zähler \texttt{numberChanges} inkrementiert,
-                  denn wir haben ja nun eine Ersetzung durchgeführt.
+            \item Anschlie{\ss}end wird der Z\"ahler \texttt{numberChanges} inkrementiert,
+                  denn wir haben ja nun eine Ersetzung durchgef\"uhrt.
             \end{enumerate}
-      \item In Zeile 11 besteht der reguläre Ausdruck nur aus dem Punkt ``\texttt{.}''.
-            Dieser reguläre Ausdruck spezifiziert ein beliebiges Zeichen, das von dem
+      \item In Zeile 11 besteht der regul\"are Ausdruck nur aus dem Punkt ``\texttt{.}''.
+            Dieser regul\"are Ausdruck spezifiziert ein beliebiges Zeichen, das von dem
             Zeilenumbruch ``\texttt{\symbol{92}n}'' verschieden ist.  Dieses Zeichen
             geben wir mit dem Befehl 
             \\[0.2cm]
@@ -147,60 +147,60 @@ gibt der Scanner am Ende aus, wieviele Ersetzungen tatsächlich durchgeführt word
             \texttt{printf(\symbol{34}\symbol{37}s\symbol{34}, yytext);}
             \\[0.2cm]
             aus.  Hier benutzen wir die in \textsl{Flex}\/ vordefinierte Variable
-            ``\texttt{yytext}'', die genau den Text enthält, der mit dem regulären Ausdruck
+            ``\texttt{yytext}'', die genau den Text enth\"alt, der mit dem regul\"aren Ausdruck
             erkannt worden ist.  In diesem Fall besteht dieser Text immer aus genau einem
             Zeichen.
 
             An dieser Stelle fragen Sie sich vielleicht, was passiert, wenn der Scanner
-            auf einen Zeilenumbruch stößt.  Ein Zeilenumbruch würde weder von der ersten
+            auf einen Zeilenumbruch st\"o{\ss}t.  Ein Zeilenumbruch w\"urde weder von der ersten
             noch von der zweiten Regel erfasst.  Die Konvention bei \textsl{Flex}\/ ist,
-            das alle Zeichen, die von keiner Regel erfasst werden, unverändert ausgegeben
-            werden.   Aus diesem Grunde hätten wir die zweite Regel ebenfalls weglassen können.
+            das alle Zeichen, die von keiner Regel erfasst werden, unver\"andert ausgegeben
+            werden.   Aus diesem Grunde h\"atten wir die zweite Regel ebenfalls weglassen k\"onnen.
       \end{enumerate}
-      Die regulären Ausdrücke der beiden Regeln überlappen sich, denn beispielsweise kann
-      der erste Buchstaben von ``\texttt{Stephan}'' auch durch den regulären Ausdruck
-      ``\texttt{.}'' erkannt werden.  Damit könnten im Prinzip die Aktionen
-      beider Regeln ausgeführt werden.  Falls zwei verschiedene Regeln angewendet werden können,
+      Die regul\"aren Ausdr\"ucke der beiden Regeln \"uberlappen sich, denn beispielsweise kann
+      der erste Buchstaben von ``\texttt{Stephan}'' auch durch den regul\"aren Ausdruck
+      ``\texttt{.}'' erkannt werden.  Damit k\"onnten im Prinzip die Aktionen
+      beider Regeln ausgef\"uhrt werden.  Falls zwei verschiedene Regeln angewendet werden k\"onnen,
       geht \textsl{Flex}\/ nach folgender  Konvention vor:
       \begin{enumerate}
-      \item Zunächst gewinnt die Regel, die auf den längeren Text passt.
+      \item Zun\"achst gewinnt die Regel, die auf den l\"angeren Text passt.
             In dem Beispiel wird also bei jedem Auftreten von ``\texttt{Stephan}''
-            die erste Regel angewendet, denn diese passt auf den gesamten Text, während
+            die erste Regel angewendet, denn diese passt auf den gesamten Text, w\"ahrend
             die zweite Regel nur auf einen einzigen Buchstaben passt.
-      \item Ist der Text für zwei Regeln gleich lang, so entscheidet die Reihenfolge,
-            in der die Regeln in der \textsl{Flex}-Spezifikation auftreten: Die Regel, die früher
+      \item Ist der Text f\"ur zwei Regeln gleich lang, so entscheidet die Reihenfolge,
+            in der die Regeln in der \textsl{Flex}-Spezifikation auftreten: Die Regel, die fr\"uher
             auftritt, gewinnt.
       \end{enumerate}
 \item Im Programm-Abschnitt definieren wir die Funktion $\texttt{main}()$.  Diese besteht
       im wesentlichen aus dem Aufruf der Funktion $\texttt{yylex}()$, die von
       \textsl{Flex}\/ automatisch erzeugt wird.  Diese Funktion startet den erzeugten Lexer.
-      Dieser Lexer liest seine Eingabe Zeichen für Zeichen ein und überprüft nach jedem
+      Dieser Lexer liest seine Eingabe Zeichen f\"ur Zeichen ein und \"uberpr\"uft nach jedem
       gelesenen Zeichen, ob eine der im Regel-Abschnitt angegebenen Regeln anwendbar ist
-      und führt gegebenenfalls die Aktionen dieser Regel aus.
+      und f\"uhrt gegebenenfalls die Aktionen dieser Regel aus.
       Nach dem Aufruf von $\texttt{yylex}()$  geben wir noch die 
-      Anzahl der durchgeführten Ersetzungen aus.
+      Anzahl der durchgef\"uhrten Ersetzungen aus.
 \end{enumerate}
 
 
-\subsection{Übersetzung des Beispiels}
+\subsection{\"Ubersetzung des Beispiels}
 Wir speichern die in Abbildung \ref{fig:change.l} gezeigte \textsl{Flex}-Spezifikation in einer
-Datei mit dem Namen ``\texttt{change.l}'' und rufen anschließend \textsl{Flex}\/ mit dem Befehl
+Datei mit dem Namen ``\texttt{change.l}'' und rufen anschlie{\ss}end \textsl{Flex}\/ mit dem Befehl
 \\[0.2cm]
 \hspace*{1.3cm} \texttt{flex change.l}
 \\[0.2cm]
 auf.  Dieser Aufruf erzeugt das \texttt{C}-Programm ``\texttt{lex.yy.c}'', das den generierten
-Scanner enthält.  Dieses Programm übersetzen wir mit dem Befehl
+Scanner enth\"alt.  Dieses Programm \"ubersetzen wir mit dem Befehl
 \\[0.2cm]
 \hspace*{1.3cm} \texttt{gcc -c lex.yy.c -o lex.yy.o}
 \\[0.2cm]
-in die Objekt-Datei ``\texttt{lex.yy.o}''.  Um daraus ein ausführbares Programm zu erzeugen, binden
+in die Objekt-Datei ``\texttt{lex.yy.o}''.  Um daraus ein ausf\"uhrbares Programm zu erzeugen, binden
 wir die \textsl{Flex}-Bibliothek ``\texttt{fl}'' (\underline{f}lex \underline{l}ibrary) mit dem
 Befehl
 \\[0.2cm]
 \hspace*{1.3cm} \texttt{gcc -o change lex.yy.o -lfl}
 \\[0.2cm]
-ein.  Dabei entsteht die ausführbare Datei ``\texttt{change}''.  Haben wir eine weitere Datei
-``\texttt{test.txt}'', so können wir den erzeugten Scanner durch den Aufruf
+ein.  Dabei entsteht die ausf\"uhrbare Datei ``\texttt{change}''.  Haben wir eine weitere Datei
+``\texttt{test.txt}'', so k\"onnen wir den erzeugten Scanner durch den Aufruf
 \\[0.2cm]
 \hspace*{1.3cm} \texttt{./change < test.txt}
 \\[0.2cm]
@@ -212,25 +212,25 @@ Bei der Erstellung von \textsl{Flex}-Spezifikationen ist auf die folgenden Punkt
 achten. 
 \begin{enumerate}
 \item Die Strings ``\texttt{\symbol{37}\symbol{37}}'', mit denen der Definitions-Abschnitt von dem 
-      Regel-Abschnitt und der Regel-Abschnitt von dem Programm-Abschnitt getrennt werden, müssen am
+      Regel-Abschnitt und der Regel-Abschnitt von dem Programm-Abschnitt getrennt werden, m\"ussen am
       Anfang einer ansonsten leeren Zeile stehen.
-\item Bei den Regeln muss der reguläre Ausdruck am Anfang der Zeile stehen.
-\item Die Kommandos, die auf eine Regel folgen, müssen in derselben Zeile beginnen wie der
-      zugehörige reguläre Ausdruck.  Es ist sinnvoll, diese Kommandos immer in
-      geschweifte Klammern einzuschließen.  Dann müssen wir lediglich darauf achten, dass
-      die öffnende Klammer ``\texttt{\{}'' in derselben Zeile steht wie der zugehörige 
-      reguläre Ausdruck.  
+\item Bei den Regeln muss der regul\"are Ausdruck am Anfang der Zeile stehen.
+\item Die Kommandos, die auf eine Regel folgen, m\"ussen in derselben Zeile beginnen wie der
+      zugeh\"orige regul\"are Ausdruck.  Es ist sinnvoll, diese Kommandos immer in
+      geschweifte Klammern einzuschlie{\ss}en.  Dann m\"ussen wir lediglich darauf achten, dass
+      die \"offnende Klammer ``\texttt{\{}'' in derselben Zeile steht wie der zugeh\"orige 
+      regul\"are Ausdruck.  
 \end{enumerate}
 
 
-\subsection{Reguläre Ausdrücke in \textsl{Flex}}
-Im letzten Kapitel haben wir reguläre Ausdrücke mit einer minimalen Syntax definiert.
-Dies ist nützlich, wenn wir später die Äquivalenz von den durch regulären Ausdrücken spezifizierten
-Sprachen mit den Sprachen, die von endlichen Automaten erkannt werden können,  beweisen wollen.
-Für die Praxis ist eine reichhaltigere Syntax wünschenswert.  Daher bietet die Eingabe-Sprache von
-\textsl{Flex}\/ eine Reihe von Abkürzungen an, mit der komplexe reguläre Ausdrücke kompakter
-beschrieben werden können.  Den regulären Ausdrücken von \texttt{Flex} liegt das
-\textsc{Ascii}-Alphabet zu Grunde, wobei zwischen den Zeichen, die als Operatoren dienen können,
+\subsection{Regul\"are Ausdr\"ucke in \textsl{Flex}}
+Im letzten Kapitel haben wir regul\"are Ausdr\"ucke mit einer minimalen Syntax definiert.
+Dies ist n\"utzlich, wenn wir sp\"ater die \"Aquivalenz von den durch regul\"aren Ausdr\"ucken spezifizierten
+Sprachen mit den Sprachen, die von endlichen Automaten erkannt werden k\"onnen,  beweisen wollen.
+F\"ur die Praxis ist eine reichhaltigere Syntax w\"unschenswert.  Daher bietet die Eingabe-Sprache von
+\textsl{Flex}\/ eine Reihe von Abk\"urzungen an, mit der komplexe regul\"are Ausdr\"ucke kompakter
+beschrieben werden k\"onnen.  Den regul\"aren Ausdr\"ucken von \texttt{Flex} liegt das
+\textsc{Ascii}-Alphabet zu Grunde, wobei zwischen den Zeichen, die als Operatoren dienen k\"onnen,
 und den restlichen Zeichen unterschieden wird.  Die Menge \textsl{OpSyms}\/ der Operator-Symbole 
 ist wie folgt definiert:
 \\[0.2cm]
@@ -256,18 +256,18 @@ $\{$ ``\texttt{.}'',
 ``\texttt{\symbol{36}}'', 
 ``\texttt{\symbol{34}}'' $\}$
 \\[0.2cm]
-Damit können wir nun die Menge $\textsl{Regexp}\/$ der von \textsl{Flex}\/ unterstützen regulären
-Ausdrücke induktiv definieren. 
+Damit k\"onnen wir nun die Menge $\textsl{Regexp}\/$ der von \textsl{Flex}\/ unterst\"utzen regul\"aren
+Ausdr\"ucke induktiv definieren. 
 \begin{enumerate}
 \item $c \in \textsl{Regexp}$ \quad falls $c \in \Sigma_{\textsc{\scriptsize Ascii}} \backslash \textsl{OpSyms}$
 
-      Alle Buchstaben $c$ aus dem \textsc{Ascii}-Alphabet, die keine Operator-Symbol sind, können
-      als reguläre Ausdrücke, verwendet werden.  Diese Ausdrücke spezifizieren genau diesen Buchstaben.
+      Alle Buchstaben $c$ aus dem \textsc{Ascii}-Alphabet, die keine Operator-Symbol sind, k\"onnen
+      als regul\"are Ausdr\"ucke, verwendet werden.  Diese Ausdr\"ucke spezifizieren genau diesen Buchstaben.
       
 \item $\texttt{\symbol{92}}x \in \textsl{Regexp}$ \quad 
       falls $x \in \{ \texttt{a}, \texttt{b}, \texttt{f}, \texttt{n}, \texttt{r}, \texttt{t}, \texttt{v} \}$ 
 
-      Die Syntax $\texttt{\symbol{92}}x$ ermöglicht es, Steuerzeichen 
+      Die Syntax $\texttt{\symbol{92}}x$ erm\"oglicht es, Steuerzeichen 
       zu spezifizieren.  Im Einzelnen gilt:
       \begin{enumerate}
       \item \texttt{\symbol{92}a} entspricht dem Steuerzeichen \texttt{Ctrl-G} (\emph{alert}).
@@ -287,14 +287,14 @@ Ausdrücke induktiv definieren.
       \textsc{Ascii}-Code an der durch die Oktalzahl $abc$ spezifizierten Stelle steht.
 \item $\texttt{\symbol{92}}o \in \textsl{Regexp}$ \quad falls $o \in \textsl{OpSyms}$ 
       
-      Die Operator-Symbole können durch Voranstellen eines Backslashs spezifiziert werden.
+      Die Operator-Symbole k\"onnen durch Voranstellen eines Backslashs spezifiziert werden.
 \item $r_1r_2 \in \textsl{Regexp}$ \quad falls $r_1,r_2 \in \textsl{Regexp}$
 
-      Die Konkatenation zweier regulärer Ausdrücke wird in \textsl{Flex}\/ ohne den Infix-Operator
+      Die Konkatenation zweier regul\"arer Ausdr\"ucke wird in \textsl{Flex}\/ ohne den Infix-Operator
       ``$\cdot$'' geschrieben.
 \item $r_1\texttt{|}r_2 \in \textsl{Regexp}$ \quad falls $r_1,r_2 \in \textsl{Regexp}$
 
-      Für die Addition zweier regulärer Ausdrücke wird in \textsl{Flex}\/ an Stelle des Infix-Operators
+      F\"ur die Addition zweier regul\"arer Ausdr\"ucke wird in \textsl{Flex}\/ an Stelle des Infix-Operators
       ``$+$'' der Operator ``\texttt{|}'' verwendet.
 \item $r\texttt{*} \in \textsl{Regexp}$ \quad falls $r \in \textsl{Regexp}$
 
@@ -302,65 +302,65 @@ Ausdrücke induktiv definieren.
 \item $r\texttt{+} \in \textsl{Regexp}$ \quad falls $r \in \textsl{Regexp}$
 
       Der Ausdruck ``$r\texttt{+}$'' ist eine Variante des Kleene-Abschlusses, bei der
-      gefordert wird, dass $r$ mindestens einmal auftritt.  Daher gilt die folgende Äquivalenz:
+      gefordert wird, dass $r$ mindestens einmal auftritt.  Daher gilt die folgende \"Aquivalenz:
       \\[0.2cm]
       \hspace*{1.3cm}
       $r\texttt{+} \doteq rr*$.
 \item $r\texttt{?} \in \textsl{Regexp}$ \quad falls $r \in \textsl{Regexp}$
 
       Der Ausdruck ``$r\texttt{?}$'' legt fest, dass $r$ einmal oder keinmal auftritt.
-      Es gilt die folgende Äquivalenz:
+      Es gilt die folgende \"Aquivalenz:
       \\[0.2cm]
       \hspace*{1.3cm}
       $r\texttt{?} \doteq r|\varepsilon$.
       \\[0.2cm]
       Hier ist allerdings zu beachten, dass der Ausdruck ``$\varepsilon$'' 
-      von \textsl{Flex} nicht unterstützt wird.
+      von \textsl{Flex} nicht unterst\"utzt wird.
 \item $r\texttt{\{}n\texttt{\}} \in \textsl{Regexp}$ \quad falls $n \in \mathbb{N}$
 
       Der Ausdruck ``$r\texttt{\{}n\texttt{\}}$'' legt fest, dass $r$ genau $n$ mal auftritt.
-      Der reguläre Ausdruck ``\texttt{a\{4\}}'' beschreibt also den String ``\texttt{aaaa}''.
+      Der regul\"are Ausdruck ``\texttt{a\{4\}}'' beschreibt also den String ``\texttt{aaaa}''.
 \item $\texttt{\symbol{94}}r$ \quad falls $r \in \textsl{Regexp}$
 
-      Der Ausdruck $\texttt{\symbol{94}}r$ legt fest, dass der reguläre Ausdruck $r$
+      Der Ausdruck $\texttt{\symbol{94}}r$ legt fest, dass der regul\"are Ausdruck $r$
       am Anfang einer Zeile stehen muss.  
 \item $r\texttt{\symbol{36}}$ \quad falls $r \in \textsl{Regexp}$
 
-      Der Ausdruck $r\texttt{\symbol{36}}$ legt fest, dass der reguläre Ausdruck $r$
+      Der Ausdruck $r\texttt{\symbol{36}}$ legt fest, dass der regul\"are Ausdruck $r$
       am Ende einer Zeile stehen muss.  
 \item $r_1\texttt{/}r_2$ \quad falls $r_1, r_2 \in \textsl{Regexp}$
   
       Der Ausdruck $r_1\texttt{/}r_2$ legt fest, dass auf den durch $r_1$ spezifizierten Text
-      ein Text folgen muss, der der Spezifikation $r_2$ genügt.  Im Unterschied zur einfachen
+      ein Text folgen muss, der der Spezifikation $r_2$ gen\"ugt.  Im Unterschied zur einfachen
       Konkatenation von $r_1$ und $r_2$ wird durch den $r_1\texttt{/}r_2$ aber derselbe Text
       spezifiziert, der durch $r_1$ spezifiziert wird.  Der Operator ``\texttt{/}'' liefert
-      also nur eine zusätzliche Bedingung, die für eine erfolgreiche Erkennung des regulären
-      Ausdrucks erfüllt sein muss.  Die Variable ``\texttt{yytext}'', in der der erkannte Text
-      aufgesammelt wird, bekommt nur den Text zugewiesen, der dem regulären Ausdruck $r_1$
-      entspricht.  Der Text, der dem regulären Ausdruck $r_2$ entspricht, wird dann von der
-      nächsten Regel gematcht.  In der angelsächsischen Literatur wird $r_2$ als
+      also nur eine zus\"atzliche Bedingung, die f\"ur eine erfolgreiche Erkennung des regul\"aren
+      Ausdrucks erf\"ullt sein muss.  Die Variable ``\texttt{yytext}'', in der der erkannte Text
+      aufgesammelt wird, bekommt nur den Text zugewiesen, der dem regul\"aren Ausdruck $r_1$
+      entspricht.  Der Text, der dem regul\"aren Ausdruck $r_2$ entspricht, wird dann von der
+      n\"achsten Regel gematcht.  In der angels\"achsischen Literatur wird $r_2$ als
       \emph{trailing context} bezeichnet.
 \item $(r) \in \textsl{Regexp}$ \quad falls $r \in \textsl{Regexp}$
 
-      Genau wie im letzten Kapitel auch können reguläre Ausdrücke geklammert werden.
-      Für die Präzedenzen der Operatoren gilt:
+      Genau wie im letzten Kapitel auch k\"onnen regul\"are Ausdr\"ucke geklammert werden.
+      F\"ur die Pr\"azedenzen der Operatoren gilt:
       Die Postfix-Operatoren ``\texttt{*}'', ``\texttt{?}'', ``\texttt{+}'' und ``\texttt{\{}$n$\texttt{\}}''
-      binden am stärksten, der Operator ``\texttt{|}'' bindet am schwächsten.
+      binden am st\"arksten, der Operator ``\texttt{|}'' bindet am schw\"achsten.
 \end{enumerate}
-Die Spezifikation der regulären Ausdrücke ist noch nicht vollständig, denn es gibt in \textsl{Flex}
-noch die Möglichkeit, sogenannte \emph{Bereiche} zu spezifizieren.  Ein \emph{Bereich}
+Die Spezifikation der regul\"aren Ausdr\"ucke ist noch nicht vollst\"andig, denn es gibt in \textsl{Flex}
+noch die M\"oglichkeit, sogenannte \emph{Bereiche} zu spezifizieren.  Ein \emph{Bereich}
 spezifiziert eine Menge von Buchstaben in kompakter Weise.  Dazu werden die eckigen
-Klammern benutzt.  Beispielsweise lassen sich die Vokale durch den regulären Ausdruck
+Klammern benutzt.  Beispielsweise lassen sich die Vokale durch den regul\"aren Ausdruck
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{[aeiou]}
 \\[0.2cm]
-spezifizieren.  Dieser Ausdruck ist als Abkürzung zu verstehen, es gilt:
+spezifizieren.  Dieser Ausdruck ist als Abk\"urzung zu verstehen, es gilt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\texttt{[aeiou]} \doteq \texttt{a|e|i|o|u}$
 \\[0.2cm]
-Die Menge aller kleinen lateinischen Buchstaben lässt sich durch
+Die Menge aller kleinen lateinischen Buchstaben l\"asst sich durch
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{[a-z]}
@@ -377,15 +377,15 @@ kann durch
 \texttt{[a-zA-Z\_]}
 \\[0.2cm]
 beschrieben werden.  \textsl{Flex} gestattet auch, das Komplement einer solchen Menge zu bilden.
-Dazu ist es lediglich erforderlich, nach der öffnenden eckigen Klammer das Zeichen
+Dazu ist es lediglich erforderlich, nach der \"offnenden eckigen Klammer das Zeichen
 ``\texttt{\symbol{94}}'' zu verwenden.  Beispielsweise beschreibt der Ausdruck
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{[\symbol{94}0-9]}
 \\[0.2cm]
 alle \textsc{Ascii}-Zeichen, die keine Ziffern sind.  Innerhalb von Bereichen verlieren 
-die meisten Operator-Symbole ihre Sonderbedeutung und können ohne Backslash geschrieben
-werden.  Innerhalb eines Bereiches zählen nur die Symbole
+die meisten Operator-Symbole ihre Sonderbedeutung und k\"onnen ohne Backslash geschrieben
+werden.  Innerhalb eines Bereiches z\"ahlen nur die Symbole
 \\[0.2cm]
 \hspace*{1.3cm}
 ``\texttt{-}'', ``\texttt{\symbol{94}}'', ``\texttt{]}'' und ``\texttt{\symbol{92}}''
@@ -398,20 +398,20 @@ als Operator-Symbole.  Damit erkennt der Bereich
 also genau die Postfix-Operatoren ``\texttt{+}'', ``\texttt{?}'' und ``\texttt{*}''.
 
 \examples
-Um die Diskussion anschaulicher zu machen, präsentieren wir einige Beispiele regulärer Ausdrücke.
+Um die Diskussion anschaulicher zu machen, pr\"asentieren wir einige Beispiele regul\"arer Ausdr\"ucke.
 \begin{enumerate}
 \item \texttt{[a-zA-Z][a-zA-Z0-9\_]*}
 
-      Dieser reguläre Ausdruck spezifiziert die Worte, die aus lateinischen Buchstaben, Ziffern und
-      dem Unterstrich ``\texttt{\_}'' bestehen und die außerdem mit einem lateinischen 
+      Dieser regul\"are Ausdruck spezifiziert die Worte, die aus lateinischen Buchstaben, Ziffern und
+      dem Unterstrich ``\texttt{\_}'' bestehen und die au{\ss}erdem mit einem lateinischen 
       Buchstaben beginnen.
 \item \texttt{\symbol{92}/\symbol{92}/.*}
 
       Hier wird ein \texttt{C}-Kommentar beschrieben, der sich bis zum Zeilenende erstreckt.
 \item \texttt{0|[1-9][0-9]*}
 
-      Dieser Ausdruck beschreibt natürliche Zahlen.  Hier ist es wichtig darauf zu achten,
-      dass eine natürliche Zahl nur dann mit der Ziffer \texttt{0} beginnt, wenn es sich um die
+      Dieser Ausdruck beschreibt nat\"urliche Zahlen.  Hier ist es wichtig darauf zu achten,
+      dass eine nat\"urliche Zahl nur dann mit der Ziffer \texttt{0} beginnt, wenn es sich um die
       Zahl \texttt{0} handelt.
 \end{enumerate}
 
@@ -434,7 +434,7 @@ in Abbildung \ref{fig:ergebnis} beispielhaft gezeigte Format besitzt.
     Kurs:    TIT07AIX
     
     Aufgaben:            1. 2. 3. 4. 5. 6.
-    Max Müller:          9 12 10  6  6  0
+    Max M\"uller:          9 12 10  6  6  0
     Dietmar Dumpfbacke:  4  4  2  0  -  -
     Susi Sorglos:        9 12 12  9  9  6
 \end{Verbatim}
@@ -444,17 +444,17 @@ in Abbildung \ref{fig:ergebnis} beispielhaft gezeigte Format besitzt.
 \end{figure}
 
 \begin{enumerate}
-\item Die erste Zeile enthält nach dem Schlüsselwort \texttt{Klausur} den Titel der Klausur.
+\item Die erste Zeile enth\"alt nach dem Schl\"usselwort \texttt{Klausur} den Titel der Klausur.
 \item Die zweite Zeile gibt den Kurs an.
 \item Die dritte Zeile ist leer.
 \item Die vierte Zeile gibt die Nummern der einzelnen Aufgaben an.
 \item Danach folgt eine Tabelle.  Jede Zeile dieser Tabelle listet die Punkte auf,
       die ein Student erzielt hat.  Der Name des Studenten wird dabei am Zeilenanfang angegeben.
-      Auf den Namen folgt ein Doppelpunkt und daran schließen sich dann Zahlen an, die angeben,
+      Auf den Namen folgt ein Doppelpunkt und daran schlie{\ss}en sich dann Zahlen an, die angeben,
       wieviele Punkte bei den einzelnen Aufgaben erzielt wurden.  Wurde eine Aufgabe nicht
       bearbeitet, so steht in der entsprechenden Spalte ein Bindestrich ``\texttt{-}''.
 \end{enumerate}
-Das \textsl{Flex}-Programm, das wir entwickeln werden, berechnet zunächst die Summe
+Das \textsl{Flex}-Programm, das wir entwickeln werden, berechnet zun\"achst die Summe
 \texttt{sumPoints} aller Punkte, die ein Student erzielt hat.  Aus dieser Summe wird dann nach der
 Formel 
 \\[0.2cm]
@@ -462,8 +462,8 @@ Formel
 $\texttt{note} = 7 - 6 \cdot \bruch{\;\texttt{sumPoints}\;}{\texttt{maxPoints}}$
 \\[0.2cm]
 die Note errechnet, wobei die Variable \texttt{maxPoints} die  Punktzahl
-angibt, die für die Note 1,0 benötigt wird.  Diese Zahl ist ein Argument, das dem Programm
-beim Start übergeben wird. 
+angibt, die f\"ur die Note 1,0 ben\"otigt wird.  Diese Zahl ist ein Argument, das dem Programm
+beim Start \"ubergeben wird. 
 
 \begin{figure}[!h]
 \centering
@@ -485,7 +485,7 @@ beim Start übergeben wird.
     float note();
     %}    
     ZAHL   0|[1-9][0-9]*
-    NAME   [A-Za-zöäüÖÄÜß]+[ ][A-Za-zöäüÖÄÜß]+
+    NAME   [A-Za-z\"o\"a\"u\"O\"A\"U{\ss}]+[ ][A-Za-z\"o\"a\"u\"O\"A\"U{\ss}]+
     %% 
     [A-Za-z]+:.*\n { ++lineNumber;               }
     {NAME}/:       { printf("%s", yytext); 
@@ -518,40 +518,40 @@ beim Start übergeben wird.
 \end{figure}
 
 Abbildung \ref{fig:noten.l} zeigt ein \textsl{Flex}-Programm, das die Aufgabe der Notenberechnung
-löst.  Wir diskutieren dieses Programm jetzt Zeile für Zeile.
+l\"ost.  Wir diskutieren dieses Programm jetzt Zeile f\"ur Zeile.
 \begin{enumerate}
 \item In dem Deklarations-Abschnitt, der sich von Zeile 1 bis Zeile 9 erstreckt, binden wir
-      zunächst die Header-Dateien ``\texttt{stdlib.h}'' und ``\texttt{stdio.h}'' ein.  
-      Anschließend deklarieren wir Variablen und Funktionen:
+      zun\"achst die Header-Dateien ``\texttt{stdlib.h}'' und ``\texttt{stdio.h}'' ein.  
+      Anschlie{\ss}end deklarieren wir Variablen und Funktionen:
       \begin{enumerate}
       \item Die Variable \texttt{sumPoints} speichert die Summe aller Punkte, die ein Student 
             in der Klausur erreicht hat und \texttt{maxPoints} speichert die Anzahl der 
             Punkte, bei der die Note 1,0 erreicht wird.
       \item In der Variablen \texttt{lineNumber} speichern wir die Zeilennummer.
-            Dies ist nützlich um später aussagekräftige Fehlermeldungen für den Fall geben
-            zu können, wenn in der Eingabedatei etwas unerwartetes gefunden wird.
+            Dies ist n\"utzlich um sp\"ater aussagekr\"aftige Fehlermeldungen f\"ur den Fall geben
+            zu k\"onnen, wenn in der Eingabedatei etwas unerwartetes gefunden wird.
       \item Die in Zeile 7 deklarierte Funktion $\texttt{errorMsg}()$ kann verwendet werden
             um Fehlermeldungen auszugeben.
             Diese Funktion wird im Programm-Abschnitt in den Zeilen 29 -- 31 definiert.  
       \item Die in Zeile 8 deklarierte Funktion $\texttt{note}()$ dient der Berechnung von Noten.
             Diese Funktion wird in den Zeilen 26 -- 28 definiert.
       \end{enumerate}
-\item In dem Definitions-Abschnitt werden zwei Abkürzungen definiert:
+\item In dem Definitions-Abschnitt werden zwei Abk\"urzungen definiert:
       \begin{enumerate}
-      \item Zeile 10 enthält die Definition von \texttt{ZAHL}.  Mit dieser Definition können
-            wir später anstelle des regulären Ausdrucks
+      \item Zeile 10 enth\"alt die Definition von \texttt{ZAHL}.  Mit dieser Definition k\"onnen
+            wir sp\"ater anstelle des regul\"aren Ausdrucks
             \\[0.2cm]
             \hspace*{1.3cm}
             \texttt{0|[1-9][0-9]*}
             \\[0.2cm]
-            kürzer ``\texttt{\{ZAHL\}}'' schreiben.  Beachten Sie, dass der Name einer Abkürzung
-            bei der Verwendung der Abkürzung in geschweiften Klammern eingefasst werden muss.
-      \item Zeile 11 enthält die Definition von \texttt{NAME}.  In dem regulären Ausdruck
+            k\"urzer ``\texttt{\{ZAHL\}}'' schreiben.  Beachten Sie, dass der Name einer Abk\"urzung
+            bei der Verwendung der Abk\"urzung in geschweiften Klammern eingefasst werden muss.
+      \item Zeile 11 enth\"alt die Definition von \texttt{NAME}.  In dem regul\"aren Ausdruck
             \\[0.2cm]
             \hspace*{1.3cm}
-            \texttt{[A-Za-zöäüÖÄÜß]+[ ][A-Za-zöäüÖÄÜß]+}
+            \texttt{[A-Za-z\"o\"a\"u\"O\"A\"U{\ss}]+[ ][A-Za-z\"o\"a\"u\"O\"A\"U{\ss}]+}
             \\[0.2cm]
-            wird festgelegt, dass ein Name großen und kleinen lateinischen
+            wird festgelegt, dass ein Name gro{\ss}en und kleinen lateinischen
             Buchstaben sowie Umlauten besteht und das Vor- und Nachname durch ein
             Leerzeichen getrennt werden.
       \end{enumerate}
@@ -561,83 +561,83 @@ löst.  Wir diskutieren dieses Programm jetzt Zeile für Zeile.
             der zu verarbeitenden Datei zu lesen.  Diese Zeilen bestehen jeweils aus einem Wort,
             auf das ein Dopplepunkt folgt.  Dahinter steht beliebiger Text, der mit einem
             Zeilenumbruch endet.  Da wir die Kopfzeilen nicht weiter verarbeiten wollen,
-            inkrementieren wir lediglich den Zähler \texttt{lineNumber}, denn wir haben ja gerade
+            inkrementieren wir lediglich den Z\"ahler \texttt{lineNumber}, denn wir haben ja gerade
             einen Zeilenumbruch gelesen.
       \item Die Regel in Zeile 14 liest den Namen eines Studenten, dem ein Doppelpunkt
             folgen muss.  Da wir den Doppelpunkt mit dem Operator ``\texttt{/}''von dem Namen
             abtrennen, ist der Doppelpunkt nicht Bestandteil des von dieser Regel gelesenen Textes.
-            Dadurch können wir den Doppelpunkt in der nächsten Regel noch benutzen.
+            Dadurch k\"onnen wir den Doppelpunkt in der n\"achsten Regel noch benutzen.
 
             Wenn wir einen Namen gelesen haben, geben wir diesen mit Hilfe eines
-            \texttt{printf}-Befehls aus und setzen anschließend die Variable \texttt{sumPoints}
+            \texttt{printf}-Befehls aus und setzen anschlie{\ss}end die Variable \texttt{sumPoints}
             auf 0.  Dies ist erforderlich, weil diese Variable ja vorher noch die Punkte eines
-            anderen Studenten enthalten könnte.
-      \item Die nächste Regel in Zeile 16 liest die Leerzeichen und Tabulatoren ein, die auf 
+            anderen Studenten enthalten k\"onnte.
+      \item Die n\"achste Regel in Zeile 16 liest die Leerzeichen und Tabulatoren ein, die auf 
             den Doppelpunkt folgen und gibt diese aus.  Dadurch erreichen wir, dass die Ausgabe
             der Noten genauso formatiert wird wie die Eingabe-Datei.
       \item Die Regel in Zeile 17 dient dazu, die Punkte, die der Student bei einer Aufgabe 
-            erreicht hat, einzulesen.  Da die Zahl zunächst nur als String zur Verfügung steht,
-            müssen wir diesen String mit Hilfe der Bibliotheks-Funktion $\texttt{atoi()}$ in eine Zahl
-            umwandeln.  Anschließend wird diese Zahl dann zu der Summe der Punkte hinzuaddiert.
+            erreicht hat, einzulesen.  Da die Zahl zun\"achst nur als String zur Verf\"ugung steht,
+            m\"ussen wir diesen String mit Hilfe der Bibliotheks-Funktion $\texttt{atoi()}$ in eine Zahl
+            umwandeln.  Anschlie{\ss}end wird diese Zahl dann zu der Summe der Punkte hinzuaddiert.
 
-            Die Verwendung der Funktion $\texttt{atoi}()$ ist übrigens der Grund, weshalb wir
-            die Header-Datei ``\texttt{stdlib.h}'' einbinden müssen.
-      \item Für nicht bearbeitete Aufgaben enthält die Eingabe-Datei einen Bindestrich
+            Die Verwendung der Funktion $\texttt{atoi}()$ ist \"ubrigens der Grund, weshalb wir
+            die Header-Datei ``\texttt{stdlib.h}'' einbinden m\"ussen.
+      \item F\"ur nicht bearbeitete Aufgaben enth\"alt die Eingabe-Datei einen Bindestrich
             ``\texttt{-}''.  Diese Bindestriche werden durch die Regel in Zeile 18
             eingelesen und ignoriert.  Daher ist das Kommando dieser Regel (bis auf den Kommentar)
             leer.
-      \item In der gleichen Weise überlesen wir mit der Regel in Zeile 19
+      \item In der gleichen Weise \"uberlesen wir mit der Regel in Zeile 19
             Leerzeichen und Tabulatoren, die nicht auf einen Doppelpunkt folgen.
       \item Die Regel in Zeile 20 dient dazu Zeilen einzulesen, die nur aus Leerzeichen
-            und Tabulatoren bestehen.  Hier muss lediglich der Zähler ``\texttt{lineNumber}''
+            und Tabulatoren bestehen.  Hier muss lediglich der Z\"ahler ``\texttt{lineNumber}''
             inkrementiert werden.
       \item Wenn wir einen einzelnen Zeilenumbruch lesen, dann muss dieser von einer Zeile
             stammen, die die Punkte eines Studenten auflistet.  In diesem Fall berechnen wir mit
             der Regel in Zeile 21 die erzielte Note und geben sie mit einer Stelle hinter
-            dem Komma aus.  Zusätzlich wird wieder der Zähler ``\texttt{lineNumber}''
+            dem Komma aus.  Zus\"atzlich wird wieder der Z\"ahler ``\texttt{lineNumber}''
             inkrementiert. 
-      \item Die bis hierhin vorgestellten Regeln ermöglichen es, eine syntaktisch korrekte 
-            Eingabe-Datei zu verarbeiten.  Für den Fall, dass die Eingabe-Datei Syntaxfehler
-            enthält, ist es sinnvoll, eine Fehlermeldung auszugeben, denn sonst könnte es passieren,
+      \item Die bis hierhin vorgestellten Regeln erm\"oglichen es, eine syntaktisch korrekte 
+            Eingabe-Datei zu verarbeiten.  F\"ur den Fall, dass die Eingabe-Datei Syntaxfehler
+            enth\"alt, ist es sinnvoll, eine Fehlermeldung auszugeben, denn sonst k\"onnte es passieren,
             dass auf Grund eines einfachen Tippfehlers eine falsche Note berechnet wird.
-            Daher enthält Zeile 24 eine Default-Regel, die immer dann greift, wenn keine der
+            Daher enth\"alt Zeile 24 eine Default-Regel, die immer dann greift, wenn keine der
             anderen Regeln zum Zuge gekommen ist.  Diese Regel liest ein einzelnes Zeichen und
-            gibt eine Fehlermeldung aus.  Diese Fehlermeldung enthält das gelesene Zeichen sowie
+            gibt eine Fehlermeldung aus.  Diese Fehlermeldung enth\"alt das gelesene Zeichen sowie
             die Zeilennummer, in der dieses Zeichen gefunden wurde. 
       \end{enumerate}
 \item Der Programm-Abschnitt erstreckt sich von Zeile 26 bis zum Ende der Datei.
       Bemerkenswert ist hier lediglich die Implementierung der Funktion $\texttt{main}()$.
-      Um die Notenberechnung durchführen zu können ist es erforderlich, dass wir dem Programm
+      Um die Notenberechnung durchf\"uhren zu k\"onnen ist es erforderlich, dass wir dem Programm
       die maximale erreichbare Punktzahl mitteilen, denn diese Punktzahl geht nicht aus der
-      Tabelle hervor.  Wir übergeben diese Zahl der Funktion $\texttt{main}()$ als erstes Argument.
-      Dieses Argument liegt in \texttt{argv[1]} zunächst als String vor.  Wir konvertieren
+      Tabelle hervor.  Wir \"ubergeben diese Zahl der Funktion $\texttt{main}()$ als erstes Argument.
+      Dieses Argument liegt in \texttt{argv[1]} zun\"achst als String vor.  Wir konvertieren
       es mit Hilfe der Funktion $\texttt{atoi}()$ in eine Zahl, die wir in der globalen
       Variablen \texttt{maxPoints} abspeichern.
 \end{enumerate}
-Das obige Beispiel löst eine vergleichsweise einfache Aufgabe.  Natürlich könnte diese Aufgabe
-auch durch ein ganz normales \texttt{C}-Programm gelöst werden.  Dieses
-\texttt{C}-Programm wäre allerdings länger als das oben gezeigte \textsl{Flex}-Programm
-und es wäre in jedem Fall deutlich schwieriger zu verstehen, denn reguläre Ausdrücke sind eine
-sehr prägnante Möglichkeit um die Syntax einzelner Token zu beschreiben.
+Das obige Beispiel l\"ost eine vergleichsweise einfache Aufgabe.  Nat\"urlich k\"onnte diese Aufgabe
+auch durch ein ganz normales \texttt{C}-Programm gel\"ost werden.  Dieses
+\texttt{C}-Programm w\"are allerdings l\"anger als das oben gezeigte \textsl{Flex}-Programm
+und es w\"are in jedem Fall deutlich schwieriger zu verstehen, denn regul\"are Ausdr\"ucke sind eine
+sehr pr\"agnante M\"oglichkeit um die Syntax einzelner Token zu beschreiben.
 
-\subsection{Start-Zustände}
-Viele syntaktische Konstrukte lassen sich zwar im Prinzip mit regulären Ausdrücken beschreiben,
-aber die Ausdrücke, die benötigt werden, sind sehr unübersichtlich.  Ein gutes Beispiel
-hierfür ist der reguläre Ausdruck zur Spezifikation von mehrzeilige
+\subsection{Start-Zust\"ande}
+Viele syntaktische Konstrukte lassen sich zwar im Prinzip mit regul\"aren Ausdr\"ucken beschreiben,
+aber die Ausdr\"ucke, die ben\"otigt werden, sind sehr un\"ubersichtlich.  Ein gutes Beispiel
+hierf\"ur ist der regul\"are Ausdruck zur Spezifikation von mehrzeilige
 \texttt{C}-Kommentaren, also Kommentaren der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{/*} $\cdots$ \texttt{*/}
 \\[0.2cm]
-Der reguläre Ausdruck, der diese Art von Kommentaren spezifiziert, ist wie folgt:
+Der regul\"are Ausdruck, der diese Art von Kommentaren spezifiziert, ist wie folgt:
 %\/\*([^*]|(\*+[^*/]))*\*+\/ 
 \begin{equation}
   \label{eq:multiline-comment}
 \texttt{\symbol{92}/\symbol{92}*([\symbol{94}*]|\symbol{92}*+[\symbol{94}*/])*\symbol{92}*+\symbol{92}/}  
 \end{equation}
-Zunächst ist dieser Ausdruck schwer zu lesen.  Das liegt vor allem daran,
+Zun\"achst ist dieser Ausdruck schwer zu lesen.  Das liegt vor allem daran,
 dass die Operator-Sysmbole ``\texttt{/}'' und ``\texttt{*}'' durch einen Backslash
-geschützt werden müssen.  Aber auch die Logik, die hinter diesem Ausdruck steht, ist nicht
+gesch\"utzt werden m\"ussen.  Aber auch die Logik, die hinter diesem Ausdruck steht, ist nicht
 ganz einfach.  Wir analysieren die einzelnen Komponenten dieses Ausdrucks:
 \begin{enumerate}
 \item \texttt{\symbol{92}/\symbol{92}*} 
@@ -645,15 +645,15 @@ ganz einfach.  Wir analysieren die einzelnen Komponenten dieses Ausdrucks:
       Hierdurch wird der String ``\texttt{/*}'', der den Kommentar einleitet,  spezifiziert.
 \item \texttt{([\symbol{94}*]|\symbol{92}*+[\symbol{94}*/])*}
   
-      Dieser Teil spezifiziert alle Zeichen, die zwischen dem öffnenden String ``\texttt{/*}''
-      und einem schließenden String der Form \texttt{*$\cdots$*/} liegen.  Wie müssen
-      sicherstellen, dass dieser Teil die Zeichenreihe ``\texttt{*/}'' nicht enthält, denn
-      sonst würden wir in einer Zeile der Form
+      Dieser Teil spezifiziert alle Zeichen, die zwischen dem \"offnenden String ``\texttt{/*}''
+      und einem schlie{\ss}enden String der Form \texttt{*$\cdots$*/} liegen.  Wie m\"ussen
+      sicherstellen, dass dieser Teil die Zeichenreihe ``\texttt{*/}'' nicht enth\"alt, denn
+      sonst w\"urden wir in einer Zeile der Form
       \\[0.2cm]
       \hspace*{1.3cm} \texttt{/* first */ ++n; /* second */}
       \\[0.2cm]
-      den Befehl ``\texttt{++n;}'' für einen Teil des Kommentars halten.  Der erste Teil des
-      obigen regulären Ausdrucks ``\texttt{[\symbol{94}*]}'' steht für ein beliebiges
+      den Befehl ``\texttt{++n;}'' f\"ur einen Teil des Kommentars halten.  Der erste Teil des
+      obigen regul\"aren Ausdrucks ``\texttt{[\symbol{94}*]}'' steht f\"ur ein beliebiges
       von ``\texttt{*}'' verschiedenes Zeichen.  Denn solange wir kein ``\texttt{*}'' lesen,
       kann der Text auch kein ``\texttt{*/}'' enthalten.  Das Problem ist, dass das Innere
       eines Kommentars aber durchaus das Zeichen ``\texttt{*}'' enthalten kann, es darf
@@ -666,20 +666,20 @@ ganz einfach.  Wir analysieren die einzelnen Komponenten dieses Ausdrucks:
       spezifiziert jetzt also entweder ein Zeichen, das von ``\texttt{*}'' verschieden
       ist, oder aber eine Folge von ``\texttt{*}''-Zeichen, auf die dann noch ein von
       ``\texttt{/}'' verschiedenes Zeichen folgt.  Da solche Folgen beliebig oft vorkommen
-      können, wird der ganze Ausdruck in Klammern eingefasst und mit dem Quantor
+      k\"onnen, wird der ganze Ausdruck in Klammern eingefasst und mit dem Quantor
       ``\texttt{*}'' dekoriert.   
 \item \texttt{\symbol{92}*+\symbol{92}/}
 
-      Dieser reguläre Ausdruck spezifiziert das Ende des Kommentars.  Es kann aus einer 
+      Dieser regul\"are Ausdruck spezifiziert das Ende des Kommentars.  Es kann aus einer 
       beliebigen positiven Anzahl von ``\texttt{*}''-Zeichen bestehen, auf die dann noch
       ein ``\texttt{/}'' folgt.  Wenn wir hier nur den Ausdruck
-      ``\texttt{\symbol{92}*\symbol{92}/}'' verwenden würden, dann könnten wir Kommentare der
+      ``\texttt{\symbol{92}*\symbol{92}/}'' verwenden w\"urden, dann k\"onnten wir Kommentare der
       Form 
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{/*** blah ***/}
       \\[0.2cm]
-      nicht mehr erkennen, denn der unter 2. diskutierte reguläre Ausdruck akzeptiert
+      nicht mehr erkennen, denn der unter 2. diskutierte regul\"are Ausdruck akzeptiert
       nur Folgen von ``\texttt{*}'', auf die kein ``\texttt{*}'' folgt.
 \end{enumerate}
 
@@ -716,20 +716,20 @@ ganz einfach.  Wir analysieren die einzelnen Komponenten dieses Ausdrucks:
 Abbildung \ref{fig:decoment.l} zeigt ein \textsl{Flex}-Programm, das aus einem
 \texttt{C}-Programm sowohl einzeilige Kommentare der Form ``\texttt{//} $\cdots$''
 als auch mehrzeilige Kommentare der Form ``\texttt{/*} $\cdots$ \texttt{*/} entfernt.
-Das Programm an sich ist zwar recht kurz, aber der reguläre Ausdruck zur Erkennung
+Das Programm an sich ist zwar recht kurz, aber der regul\"are Ausdruck zur Erkennung
 mehrzeiliger Kommentare ist sehr kompliziert und damit nur schwer zu verstehen.
-Um in ähnlichen Fällen ein lesbareres Programm schreiben zu können, gibt es in
-\textsl{Flex}\/ sogenannte \emph{Start-Zustände} (engl.~\emph{start conditions}), mit deren
-Hilfe komplizierte reguläre Ausdrücke vermieden werden können.
-Wir diskutieren diese Zustände anhand eines Beispiels: Wir wollen eine
+Um in \"ahnlichen F\"allen ein lesbareres Programm schreiben zu k\"onnen, gibt es in
+\textsl{Flex}\/ sogenannte \emph{Start-Zust\"ande} (engl.~\emph{start conditions}), mit deren
+Hilfe komplizierte regul\"are Ausdr\"ucke vermieden werden k\"onnen.
+Wir diskutieren diese Zust\"ande anhand eines Beispiels: Wir wollen eine
 \textsc{Html}-Datei in eine Text-Datei konvertieren.  Die \textsl{Flex}-Spezifikation, die
-in Abbildung \ref{fig:html2txt} gezeigt wird, führt dazu die folgenden Aktionen durch:
+in Abbildung \ref{fig:html2txt} gezeigt wird, f\"uhrt dazu die folgenden Aktionen durch:
 \begin{enumerate}
-\item Zunächst wird der Kopf der \textsc{Html}-Datei, der in den Tags ``\texttt{<head>}''
+\item Zun\"achst wird der Kopf der \textsc{Html}-Datei, der in den Tags ``\texttt{<head>}''
       und ``\texttt{</head>}'' eingeschlossen ist, entfernt.
 \item Die Skripte, die in der \textsc{Html}-Datei enthalten sind, werden ebenfalls
       entfernt.
-\item Außerdem werden die \textsc{Html}-Tags entfernt.
+\item Au{\ss}erdem werden die \textsc{Html}-Tags entfernt.
 \end{enumerate}
 
 \begin{figure}[!h]
@@ -765,23 +765,23 @@ in Abbildung \ref{fig:html2txt} gezeigt wird, führt dazu die folgenden Aktionen 
 Wir diskutieren jetzt die \textsl{Flex}-Spezifikation aus Abbildung \ref{fig:html2txt} im
 Detail.
 \begin{enumerate}
-\item Im Definitions-Teil deklarieren wir in Zeile 1 die beiden \textsl{Zustände}\/
-      \texttt{header} und \texttt{script} als \emph{exklusive} Start-Zustände.
+\item Im Definitions-Teil deklarieren wir in Zeile 1 die beiden \textsl{Zust\"ande}\/
+      \texttt{header} und \texttt{script} als \emph{exklusive} Start-Zust\"ande.
       Die allgemeine Syntax einer solchen Deklaration ist wie folgt:
       \begin{enumerate}
       \item Am Zeilen-Anfang einer Zustands-Deklaration steht der String ``\texttt{\symbol{37}x}''
             oder ``\texttt{\symbol{37}s}''.  
-            Der String ``\texttt{\symbol{37}x}'' spezifiziert \emph{exklusive} Zustände,
-            der String ``\texttt{\symbol{37}s}'' spezifiziert \emph{inklusive} Zustände.
-            Den Unterschied zwischen diesen beiden Zustandsarten erklären wir später.
-      \item Darauf folgt eine Liste der Namen der deklarierten Zustände.  Die Namen werden
+            Der String ``\texttt{\symbol{37}x}'' spezifiziert \emph{exklusive} Zust\"ande,
+            der String ``\texttt{\symbol{37}s}'' spezifiziert \emph{inklusive} Zust\"ande.
+            Den Unterschied zwischen diesen beiden Zustandsarten erkl\"aren wir sp\"ater.
+      \item Darauf folgt eine Liste der Namen der deklarierten Zust\"ande.  Die Namen werden
             durch Leerzeichen getrennt.
       \end{enumerate}
 \item In Zeile 3 haben wir den String ``\texttt{<head>}'' in doppelte Hochkommata
       eingeschlossen.  Dadurch verlieren die Operator-Symbole ``\texttt{<}'' ihre
-      Bedeutung.  Dies ist eine allgemeine Möglichkeit, um Operator-Symbole in
-      \textsl{Flex}\/ spezifizieren zu können.  Wollen wir beispielsweise den String
-      ``\texttt{a*}''  wörtlich erkennen, so können wir an Stelle von ``\texttt{a\symbol{92}*}''
+      Bedeutung.  Dies ist eine allgemeine M\"oglichkeit, um Operator-Symbole in
+      \textsl{Flex}\/ spezifizieren zu k\"onnen.  Wollen wir beispielsweise den String
+      ``\texttt{a*}''  w\"ortlich erkennen, so k\"onnen wir an Stelle von ``\texttt{a\symbol{92}*}''
       auch klarer
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -790,57 +790,57 @@ Detail.
       schreiben.
       
       Wird der String ``\texttt{<head>}'' erkannt, so wird in Zeile 3 die Aktion 
-      ``\texttt{BEGIN(header)}'' ausgeführt.  Damit wechselt der Scanner aus dem
+      ``\texttt{BEGIN(header)}'' ausgef\"uhrt.  Damit wechselt der Scanner aus dem
       Default-Zustand ``\texttt{INITIAL}'', in dem der Scanner startet,
       in den oben deklarierten Zustand \texttt{header}.
-      Da dieser Zustand als \emph{exklusiver} Zustand deklariert worden ist, können jetzt
+      Da dieser Zustand als \emph{exklusiver} Zustand deklariert worden ist, k\"onnen jetzt
       nur noch solche Regeln angewendet werden, die mit dem Prefix ``\texttt{<header>}''
-      beginnen.  Wäre der Zustand als \emph{inklusiver} Zustand deklariert worden, so könnten auch solche 
+      beginnen.  W\"are der Zustand als \emph{inklusiver} Zustand deklariert worden, so k\"onnten auch solche 
       Regeln verwendet werden, die nicht mit einem Zustand markiert sind.  Solche Regeln
       sind implizit mit dem Zustand ``\texttt{<INITIAL>}'' markiert.
       
       Die Regeln, die mit dem Zustand ``\texttt{header}'' markiert sind, finden wir weiter
       unten in den Zeilen 8 und 9.
 \item In Zeile 4 wechseln wir entsprechend in den Zustand ``\texttt{script}'' wenn
-      wir ein öffnendes \texttt{Script}-Tag sehen.
+      wir ein \"offnendes \texttt{Script}-Tag sehen.
 \item In Zeile 5 werden alle restlichen Tags gelesen.  Da die Aktion hier leer ist,
       werden diese Tags entfernt.
 \item In Zeile 6 ersetzen wir die Zeichenreihe ``\texttt{\&nbsp;}'' durch ein Blank.
-      Wollten wir das Skript wirklich einsetzen, so hätten wir hier noch analoge
+      Wollten wir das Skript wirklich einsetzen, so h\"atten wir hier noch analoge
       Zeilen zur Verarbeitung von Umlauten und Sonderzeichen.
 \item Zeile 8 beginnt mit der Zustands-Spezifikation ``\texttt{header}''.  Daher ist
       diese Regel nur dann aktiv, wenn der Scanner in dem Zustand ``\texttt{head}'' ist.
-      Diese Regel sucht nach dem schließenden Tag ``\texttt{</head>}''.  Wird dieses Tag
-      gefunden, so wechselt der Scanner zurück in den Default-Zustand \texttt{INITIAL},
+      Diese Regel sucht nach dem schlie{\ss}enden Tag ``\texttt{</head>}''.  Wird dieses Tag
+      gefunden, so wechselt der Scanner zur\"uck in den Default-Zustand \texttt{INITIAL},
       in dem nur die Regeln verwendet werden, die nicht mit einem Zustand markiert sind.
-\item Zeile 9 enthält ebenfalls eine Regel, die nur im Zustand ``\texttt{header}''
-      ausgeführt wird.  Diese Regel liest ein beliebiges Zeichen, welches nicht weiter 
+\item Zeile 9 enth\"alt ebenfalls eine Regel, die nur im Zustand ``\texttt{header}''
+      ausgef\"uhrt wird.  Diese Regel liest ein beliebiges Zeichen, welches nicht weiter 
       verarbeitet wird und daher im Endeffekt verworfen wird.
-\item Die Zeilen 11 und 12 enthalten entsprechende Regeln für den Zustand
+\item Die Zeilen 11 und 12 enthalten entsprechende Regeln f\"ur den Zustand
       ``\texttt{script}''.
 \end{enumerate}
 Ist der Automat im Default-Zustand ``\texttt{INITIAL}'' und liest ein Zeichen, das nicht
-durch die obigen Regeln verarbeitet wird, so wird dieses Zeichen unverändert ausgegeben.
+durch die obigen Regeln verarbeitet wird, so wird dieses Zeichen unver\"andert ausgegeben.
 Dadurch erreichen wir, dass der in der HTML-Datei enthaltene Text ausgegeben wird.
 
 \exercise
 Implementieren Sie eine \textsl{Flex}-Spezifikation, die aus einem
-\texttt{C}-Programm alle Kommentare entfernt.  Das Programm soll mit Hilfe von Zuständen arbeiten.
+\texttt{C}-Programm alle Kommentare entfernt.  Das Programm soll mit Hilfe von Zust\"anden arbeiten.
 
 
 \subsection{Zusammenfassung}
-\textsl{Flex}\/ ist ein mächtiges Werkzeug um effiziente Scanner zu erzeugen,
-das in den Werkzeugkasten jedes Informatikers gehört.  Die obige Darstellung ist eher als
-Appetitanreger gedacht, denn für eine ausführliche Darstellung fehlt uns jetzt die Zeit.
-Wir werden das Thema \textsl{Flex}\/ allerdings später noch einmal aufgreifen und zwar dann, wenn wir den
+\textsl{Flex}\/ ist ein m\"achtiges Werkzeug um effiziente Scanner zu erzeugen,
+das in den Werkzeugkasten jedes Informatikers geh\"ort.  Die obige Darstellung ist eher als
+Appetitanreger gedacht, denn f\"ur eine ausf\"uhrliche Darstellung fehlt uns jetzt die Zeit.
+Wir werden das Thema \textsl{Flex}\/ allerdings sp\"ater noch einmal aufgreifen und zwar dann, wenn wir den
 Parser-Generator \textsl{Bison}\/ diskutieren.
 
-Falls Sie später einmal \textsl{Flex}\/ selber einsetzen wollen, dann finden Sie weitere Informationen
+Falls Sie sp\"ater einmal \textsl{Flex}\/ selber einsetzen wollen, dann finden Sie weitere Informationen
 in dem Buch von Levine, Mason und Brown \cite{levine92}, sowie in den Manual-Seiten und 
 im Unix-Info-System.
 
 \paragraph{Historisches}
-Das Werkzeug \textsl{Lex}\/, das der Vorläufer von \textsl{Flex}\/ ist, wurde 1975 vom Michael
+Das Werkzeug \textsl{Lex}\/, das der Vorl\"aufer von \textsl{Flex}\/ ist, wurde 1975 vom Michael
 E.~Lesk in den Bell Laboratories entwickelt \cite{lesk:1975}.
 \pagebreak
 

--- a/Lecture-Notes/liveness.tex
+++ b/Lecture-Notes/liveness.tex
@@ -1,15 +1,15 @@
 \chapter{Lebendigkeits-Analyse}
-Bei komplexeren Funktionen ist es in der Regel nicht möglich,  für jede in der Funktion
-auftretende Variable ein neues Register zu allokieren, denn dafür ist die Zahl der Register
+Bei komplexeren Funktionen ist es in der Regel nicht m\"oglich,  f\"ur jede in der Funktion
+auftretende Variable ein neues Register zu allokieren, denn daf\"ur ist die Zahl der Register
 insbesondere bei einem \textsc{Cisc}-Prozessor nicht ausreichend.  Dies ist in der Regel aber auch
-nicht notwendig, denn zwei verschiedene Variablen können sich dann ein Register teilen, wenn diese
+nicht notwendig, denn zwei verschiedene Variablen k\"onnen sich dann ein Register teilen, wenn diese
 Variablen nie gleichzeitig \emph{lebendig} sind.  Dabei nennen wir eine Variable an einer bestimmten
-Position lebendig, wenn auf den Wert dieser Variablen zu einem späteren Zeitpunkt noch zugegriffen
+Position lebendig, wenn auf den Wert dieser Variablen zu einem sp\"ateren Zeitpunkt noch zugegriffen
 werden kann.  Betrachten wir zur Veranschaulichung die in Abbildung
 \ref{fig:liveness-example-1.c} gezeigte \texttt{C}-Funktion.  In dieser Funktion werden
 die vie Variablen \texttt{a}, \texttt{b}, \texttt{c} und \texttt{n} verwendet.  Es sieht
-zunächst so aus, als ob vier Register notwendig wären, um alle Variablen in Registern
-speichern zu können.  Wir werden zeigen, dass drei Register bereits ausreichend sind.
+zun\"achst so aus, als ob vier Register notwendig w\"aren, um alle Variablen in Registern
+speichern zu k\"onnen.  Wir werden zeigen, dass drei Register bereits ausreichend sind.
 
 \begin{figure}[!ht]
 \centering
@@ -40,20 +40,20 @@ speichern zu können.  Wir werden zeigen, dass drei Register bereits ausreichend 
 \end{figure}
 
 Wenn wir analysieren wollen, welche Variablen gleichzeitig dasselbe Register belegen
-können,  müssen wir uns zunächst darüber klar werden, wann der Wert einer Variablen, der
-eventuell in einem Register liegt, noch benötigt wird.  Dazu definieren wir, dass eine
-Variable $v$ in einer Zeile $l$ im Programm \emph{lebendig} ist, wenn wir später noch
-auf den Wert dieser Variablen zugreifen müssen.  Wir bezeichnen die Menge aller Zeilen, in denen eine
-Variable $v$ lebendig ist, mit $\textsl{live}(v)$.  Diese Definition der Lebendigkeit ist zunächst noch etwas
-ungenau und wird auf den folgenden Seiten präzisiert.
+k\"onnen,  m\"ussen wir uns zun\"achst dar\"uber klar werden, wann der Wert einer Variablen, der
+eventuell in einem Register liegt, noch ben\"otigt wird.  Dazu definieren wir, dass eine
+Variable $v$ in einer Zeile $l$ im Programm \emph{lebendig} ist, wenn wir sp\"ater noch
+auf den Wert dieser Variablen zugreifen m\"ussen.  Wir bezeichnen die Menge aller Zeilen, in denen eine
+Variable $v$ lebendig ist, mit $\textsl{live}(v)$.  Diese Definition der Lebendigkeit ist zun\"achst noch etwas
+ungenau und wird auf den folgenden Seiten pr\"azisiert.
 
-Zur Beantwortung der Frage, wieviele Register  zur Übersetzung des \ref{fig:liveness-example-1.c}
-gezeigte Programm benötigt werden, transformieren wir dieses Programm in ein 
-\emph{Assembler-ähnliches} Programm, wobei wir unter einem \emph{Assembler-ähnlichen} Programm ein
-Programm verstehen wollen, dass keine komplexen Kontroll-Strukturen wie Schleifen enthält.
-Das Assembler-ähnliche Programm ist in Abbildung \ref{fig:liveness-example-1-asm.c} gezeigt.  Wir
+Zur Beantwortung der Frage, wieviele Register  zur \"Ubersetzung des \ref{fig:liveness-example-1.c}
+gezeigte Programm ben\"otigt werden, transformieren wir dieses Programm in ein 
+\emph{Assembler-\"ahnliches} Programm, wobei wir unter einem \emph{Assembler-\"ahnlichen} Programm ein
+Programm verstehen wollen, dass keine komplexen Kontroll-Strukturen wie Schleifen enth\"alt.
+Das Assembler-\"ahnliche Programm ist in Abbildung \ref{fig:liveness-example-1-asm.c} gezeigt.  Wir
 untersuchen nun, wann die einzelnen in diesem Programm benutzten Variablen lebendig sind.  Ein erster Versuch
-könnte wie folgt aussehen:
+k\"onnte wie folgt aussehen:
 
 \begin{figure}[!ht]
 \centering
@@ -89,44 +89,44 @@ könnte wie folgt aussehen:
       Da Zeile von Zeile 3 und 4 sowie auch von Zeile 8 und 9
       erreicht werden kann, ist \texttt{a} auch in diesen Zeile lebendig.  In Zeile
       7 ist \texttt{a} nicht lebendig, denn der Wert, den \texttt{a} zu diesem Zeitpunkt
-      hat, wird in Zeile 8 überschrieben.  In Zeile 10 ist \texttt{a} ebenfalls nicht
+      hat, wird in Zeile 8 \"uberschrieben.  In Zeile 10 ist \texttt{a} ebenfalls nicht
       lebendig.  Insgesamt haben wir
       \[ \textsl{live}(\mathtt{a}) = \{ 3, 4, 6, 8, 9 \} \]
       \textbf{Bemerkung}:  Zeilen, die keine echten Anweisungen sondern nur Deklarationen
       enthalten, werden bei der Berechnung der Lebendigkeit einer Variablen nicht
-      berücksichtigt.
+      ber\"ucksichtigt.
       In dem obigen Beispiel sind dies die Zeilen 2 und 5.
 \item \texttt{b} wird in Zeile 7 und 8 gelesen und ist daher dort lebendig.  Der Wert von
-      \texttt{b} wird in Zeile 6 berechnet.  Wir könnten daher vermuten, dass 
+      \texttt{b} wird in Zeile 6 berechnet.  Wir k\"onnten daher vermuten, dass 
       \[ \textsl{live}(\mathtt{b}) = \{ 6, 7, 8 \} \]
-      gilt.  Wenn wir so rechnen würden, dann  würden sich die Lebendigkeits-Bereiche
-      der Variablen \texttt{a} und \texttt{b} überlappen.  Tatsächlich können wir die
+      gilt.  Wenn wir so rechnen w\"urden, dann  w\"urden sich die Lebendigkeits-Bereiche
+      der Variablen \texttt{a} und \texttt{b} \"uberlappen.  Tats\"achlich k\"onnen wir die
       Variable \texttt{a} aber in dem selben Register wie die Variable \texttt{b}
       speichern, denn \texttt{a} wird nur bei der Berechnung des Wertes \texttt{b}
-      benötigt, aber sobald dieser Wert berechnet ist, ist der Wert von \texttt{a}
+      ben\"otigt, aber sobald dieser Wert berechnet ist, ist der Wert von \texttt{a}
       irrelevant.
 
       Das Problem ist, dass die Frage, ob eine Variable lebendig ist, nicht an einer
-      Programmzeile festgemacht werden kann, sondern an dem Übergang von einer
+      Programmzeile festgemacht werden kann, sondern an dem \"Ubergang von einer
       Programmzeile zu einer anderen Programmzeile.  Wir schreiben daher
       \[ \textsl{live}(\mathtt{b}) = \{ 6 \ra 7,\; 7 \ra 8 \}. \]
       Damit schreibt sich $\textsl{live}(\mathtt{a})$ als
       \[ \textsl{live}(\mathtt{a}) = \{ 3 \ra 4,\; 4 \ra 6,\; 8 \ra 9,\; 9 \ra 6 \} \]
       Wir stellen nun fest, dass die Mengen $\textsl{live}(\mathtt{a})$ und
       $\textsl{live}(\mathtt{b})$ disjunkt sind, so dass wir die beiden Variablen
-      tatsächlich in dem selben Register speichern können.
-\item \texttt{c} wird in Zeile 7 gelesen und auch geschrieben.  Außerdem wird \texttt{c}
+      tats\"achlich in dem selben Register speichern k\"onnen.
+\item \texttt{c} wird in Zeile 7 gelesen und auch geschrieben.  Au{\ss}erdem wird \texttt{c}
       auch in Zeile 10 gelesen.  Die Definition dieser Variablen ist in Zeile 4.  Daher
       haben wir
       \[ \textsl{live}(\mathtt{c})  = 
          \{ 4 \ra 6,\; 6 \ra 7,\; 7 \ra 8,\; 8 \ra 9,\; 9 \ra 6,\; 9 \ra 10 \}
       \]
-      Die Argumentation für diese Gleichung ist in Detail wie folgt:
+      Die Argumentation f\"ur diese Gleichung ist in Detail wie folgt:
       \begin{enumerate}
       \item Da \texttt{c} in Zeile 7 gelesen wird und der Befehl 7 auf den Befehl 6 folgt, gilt
             \[ 6 \rightarrow 7 \in \textsl{live}(\mathtt{c}). \]
       \item Da \texttt{c} in Zeile 6 lebendig ist und auch nicht neu geschrieben wird,
-            ist \texttt{c} auch in den Zeilen, die unmittelbar vor Zeile 6 kommen können, lebendig.
+            ist \texttt{c} auch in den Zeilen, die unmittelbar vor Zeile 6 kommen k\"onnen, lebendig.
             Damit haben wir
             \[ 9 \rightarrow 6 \in \textsl{live}(\mathtt{c}) \quad \mbox{und} \quad
                4 \rightarrow 6 \in \textsl{live}(\mathtt{c}) 
@@ -144,9 +144,9 @@ könnte wie folgt aussehen:
       \]
       Nur in Zeile 10 ist also \texttt{n} nicht mehr lebendig.
 \end{enumerate}
-Wir formalisieren nun die in dem obigen Beispiel durchführte Argumentation.  Wir fassen
-dazu das Assembler-ähnliche Programm als einen Graphen auf.  Die Zeilen des Programms, die
-später in einen Assembler-Befehl übersetzt werden, sind die Knoten des Programms. 
+Wir formalisieren nun die in dem obigen Beispiel durchf\"uhrte Argumentation.  Wir fassen
+dazu das Assembler-\"ahnliche Programm als einen Graphen auf.  Die Zeilen des Programms, die
+sp\"ater in einen Assembler-Befehl \"ubersetzt werden, sind die Knoten des Programms. 
 Zwischen zwei Zeilen $a$ und $b$ gibt es genau dann eine Kante von $a$ nach $b$, wenn bei
 der Abarbeitung des Programms die Instruktion $b$ auf die Instruktion $a$ unmittelbar
 folgen kann.  Den so erstellten Graph bezeichnen wir als den \emph{Kontrollfluss-Graphen}.
@@ -154,19 +154,19 @@ In dem obigen Beispiel besteht der Kontrollfluss-Graph aus den folgenden Kanten:
 \[ 
   \{ 1 \ra 3,\; 3 \ra 4,\; 4 \ra 6,\; 6 \ra 7,\; 7 \ra 8,\; 8 \ra 9,\; 9 \ra 6,\; 9 \ra 10 \}.
 \]
-Für eine Programm-Zeile $n$ bezeichnen wir mit $\textsl{pred}(n)$ die Menge aller Knoten,
+F\"ur eine Programm-Zeile $n$ bezeichnen wir mit $\textsl{pred}(n)$ die Menge aller Knoten,
 von denen eine Kante zum Knoten $n$ hin geht.  Der Funktionsname \textsl{pred} steht hier
-für \emph{predecessor}.   Weiter bezeichnen wir mit $\textsl{succ}(n)$ die Menge aller
-Knoten, zu denen eine Kante von $n$ aus hin führt.  Der Name \textsl{succ} steht für
+f\"ur \emph{predecessor}.   Weiter bezeichnen wir mit $\textsl{succ}(n)$ die Menge aller
+Knoten, zu denen eine Kante von $n$ aus hin f\"uhrt.  Der Name \textsl{succ} steht f\"ur
 \emph{successor}.  In dem obigen Beispiel gilt
 \[ \textsl{pred}(6) = \{ 4, 9 \} \quad \mbox{und} \quad \textsl{succ}(9) = \{ 6, 10 \}.  \]
-Weiter bezeichnen wir für eine Variable $x$ mit $\textsl{def}(x)$ die Menge aller Knoten,
+Weiter bezeichnen wir f\"ur eine Variable $x$ mit $\textsl{def}(x)$ die Menge aller Knoten,
 in denen der Variablen ein Wert zugewiesen wird.  Beispielsweise gilt
 \[ 
    \textsl{def}(\mathtt{a}) = \{ 3, 8 \} \quad \mbox{und} \quad
    \textsl{def}(\mathtt{b}) = \{ 6 \}.
 \]
-Schließlich bezeichnen wir für eine Variablen $x$ mit $\textsl{use}(x)$ die Menge aller
+Schlie{\ss}lich bezeichnen wir f\"ur eine Variablen $x$ mit $\textsl{use}(x)$ die Menge aller
 Knoten im Kontrollfluss-Graphen, in denen die Variable $x$ gelesen wird.  Beispielsweise gilt
 \[ 
    \textsl{use}(\mathtt{a}) = \{ 6, 9 \} \quad \mbox{und} \quad
@@ -194,7 +194,7 @@ Pfad $[7, 8, 9, 6, 7]$ fortgesetzt werden und auf den Punkten der Menge $\{8,9,6
 \texttt{c} nicht neu definiert.
 
 \begin{Definition}[\textsl{liveIn}, \textsl{liveOut}]
-Für eine Variable $x$ und einen Knoten $n$ sagen wir dass $x \in \textsl{liveIn}(n)$ ist,
+F\"ur eine Variable $x$ und einen Knoten $n$ sagen wir dass $x \in \textsl{liveIn}(n)$ ist,
 falls es einen Knoten $m$  gibt, so dass $x$ auf der Kante $m \ra n$ lebendig ist.
 Es gilt $x \in \textsl{liveOut}(n)$ wenn es einen Knoten $k$ gibt, so dass $x$ auf der
 Kante $n \ra k$ lebendig ist.
@@ -203,11 +203,11 @@ Kante $n \ra k$ lebendig ist.
 \noindent
 \textbf{Bemerkung}: Anschaulich gilt $x \in \textsl{liveIn}(n)$, falls die Variable in dem
 Knoten $n$ oder in einem Knoten, der im Kontrollfluss-Graphen auf $n$ folgt, gelesen wird,
-ohne vorher überschrieben zu werden.  Die Bedingung $x \in \textsl{liveOut}(n)$ bedeutet,
-dass der Wert von $x$ in dem Knoten $n$ (oder einem seiner Vorgänger-Knoten) definiert
-wird und später noch gelesen wird, ohne vorher überschrieben zu werden.
+ohne vorher \"uberschrieben zu werden.  Die Bedingung $x \in \textsl{liveOut}(n)$ bedeutet,
+dass der Wert von $x$ in dem Knoten $n$ (oder einem seiner Vorg\"anger-Knoten) definiert
+wird und sp\"ater noch gelesen wird, ohne vorher \"uberschrieben zu werden.
 
-Die Funktionen $\textsl{liveIn}()$ und $\textsl{liveOut}()$ genügen damit den folgenden
+Die Funktionen $\textsl{liveIn}()$ und $\textsl{liveOut}()$ gen\"ugen damit den folgenden
 beiden Gleichungen:
 \begin{enumerate}
 \item $\textsl{liveIn}(n) = 
@@ -222,12 +222,12 @@ beiden Gleichungen:
       in dem Knoten $n$ sind genau die Variablen \emph{live-out}, die in einem der
       Nachfolgerknoten \emph{live-in} sind.
 \end{enumerate}
-Über diese Gleichungen können nun die Funktionen $\textsl{liveIn}()$ und
+\"Uber diese Gleichungen k\"onnen nun die Funktionen $\textsl{liveIn}()$ und
 $\textsl{liveOut}()$ iterativ berechnet werden.   Abbildung \ref{fig:live-loop} zeigt
-den Pseudo-Code.  Zunächst werden  $\textsl{liveIn}(n)$ und
-$\textsl{liveOut}(n)$ für jeden Knoten $n$ mit der leeren Menge initialsiert.
+den Pseudo-Code.  Zun\"achst werden  $\textsl{liveIn}(n)$ und
+$\textsl{liveOut}(n)$ f\"ur jeden Knoten $n$ mit der leeren Menge initialsiert.
 Die \texttt{while}-Schleife in Zeile 5 wird solange iteriert, bis sich
-die Mengen $\textsl{liveIn}(n)$ und $\textsl{liveOut}(n)$ nicht mehr ändern.
+die Mengen $\textsl{liveIn}(n)$ und $\textsl{liveOut}(n)$ nicht mehr \"andern.
 
 
 \begin{figure}[!ht]
@@ -258,22 +258,22 @@ die Mengen $\textsl{liveIn}(n)$ und $\textsl{liveOut}(n)$ nicht mehr ändern.
 \end{figure}
 
 \noindent
-Die Berechnung der Funktion $\textsl{live}(x)$ für eine Kante $k \ra n$ ergibt sich nun
+Die Berechnung der Funktion $\textsl{live}(x)$ f\"ur eine Kante $k \ra n$ ergibt sich nun
 nach der folgenden Formel
 \[ 
    (k \ra n) \in \textsl{live}(x) \quad \mbox{g.d.w.} \quad
    n \in \textsl{liveIn}(x) \wedge k \in \textsl{pred}(n).
 \]
 Die Variable $x$ ist also auf der Kante $k \ra n$ genau dann lebendig, wenn $x$ eine
-Element der Menge $\textsl{liveIn}(n)$ ist und wenn außerdem die Kante $k \ra n$ eine
+Element der Menge $\textsl{liveIn}(n)$ ist und wenn au{\ss}erdem die Kante $k \ra n$ eine
 Kante des Kontrollfluss-Graphen ist.  
 
 
-Ist die Funktion $\textsl{live}(x)$ für alle Variablen berechnet, so definieren wir, dass
+Ist die Funktion $\textsl{live}(x)$ f\"ur alle Variablen berechnet, so definieren wir, dass
 zwei Variablen $x$ und $y$ \emph{im Konflikt} miteinander stehen, wenn 
 \[ \textsl{live}(x) \cap \textsl{live}(y) \not= \{\}.  \]
-gilt.  In diesem Fall benötigen wir verschiedene Register für die Variablen $x$ und $y$.
-Ist die Schnittmenge $\textsl{live}(x) \cap \textsl{live}(y)$ hingegen leer, so können wir
+gilt.  In diesem Fall ben\"otigen wir verschiedene Register f\"ur die Variablen $x$ und $y$.
+Ist die Schnittmenge $\textsl{live}(x) \cap \textsl{live}(y)$ hingegen leer, so k\"onnen wir
 die Variablen $x$ und $y$ im selben Register speichern.
 
 

--- a/Lecture-Notes/ll.tex
+++ b/Lecture-Notes/ll.tex
@@ -2,19 +2,19 @@
 In diesem Kapitel werden wir die Theorie vorstellen,  die 
 Top-Down Parser-Generatoren wie beispielsweise \textsc{Antlr} zu Grunde liegt.  Es handelt
 sich dabei um die Theorie der LL($k$)-Sprachen. 
-Dabei steht das erste $L$ dafür, dass der Parser die Eingabe von \underline{l}inks nach rechts parst,
-das zweite $L$ steht dafür, dass der Parser versucht, eine \underline{L}inks-Ableitung des
+Dabei steht das erste $L$ daf\"ur, dass der Parser die Eingabe von \underline{l}inks nach rechts parst,
+das zweite $L$ steht daf\"ur, dass der Parser versucht, eine \underline{L}inks-Ableitung des
 zu parsenden Wortes zu berechnen. Eine Links-Ableitung ist dabei eine Ableitung, bei der
 immer die linkeste Variable ersetzt wird.
- Die Zahl $k$ in LL($k$) bedeutet, dass der Parser anhand der nächsten $k$ Token
-entscheidet, welche Regel verwendet wird.  Falls beispielsweise $k=1$ ist, wird also nur das nächste 
+ Die Zahl $k$ in LL($k$) bedeutet, dass der Parser anhand der n\"achsten $k$ Token
+entscheidet, welche Regel verwendet wird.  Falls beispielsweise $k=1$ ist, wird also nur das n\"achste 
 Token zur Entscheidung herangezogen.  Dieses Token bezeichnen wir dann als \emph{Lookahead-Token}.
-Wir betrachten zunächst den Fall $k=1$. 
+Wir betrachten zun\"achst den Fall $k=1$. 
 Bevor wir die Theorie der LL(1)-Parser darstellen, machen wir auf zwei Probleme
-aufmerksam, die wir bei der Erstellung von Top-Down-Parsern lösen müssen.
+aufmerksam, die wir bei der Erstellung von Top-Down-Parsern l\"osen m\"ussen.
 \begin{enumerate}
 \item Das erste Problem ist die Links-Rekursion, die beispielsweise in den folgenden
-      Regeln zur Beschreibung arithmetischer Ausdrücke auftritt:
+      Regeln zur Beschreibung arithmetischer Ausdr\"ucke auftritt:
       \begin{eqnarray*}
         \textsl{expr}    & \rightarrow & \;\textsl{expr} \quoted{+} \textsl{product}  \\
                          & \mid        & \;\textsl{expr} \quoted{-} \textsl{product}  \\
@@ -23,22 +23,22 @@ aufmerksam, die wir bei der Erstellung von Top-Down-Parsern lösen müssen.
       Wir hatten im Abschnitt \ref{links-rekursion} gezeigt, wie die Links-Rekursion aus
       einer Grammatik eliminiert werden kann. 
       
-      Zusätzlich haben wir gesehen, dass es bei der Verwendung von \textsc{Ebnf}-Grammatiken 
-      oft in natürlicher Weise möglich ist, die Links-Rekursion durch die Verwendung der
+      Zus\"atzlich haben wir gesehen, dass es bei der Verwendung von \textsc{Ebnf}-Grammatiken 
+      oft in nat\"urlicher Weise m\"oglich ist, die Links-Rekursion durch die Verwendung der
       Postfix-Operatoren ``\texttt{*}'' und ``\texttt{+}'' zu vermeiden.  Beispielsweise
-      können wir die obigen Regeln für arithmetische Ausdrücke zu der \textsc{Ebnf}-Regel
+      k\"onnen wir die obigen Regeln f\"ur arithmetische Ausdr\"ucke zu der \textsc{Ebnf}-Regel
       \begin{eqnarray*} 
         \textsl{expr}    & \rightarrow & \textsl{product}\;\; \bigl((\quoted{+}|\quoted{-}) \;\;\textsl{product}\bigr)^* 
       \end{eqnarray*}
       umschreiben.
-\item Das zweite Problem erkennen wir, wenn wir die folgende Grammatik-Regel für 
+\item Das zweite Problem erkennen wir, wenn wir die folgende Grammatik-Regel f\"ur 
       Gleichungen und Ungleichungen betrachten:
       \begin{eqnarray*}
         \textsl{boolExpr} & \rightarrow & \textsl{expr} \quoted{==}    \textsl{expr} \\
                           & \mid        & \textsl{expr} \quoted{<}\;\, \textsl{expr} 
       \end{eqnarray*}
       Diese Grammatik-Regeln sind nicht links-rekursiv, aber
-      für einen Top-Down-Parser, der mit nur einem Token Look-Ahead
+      f\"ur einen Top-Down-Parser, der mit nur einem Token Look-Ahead
       auskommen soll, ist die Frage, welche der beiden Regeln zum Parsen verwendet
       werden soll, offenbar nicht zu beantworten.  Wir stellen gleich ein Verfahren vor, mit dem sich
       Grammatiken so transformieren lassen, dass dieses Problem verschwindet.
@@ -51,12 +51,12 @@ und gibt es zwei verschiedene Regeln, mit denen $\textsl{a}$ abgeleitet werden k
 \hspace*{1.3cm}
 $\textsl{a} \rightarrow \beta$ \quad und \quad $\textsl{a} \rightarrow \gamma$,
 \\[0.2cm]
-so muss es bei der Verwendung eines LL(1)-Parsers möglich sein, anhand des Look-Ahead-Tokens zu
-erkennen, welche Regel benutzt werden soll.  In der Praxis gibt es häufig Situationen, wo
-diese Voraussetzung nicht erfüllt ist.  Wir haben oben bereits ein solches Beispiel
-gesehen.  Um das Beispiel zu vervollständigen, benötigen wir noch Regeln zur Ableitung von
-\textsl{expr}.  Abbildung \ref{fig:Expr3} zeigt eine vollständige Grammatik, mit der
-Gleichungen und Ungleichungen beschrieben werden können, die aus arithmetischen Ausdrücken
+so muss es bei der Verwendung eines LL(1)-Parsers m\"oglich sein, anhand des Look-Ahead-Tokens zu
+erkennen, welche Regel benutzt werden soll.  In der Praxis gibt es h\"aufig Situationen, wo
+diese Voraussetzung nicht erf\"ullt ist.  Wir haben oben bereits ein solches Beispiel
+gesehen.  Um das Beispiel zu vervollst\"andigen, ben\"otigen wir noch Regeln zur Ableitung von
+\textsl{expr}.  Abbildung \ref{fig:Expr3} zeigt eine vollst\"andige Grammatik, mit der
+Gleichungen und Ungleichungen beschrieben werden k\"onnen, die aus arithmetischen Ausdr\"ucken
 aufgebaut sind.
 
 
@@ -89,18 +89,18 @@ aufgebaut sind.
 
   \end{minipage}}}
   \end{center}
-  \caption{Grammatik ohne Links-Rekursion für Gleichungen und Ungleichungen.}
+  \caption{Grammatik ohne Links-Rekursion f\"ur Gleichungen und Ungleichungen.}
   \label{fig:Expr3}
 \end{figure}
 
 \noindent
-Es ist nicht möglich einen LL(1)-Parser zu implementieren, der Boole'sche Ausdrücke
-mit Hilfe dieser Regeln  erkennen kann, denn alle Regeln für \textsl{boolExpr} beginnen
-mit \textsl{expr}.  Wir können die Grammatik aber durch \emph{Links-Faktorisierung}
+Es ist nicht m\"oglich einen LL(1)-Parser zu implementieren, der Boole'sche Ausdr\"ucke
+mit Hilfe dieser Regeln  erkennen kann, denn alle Regeln f\"ur \textsl{boolExpr} beginnen
+mit \textsl{expr}.  Wir k\"onnen die Grammatik aber durch \emph{Links-Faktorisierung}
 (Englisch: \emph{left factoring})  
 so umschreiben, dass ein Token als Look-Ahead ausreicht, indem wir den Teil aus den beiden 
 Grammatik-Regeln ausklammern, der am Anfang der beiden Regeln identisch ist.  In dem
-obigen Beispiel führen wir dann für den verbleibenden Rest das neue Nicht-Terminal
+obigen Beispiel f\"uhren wir dann f\"ur den verbleibenden Rest das neue Nicht-Terminal
 \textsl{boolExprRest} ein und erhalten so die Regeln
 \begin{eqnarray*}
 \textsl{boolExpr}     & \rightarrow & \;\textsl{expr} \;\;\textsl{boolExprRest} \\[0.2cm]
@@ -109,10 +109,10 @@ obigen Beispiel führen wir dann für den verbleibenden Rest das neue Nicht-Termin
                       & \mid        & \quoted{>=}\;\, \textsl{expr} \quad \mid \quad \quoted{<} \textsl{expr} 
                                       \quad \mid \quad \quoted{>} \textsl{expr}. 
 \end{eqnarray*}
-Mit diesen Regeln reicht ein Token als Look-Ahead aus, denn die verschiedenen Alternativen für 
+Mit diesen Regeln reicht ein Token als Look-Ahead aus, denn die verschiedenen Alternativen f\"ur 
 \mbox{\textsl{boolExprRest}} unterscheiden sich in dem ersten Token des Rumpfs der Regel.
 Verwenden wir statt einer einfachen Grammatik eine \textsc{Ebnf}-Grammatik, so lassen sich die 
-obigen Regeln kürzer und klarer in der Form
+obigen Regeln k\"urzer und klarer in der Form
 \begin{eqnarray*}
 \textsl{boolExpr} & \rightarrow & \textsl{expr}\;\;
                                   (\quoted{==}\mid \quoted{!=}\mid \quoted{<=} \mid \quoted{>=} \mid \quoted{<})  
@@ -120,9 +120,9 @@ obigen Regeln kürzer und klarer in der Form
 \end{eqnarray*}
 darstellen.
 
-Um den allgemeinen Fall der Links-Faktorisierung diskutieren zu können, nehmen wir an, dass
+Um den allgemeinen Fall der Links-Faktorisierung diskutieren zu k\"onnen, nehmen wir an, dass
 $\textsl{a}$ ein Nicht-Terminal ist, das durch insgesamt $m + n$ Regeln definiert wird, wobei der
-Rumpf der ersten $m$ Regeln immer mit $\alpha$ anfängt, wobei $\alpha$ ein String aus
+Rumpf der ersten $m$ Regeln immer mit $\alpha$ anf\"angt, wobei $\alpha$ ein String aus
 Terminalen und syntaktischen Variablen ist.  Die Regeln haben also die folgende Form:
 \begin{eqnarray*}
   \textsl{a} & \rightarrow & \alpha \;\; \beta_1 \\
@@ -134,9 +134,9 @@ Terminalen und syntaktischen Variablen ist.  Die Regeln haben also die folgende 
     & \mid        & \gamma_n            
 \end{eqnarray*}
 Bei dieser Darstellung sei vorausgesetzt, dass die Strings $\beta_1$, $\cdots$, $\beta_m$
-keinen  Präfix haben, der allen $\beta_i$ gemeinsam ist und dass $\alpha$ kein Präfix einer der Strings
+keinen  Pr\"afix haben, der allen $\beta_i$ gemeinsam ist und dass $\alpha$ kein Pr\"afix einer der Strings
 $\gamma_1, \cdots, \gamma_n$ ist.  Bei der Links-Faktorisierung dieser Regeln klammern wir einerseits den
-gemeinsamen Präfix $\alpha$ aus und führen andererseits eine neue syntaktische Variable $\textsl{b}$ ein, die
+gemeinsamen Pr\"afix $\alpha$ aus und f\"uhren andererseits eine neue syntaktische Variable $\textsl{b}$ ein, die
 den auf $\alpha$ folgenden Rest bezeichnet.  Wir erhalten dann die folgenden Regeln:
 \[
 \begin{array}{lclclcl}
@@ -146,11 +146,11 @@ den auf $\alpha$ folgenden Rest bezeichnet.  Wir erhalten dann die folgenden Reg
     & \mid        & \gamma_n      &        &   & \mid        & \beta_m   \\[0.2cm]
 \end{array}
 \]
-Um alle gemeinsamen Präfixe auszuklammern muss dieses Verfahren unter 
-Umständen mehrfach durchgeführt werden.  Die nächste Aufgabe gibt dafür ein Beispiel.
+Um alle gemeinsamen Pr\"afixe auszuklammern muss dieses Verfahren unter 
+Umst\"anden mehrfach durchgef\"uhrt werden.  Die n\"achste Aufgabe gibt daf\"ur ein Beispiel.
 
 \exercise
-Geben Sie eine Links-Faktorisierung für die folgenden Grammatik-Regeln an.
+Geben Sie eine Links-Faktorisierung f\"ur die folgenden Grammatik-Regeln an.
 \begin{eqnarray*}
   \textsl{a} & \rightarrow & \quoted{A} \quoted{B} \textsl{u} \quoted{D} \\
              & \mid        & \quoted{A} \textsl{v} \quoted{B} \quoted{D} \\
@@ -160,7 +160,7 @@ Geben Sie eine Links-Faktorisierung für die folgenden Grammatik-Regeln an.
 \end{eqnarray*}
 
 \solution
-Zunächst eliminieren wir das gemeinsame Präfix \qote{A} und führen dazu die neue
+Zun\"achst eliminieren wir das gemeinsame Pr\"afix \qote{A} und f\"uhren dazu die neue
 syntaktische Variable $\textsl{b}$ ein.  Wir erhalten:
 \begin{eqnarray*}
   \textsl{a} & \rightarrow & \quoted{A} \textsl{b}             \\
@@ -170,7 +170,7 @@ syntaktische Variable $\textsl{b}$ ein.  Wir erhalten:
     & \mid        & \;\textsl{v} \quoted{B} \quoted{D}\\
     & \mid        & \quoted{B} \textsl{w}             
 \end{eqnarray*}
-Nun eliminieren wir das Präfix \qote{X} aus beiden letzten Regeln für $\textsl{a}$.  Wir führen
+Nun eliminieren wir das Pr\"afix \qote{X} aus beiden letzten Regeln f\"ur $\textsl{a}$.  Wir f\"uhren
 dazu die neue syntaktische Variable $\textsl{c}$ ein. Dann erhalten wir:
 \begin{eqnarray*}
   \textsl{a} & \rightarrow & \quoted{A} \textsl{b}              \\
@@ -181,8 +181,8 @@ dazu die neue syntaktische Variable $\textsl{c}$ ein. Dann erhalten wir:
     & \mid        & \;\textsl{v} \quoted{B} \quoted{D} \\
     & \mid        & \quoted{B} \textsl{w}              
 \end{eqnarray*}
-Als letztes eliminieren wir das Präfix \qote{B}, das in zwei der Regeln für die
-syntaktische Variable $\textsl{b}$ auftritt.  Wir nennen die neu eingeführte Variable $\textsl{d}$ und erhalten:
+Als letztes eliminieren wir das Pr\"afix \qote{B}, das in zwei der Regeln f\"ur die
+syntaktische Variable $\textsl{b}$ auftritt.  Wir nennen die neu eingef\"uhrte Variable $\textsl{d}$ und erhalten:
 \begin{eqnarray*}
   \textsl{a} & \rightarrow & \quoted{A} \textsl{b}              \\
     & \mid        & \quoted{X} \textsl{c}              \\[0.2cm]
@@ -200,34 +200,34 @@ syntaktische Variable $\textsl{b}$ auftritt.  Wir nennen die neu eingeführte Var
 
 
 \section{\textsl{First} und \textsl{Follow}}
-Nicht für jede links-faktorisierte Grammatik lässt sich ein LL(1)-Parser bauen.  Betrachten
+Nicht f\"ur jede links-faktorisierte Grammatik l\"asst sich ein LL(1)-Parser bauen.  Betrachten
 wir die folgenden Regeln:
 \begin{eqnarray*}
   \textsl{a} & \rightarrow & \textsl{b} \; \mid\; \textsl{c} \\
   \textsl{b} & \rightarrow & \quoted{A} \textsl{u}  \\
   \textsl{c} & \rightarrow & \quoted{A} \textsl{v}  
 \end{eqnarray*}
-Will der Parser ein $\textsl{a}$ parsen und ist das nächste Token ein \qote{A}, so ist nicht klar,
-ob der Parser als nächstes die Regel
+Will der Parser ein $\textsl{a}$ parsen und ist das n\"achste Token ein \qote{A}, so ist nicht klar,
+ob der Parser als n\"achstes die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{a} \rightarrow \textsl{b}$ \quad oder \quad $\textsl{a} \rightarrow \textsl{c}$
 \\[0.2cm]
-verwenden soll.  Für die obige Grammatik lässt sich daher kein LL(1)-Parser implementieren.
-Zur Entscheidung, ob sich für eine gegebene Grammatik ein LL(1)-Parser implementieren lässt,
-benötigen wir die Funktionen $\textsl{First}()$ und $\textsl{Follow}()$, die wir gleich
-definieren werden.  Um diese Funktionen implementieren zu können, definieren wir vorher  den
+verwenden soll.  F\"ur die obige Grammatik l\"asst sich daher kein LL(1)-Parser implementieren.
+Zur Entscheidung, ob sich f\"ur eine gegebene Grammatik ein LL(1)-Parser implementieren l\"asst,
+ben\"otigen wir die Funktionen $\textsl{First}()$ und $\textsl{Follow}()$, die wir gleich
+definieren werden.  Um diese Funktionen implementieren zu k\"onnen, definieren wir vorher  den
 Begriff einer $\varepsilon$-erzeugenden syntaktischen Variablen.
 
 \begin{Definition}[$\varepsilon$-erzeugend]
 Es sei $G = \langle V, T, R, S \rangle$ eine kontextfreie Grammatik und $\textsl{a}$ sei eine
-syntaktische Variable, also $\textsl{a} \in V$.  Die Variable $\textsl{a}$ heißt 
+syntaktische Variable, also $\textsl{a} \in V$.  Die Variable $\textsl{a}$ hei{\ss}t 
 \emph{$\varepsilon$-erzeugend} genau dann, wenn
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{a} \Rightarrow^* \varepsilon$
 \\[0.2cm]
-gilt, also dann, wenn sich aus der Variablen $\textsl{a}$ das leere Wort ableiten lässt. 
+gilt, also dann, wenn sich aus der Variablen $\textsl{a}$ das leere Wort ableiten l\"asst. 
 Wir schreiben $\textsl{nullable}(\textsl{a})$ wenn die Variable $\textsl{a}$ als $\varepsilon$-erzeugend
 nachgewiesen ist.
 \eox
@@ -252,10 +252,10 @@ nachgewiesen ist.
       \hspace*{1.3cm}
       $\textsl{c} \rightarrow \textsl{a}\;\textsl{b}\; \textsl{c} \mid \varepsilon$
       \\[0.2cm]
-      Zunächst ist offenbar die Variable $\textsl{c}$ $\varepsilon$-erzeugend.  Dann sehen wir,
+      Zun\"achst ist offenbar die Variable $\textsl{c}$ $\varepsilon$-erzeugend.  Dann sehen wir,
       dass aufgrund der Regel $\textsl{b} \rightarrow \textsl{c} \;\textsl{c}$ auch $\textsl{b}$ $\varepsilon$-erzeugend ist
       und daraus folgt wegen der Regel $\textsl{a} \rightarrow \textsl{b}\;\textsl{c}$, dass auch $\textsl{a}$
-      $\varepsilon$-erzeugend ist.  Schließlich erkennen wir $S$ als $\varepsilon$-erzeugend,
+      $\varepsilon$-erzeugend ist.  Schlie{\ss}lich erkennen wir $S$ als $\varepsilon$-erzeugend,
       denn die erste Regel lautet
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -306,17 +306,17 @@ then continue to iterate the equations defining $\textsl{First}(\textsl{a})$ unt
 $\textsl{First}(\textsl{a})$ changes any more.  The next example clarifies this idea.
 
 \example
-Wir können für die Variablen $\textsl{a}$ der in Abbildung \ref{fig:Expr3} gezeigten Grammatik 
+Wir k\"onnen f\"ur die Variablen $\textsl{a}$ der in Abbildung \ref{fig:Expr3} gezeigten Grammatik 
 die Mengen $\textsl{First}(\textsl{a})$ iterativ berechnen.  Wir berechnen
-die Funktion $\textsl{First}(\textsl{a})$ für die einzelnen Variablen $\textsl{a}$ am besten so, dass wir mit den
+die Funktion $\textsl{First}(\textsl{a})$ f\"ur die einzelnen Variablen $\textsl{a}$ am besten so, dass wir mit den
 Variablen beginnen, die in der Hierarchie ganz unten stehen. 
 \begin{enumerate}
-\item Zunächst folgt aus den Regeln
+\item Zun\"achst folgt aus den Regeln
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{factor} \rightarrow \quoted{(} \textsl{expr} \quoted{)} \mid \textsc{Number} \mid \textsc{Identifier}$,
       \\[0.2cm]
-      dass jeder von \textsl{Factor} abgeleitete String entweder mit einer öffnenden
+      dass jeder von \textsl{Factor} abgeleitete String entweder mit einer \"offnenden
       Klammer, einer Zahl oder einem Bezeichner beginnt:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -332,14 +332,14 @@ Variablen beginnen, die in der Hierarchie ganz unten stehen.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{First}(\textsl{productRest}) = \{ \quoted{*}, \quoted{/} \}$
-\item Die Regel für die Variable \textsl{product} lautet
+\item Die Regel f\"ur die Variable \textsl{product} lautet
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{product} \rightarrow \textsl{factor}\;\;\textsl{productRest}$.
       \\[0.2cm]
       Da die Variable \textsl{factor} nicht $\varepsilon$ erzeugend ist, sehen wir, dass
       die Menge $\textsl{First}(\textsl{product})$ mit der Menge
-      $\textsl{First}(\textsl{factor})$ übereinstimmt:
+      $\textsl{First}(\textsl{factor})$ \"ubereinstimmt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{First}(\textsl{product}) = \{ \quoted{(}, \textsc{Number}, \textsc{Identifier}\; \}$.
@@ -350,7 +350,7 @@ Variablen beginnen, die in der Hierarchie ganz unten stehen.
                          \mid        \quoted{-} \textsl{product}\;\;\textsl{exprRest} 
                          \mid        \varepsilon$
       \\[0.2cm]
-      können wir $\textsl{First}(\textsl{exprRest})$ wie folgt berechnen:
+      k\"onnen wir $\textsl{First}(\textsl{exprRest})$ wie folgt berechnen:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{First}(\textsl{exprRest}) = \{ \quoted{+}, \quoted{-} \}$.
@@ -361,11 +361,11 @@ Variablen beginnen, die in der Hierarchie ganz unten stehen.
       \\[0.2cm]
       und der Tatsache, dass $\textsl{product}$ nicht $\varepsilon$-erzeugend ist,
       dass die Menge $\textsl{First}(\textsl{expr})$ mit der Menge
-      $\textsl{First}(\textsl{product})$ übereinstimmt:
+      $\textsl{First}(\textsl{product})$ \"ubereinstimmt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{First}(\textsl{expr}) = \{ \quoted{(}, \textsc{Number}, \textsc{Identifier}\; \}$.
-\item Schließlich folgt aus den Regeln für die syntaktische Variable \textsl{boolExpr}
+\item Schlie{\ss}lich folgt aus den Regeln f\"ur die syntaktische Variable \textsl{boolExpr}
       sowie der Tatsache, dass die syntaktische Variable \textsl{expr} nicht $\varepsilon$-erzeugend ist,
       dass $\textsl{First}(\textsl{boolExpr})$ mit $\textsl{First}(\textsl{expr})$ identisch ist:
       \\[0.2cm]
@@ -379,25 +379,25 @@ proper fixpoint iteration in this example.
 
 \begin{Definition}[$\textsl{Follow}()$]
 Es sei $G = \langle V, T, R, S \rangle$ eine kontextfreie Grammatik und $\textsl{a} \in V$.
-Bei der Berechnung von $\textsl{Follow}()$ wird die Grammatik zunächst abgeändert,
+Bei der Berechnung von $\textsl{Follow}()$ wird die Grammatik zun\"achst abge\"andert,
 indem wir das Symbol \qote{\symbol{36}} als neues Symbol zu der Menge $T$ der Terminale
-hinzufügen.  Zu den Variablen wird das neue Symbol $\widehat{S}$ hinzugefügt, das auch
+hinzuf\"ugen.  Zu den Variablen wird das neue Symbol $\widehat{S}$ hinzugef\"ugt, das auch
 gleichzeitig das neue Start-Symbol der Grammatik ist.  Zu der Menge $R$ der Regeln
-fügen wir die folgende Regel neu hinzu:
+f\"ugen wir die folgende Regel neu hinzu:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\widehat{S} \rightarrow S \quoted{\symbol{36}}$.
 \\[0.2cm]
-Das Terminal \qote{\symbol{36}} steht hierbei für das Ende der Eingabe (\textsc{Eof},
+Das Terminal \qote{\symbol{36}} steht hierbei f\"ur das Ende der Eingabe (\textsc{Eof},
 \emph{end of file}).
 Weiter definieren wir
 \\[0.2cm]
 \hspace*{1.3cm}
  $\widehat{T} := T \cup \{ \quoted{\symbol{36}} \}$.
 \\[0.2cm]
-Die so veränderte Grammatik bezeichnen wir als die \emph{augmentierte} Grammatik.
+Die so ver\"anderte Grammatik bezeichnen wir als die \emph{augmentierte} Grammatik.
 Dann definieren wir $\textsl{Follow}(\textsl{a})$ als die Menge aller der Token $t$, die in einer
-Ableitung auf $\textsl{a}$ folgen können:
+Ableitung auf $\textsl{a}$ folgen k\"onnen:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{Follow}(\textsl{a}) := 
@@ -406,16 +406,16 @@ $\textsl{Follow}(\textsl{a}) :=
   \}
 $.
 \\[0.2cm]
-Wenn sich aus dem Start-Symbol $\widehat{S}$ also irgendwie ein String $\beta \textsl{a} t\gamma$ ableiten lässt,
+Wenn sich aus dem Start-Symbol $\widehat{S}$ also irgendwie ein String $\beta \textsl{a} t\gamma$ ableiten l\"asst,
 bei dem das Token $t$ auf die Variable $\textsl{a}$ folgt, dann ist $t$ ein Element
 der Menge $\textsl{Follow}(\textsl{a})$.
 \eox
 \end{Definition}
 
 \example
-Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für arithmetische Ausdrücke.
+Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik f\"ur arithmetische Ausdr\"ucke.
 \begin{enumerate}
-\item Aufgrund der neu hinzugefügten Regel
+\item Aufgrund der neu hinzugef\"ugten Regel
       \\[0.2cm]
       \hspace*{1.3cm}
       $\widehat{S} \rightarrow \textsl{boolExpr} \quoted{\symbol{36}}$
@@ -426,11 +426,11 @@ Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für a
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{Follow}(\textsl{boolExpr}) = \{ \quoted{\symbol{36}} \}$.
-\item Die Grammatik-Regeln für die syntaktische Variable \textsl{boolExpr}
-      zeigen uns zunächst, dass die Menge $\textsl{Follow}(\textsl{expr})$ die Zeichen
-      \qote{==}, \qote{!=}, \qote{<=}, \qote{>=}, \qote{<}   und \qote{>} enthält.  Da \textsl{expr} auch am Ende dieser Regeln steht,
+\item Die Grammatik-Regeln f\"ur die syntaktische Variable \textsl{boolExpr}
+      zeigen uns zun\"achst, dass die Menge $\textsl{Follow}(\textsl{expr})$ die Zeichen
+      \qote{==}, \qote{!=}, \qote{<=}, \qote{>=}, \qote{<}   und \qote{>} enth\"alt.  Da \textsl{expr} auch am Ende dieser Regeln steht,
       folgt weiter, dass alle Elemente aus $\textsl{Follow}(\textsl{boolExpr})$ auch auf 
-      \textsl{expr} folgen können, wir haben also auch
+      \textsl{expr} folgen k\"onnen, wir haben also auch
       \\[0.2cm]
       \hspace*{1.3cm}
       $\quoted{\symbol{36}} \in \textsl{Follow}(\textsl{expr})$.
@@ -440,7 +440,7 @@ Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für a
       \hspace*{1.3cm}
       $\textsl{factor} \rightarrow \quoted{(} \textsl{expr} \quoted{)}$
       \\[0.2cm]
-      muss die Menge $\textsl{Follow}(\textsl{expr})$ außerdem das Zeichen \qote{)}
+      muss die Menge $\textsl{Follow}(\textsl{expr})$ au{\ss}erdem das Zeichen \qote{)}
       enthalten.  Also haben wir insgesamt
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -450,12 +450,12 @@ Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für a
       \hspace*{1.3cm}
       $\textsl{expr} \rightarrow \textsl{product}\;\;\textsl{exprRest}$
       \\[0.2cm]      
-      wissen wir, dass alle Terminale, die auf ein \textsl{expr} folgen können, auch auf
-      ein \textsl{exprRest} folgen können, womit wir schon mal wissen, dass
+      wissen wir, dass alle Terminale, die auf ein \textsl{expr} folgen k\"onnen, auch auf
+      ein \textsl{exprRest} folgen k\"onnen, womit wir schon mal wissen, dass
       $\textsl{Follow}(\textsl{exprRest})$ die Token \qote{==}, \qote{!=}, \qote{<=}, \qote{>=}, \qote{<}, \qote{\symbol{36}}  und \qote{)}
-      enthält.   Da \textsl{exprRest} sonst nur am Ende der Regeln vorkommt, die
+      enth\"alt.   Da \textsl{exprRest} sonst nur am Ende der Regeln vorkommt, die
       \textsl{exprRest} definieren, sind das auch schon alle Token, die auf
-      \textsl{exprRest} folgen können und wir haben
+      \textsl{exprRest} folgen k\"onnen und wir haben
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{Follow}(\textsl{exprRest}) = 
@@ -467,8 +467,8 @@ Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für a
                          \mid        \quoted{-} \textsl{product}\;\;\textsl{exprRest}$
       \\[0.2cm]
       zeigen, dass auf ein \textsl{product} alle Elemente aus $\textsl{First}(\textsl{exprRest})$
-      folgen können, aber das ist noch nicht alles:  Da die Variable \textsl{exprRest}
-      $\varepsilon$-erzeugend ist, können zusätzlich auf \textsl{product} auch
+      folgen k\"onnen, aber das ist noch nicht alles:  Da die Variable \textsl{exprRest}
+      $\varepsilon$-erzeugend ist, k\"onnen zus\"atzlich auf \textsl{product} auch
       alle Token folgen, die auf \textsl{exprRest} folgen.  Damit haben wir insgesamt
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -479,11 +479,11 @@ Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für a
       \hspace*{1.3cm}
       $\textsl{product} \rightarrow \textsl{factor}\;\;\textsl{productRest}$
       \\[0.2cm]      
-      zeigt, dass alle Terminale, die auf ein \textsl{product} folgen können, auch auf
-      ein \textsl{productRest} folgen können.
+      zeigt, dass alle Terminale, die auf ein \textsl{product} folgen k\"onnen, auch auf
+      ein \textsl{productRest} folgen k\"onnen.
       Da \textsl{productRest} sonst nur am Ende der Regeln vorkommt, die
       \textsl{productRest} definieren, sind das auch schon alle Token, die auf
-      \textsl{productRest} folgen können und wir haben insgesamt
+      \textsl{productRest} folgen k\"onnen und wir haben insgesamt
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{Follow}(\textsl{productRest}) = 
@@ -495,8 +495,8 @@ Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für a
                             \mid        \quoted{/} \textsl{factor}\;\;\textsl{productRest}$ 
       \\[0.2cm]
       zeigen, dass auf ein \textsl{factor} alle Elemente aus $\textsl{First}(\textsl{productRest})$
-      folgen können, aber das ist noch nicht alles:  Da die Variable \textsl{productRest}
-      $\varepsilon$-erzeugend ist, können zusätzlich auf \textsl{factor} auch
+      folgen k\"onnen, aber das ist noch nicht alles:  Da die Variable \textsl{productRest}
+      $\varepsilon$-erzeugend ist, k\"onnen zus\"atzlich auf \textsl{factor} auch
       alle Token folgen, die auf \textsl{productRest} folgen.  Damit haben wir insgesamt
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -506,8 +506,8 @@ Wir untersuchen wieder die in Abbildung \ref{fig:Expr3} gezeigte Grammatik für a
 \end{enumerate}
 
 \noindent
-Das letzte Beispiel zeigt, dass die Berechnung des Prädikats $\textsl{nullable}()$ 
-und die Berechnung der Mengen $\textsl{First}(\textsl{a})$ und $\textsl{Follow}(\textsl{a})$ für eine syntaktische
+Das letzte Beispiel zeigt, dass die Berechnung des Pr\"adikats $\textsl{nullable}()$ 
+und die Berechnung der Mengen $\textsl{First}(\textsl{a})$ und $\textsl{Follow}(\textsl{a})$ f\"ur eine syntaktische
 Variable $\textsl{a}$ eng miteinander verbunden sind.  
 Es sei
 \\[0.2cm]
@@ -515,7 +515,7 @@ Es sei
  $\textsl{a} \rightarrow Y_1 Y_2 \cdots Y_k$ 
 \\[0.2cm]
 eine Grammatik-Regel.
-Dann bestehen zwischen dem Prädikat $\texttt{nullable}()$ und den beiden Funktionen
+Dann bestehen zwischen dem Pr\"adikat $\texttt{nullable}()$ und den beiden Funktionen
 $\textsl{First}()$ und $\textsl{Follow}()$ die folgenden Beziehungen:
 \begin{enumerate}
 \item $\forall t \in T: \neg\, \textsl{nullable}(t)$.
@@ -540,42 +540,42 @@ $\textsl{First}()$ und $\textsl{Follow}()$ die folgenden Beziehungen:
 
       Setzen wir hier $l=i+1$ so sehen wir, dass 8.~ein Spezialfall von 9.~ist.
 \end{enumerate}
-Mit Hilfe dieser Beziehungen können $\textsl{nullable}()$, $\textsl{First}()$ und
-$\textsl{Follow}()$ iterativ über eine Fixpunkt-Iteration berechnet werden:  
+Mit Hilfe dieser Beziehungen k\"onnen $\textsl{nullable}()$, $\textsl{First}()$ und
+$\textsl{Follow}()$ iterativ \"uber eine Fixpunkt-Iteration berechnet werden:  
 \begin{enumerate}
-\item Zunächst werden die Funktionen $\textsl{First}(\textsl{a})$ und
-      $\textsl{Follow}(\textsl{a})$ für jede syntaktische Variable $\textsl{a}$ mit der leeren Menge initialisiert.
-      Das Prädikat $\textsl{nullable}(\textsl{a})$ wird für jede syntaktische Variable auf $\texttt{false}$
+\item Zun\"achst werden die Funktionen $\textsl{First}(\textsl{a})$ und
+      $\textsl{Follow}(\textsl{a})$ f\"ur jede syntaktische Variable $\textsl{a}$ mit der leeren Menge initialisiert.
+      Das Pr\"adikat $\textsl{nullable}(\textsl{a})$ wird f\"ur jede syntaktische Variable auf $\texttt{false}$
       gesetzt.
-\item Anschließend werden die oben angegebenen Regeln so lange angewendet, wie sich durch die
-      Anwendung Änderungen ergeben. 
+\item Anschlie{\ss}end werden die oben angegebenen Regeln so lange angewendet, wie sich durch die
+      Anwendung \"Anderungen ergeben. 
 \end{enumerate}
 
 \section{LL(1)-Grammatiken}
-Wir können nun die Frage beantworten, für welche Grammatiken ein Top-Down-Parser erzeugt
+Wir k\"onnen nun die Frage beantworten, f\"ur welche Grammatiken ein Top-Down-Parser erzeugt
 werden kann, der immer mit einem Token Lookahead auskommt.  
 
 \begin{Definition}[LL(1)-Grammatik]
-Eine Grammatik $G$ ist eine \emph{LL(1)-Grammatik} genau dann, wenn für jede syntaktische Variable
-$\textsl{a}$, für die es in der Grammatik $G$ zwei verschiedene Regeln
+Eine Grammatik $G$ ist eine \emph{LL(1)-Grammatik} genau dann, wenn f\"ur jede syntaktische Variable
+$\textsl{a}$, f\"ur die es in der Grammatik $G$ zwei verschiedene Regeln
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{a} \rightarrow \alpha$ \quad und \quad $\textsl{a} \rightarrow \beta$ 
 \\[0.2cm]
-gibt, die folgenden Bedingungen erfüllt sind:
+gibt, die folgenden Bedingungen erf\"ullt sind:
 \begin{enumerate}
 \item $\neg( \alpha \Rightarrow^* \varepsilon \wedge \beta \Rightarrow^* \varepsilon)$.
 
-      Die Rümpfe zweier verschiedener Regeln derselben Variablen
-      dürfen nicht beide das leere Wort ableiten.
+      Die R\"umpfe zweier verschiedener Regeln derselben Variablen
+      d\"urfen nicht beide das leere Wort ableiten.
 \item $\textsl{First}(\alpha) \cap \textsl{First}(\beta) = \{\}$.
 
-      Die Ableitungen der Rümpfe zweier verschiedener Regeln derselben Variablen
-      dürfen nicht mit dem selben Token beginnen.
+      Die Ableitungen der R\"umpfe zweier verschiedener Regeln derselben Variablen
+      d\"urfen nicht mit dem selben Token beginnen.
 \item   $(\beta  \Rightarrow^* \varepsilon) \rightarrow \textsl{First}(\alpha) \cap
 \textsl{Follow}(\textsl{a}) = \{\}$.
 
-      Wenn $\beta$ den leeren String ableitet, dann müssen die Mengen
+      Wenn $\beta$ den leeren String ableitet, dann m\"ussen die Mengen
       $\textsl{First}(\alpha)$ und $\textsl{Follow}(\textsl{a})$ disjunkt sein.  
       \eox
 \end{enumerate}
@@ -584,15 +584,15 @@ gibt, die folgenden Bedingungen erfüllt sind:
 \noindent
 Wir diskutieren nun die Idee, die hinter der obigen Definition steht.
 \begin{enumerate}
-\item Falls das leere Wort sowohl über die Regel
+\item Falls das leere Wort sowohl \"uber die Regel
       \\[0.2cm]
       \hspace*{1.3cm}
-      $\textsl{a} \rightarrow \alpha$ \quad als auch über \quad $\textsl{a} \rightarrow \beta$
+      $\textsl{a} \rightarrow \alpha$ \quad als auch \"uber \quad $\textsl{a} \rightarrow \beta$
       \\[0.2cm]
-      ableitbar wäre, so wissen wir nicht, welche Regel wir anwenden sollen, wenn
-      wir ein $\textsl{a}$ ableiten sollen und das nächste Eingabe-Token ein Element der Menge
+      ableitbar w\"are, so wissen wir nicht, welche Regel wir anwenden sollen, wenn
+      wir ein $\textsl{a}$ ableiten sollen und das n\"achste Eingabe-Token ein Element der Menge
       $\textsl{Follow}(\textsl{a})$ ist.
-\item Um ein $\textsl{a}$ zu parsen und zwischen den beiden Regeln für $\textsl{a}$ unterscheiden zu können,
+\item Um ein $\textsl{a}$ zu parsen und zwischen den beiden Regeln f\"ur $\textsl{a}$ unterscheiden zu k\"onnen,
       verwenden wir das folgende Rezept:
 
       Parsen wir ein $\textsl{a}$ und ist das Lookahead-Token ein Element der Menge
@@ -608,7 +608,7 @@ Wir diskutieren nun die Idee, die hinter der obigen Definition steht.
       \\[0.2cm]
       wenn das Lookahead-Token ein Element der Menge $\textsl{First}(\beta)$ ist.
 
-      Dieses Rezept funktioniert natürlich nur, wenn die Mengen $\textsl{First}(\alpha)$
+      Dieses Rezept funktioniert nat\"urlich nur, wenn die Mengen $\textsl{First}(\alpha)$
       und $\textsl{First}(\beta)$ disjunkt sind.
 \item Das obige Rezept um ein $\textsl{a}$ zu parsen muss in dem Fall, dass $\beta$ das leere Wort
       ableitet, wie folgt erweitert werden.
@@ -620,13 +620,13 @@ Wir diskutieren nun die Idee, die hinter der obigen Definition steht.
       $\textsl{a} \rightarrow \beta$.
      
       Damit diese Regel nicht im Widerspruch zu den unter Punkt 2.~genannten Regeln steht,
-      benötigen wir die Bedingungen
+      ben\"otigen wir die Bedingungen
       \\[0.2cm]
       \hspace*{1.3cm}
       $(\beta  \Rightarrow^* \varepsilon) \rightarrow \textsl{First}(\alpha) \cap \textsl{Follow}(\textsl{a}) = \{\}.$ 
 \end{enumerate}
 Insgesamt versuchen wir also dann mit einer Regel $\textsl{a} \rightarrow \alpha$ zu reduzieren,
-wenn eine der beiden folgenden Bedingungen erfüllt ist.  In diesen Bedingungen bezeichnet
+wenn eine der beiden folgenden Bedingungen erf\"ullt ist.  In diesen Bedingungen bezeichnet
 \textsl{lat} das Lookahead-Token.
 \begin{enumerate}
 \item $\textsl{lat} \in \textsl{First}(\alpha)$ \quad oder
@@ -638,8 +638,8 @@ Falls eine Grammatik $G$ links-rekursiv ist, dann kann $G$ keine LL(1)-Grammatik
 
 
 \subsection{Berechnung der Parse-Tabelle}
-Nach diesen Vorbereitungen können wir nun zu einer LL(1)-Grammatik die \emph{Parse-Tabelle}
-berechnen.  Für eine Grammatik $G = \langle V, T, R, S \rangle$ ist die Parse-Tabelle
+Nach diesen Vorbereitungen k\"onnen wir nun zu einer LL(1)-Grammatik die \emph{Parse-Tabelle}
+berechnen.  F\"ur eine Grammatik $G = \langle V, T, R, S \rangle$ ist die Parse-Tabelle
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{parseTable}: V \times T \rightarrow 2^R$,
@@ -650,8 +650,8 @@ einem Token $t$ die Menge aller Regeln der Form
 \hspace*{1.3cm}
 $\textsl{a} \rightarrow \alpha$
 \\[0.2cm]
-zuordnet, die bei einer Ableitung von $\textsl{a}$ in Frage kommen, wenn das nächste zu lesenden Token den
-Wert $t$ hat.  Diese Funktion genügt den folgenden beiden Bedingungen:
+zuordnet, die bei einer Ableitung von $\textsl{a}$ in Frage kommen, wenn das n\"achste zu lesenden Token den
+Wert $t$ hat.  Diese Funktion gen\"ugt den folgenden beiden Bedingungen:
 \begin{enumerate}
 \item Ist  $\textsl{a} \rightarrow \alpha$ eine Regel der Grammatik und ist $t$ ein Token aus der Menge 
       $\textsl{First}(\alpha)$, dann ist diese Regel ein Element der Menge
@@ -671,14 +671,14 @@ Wert $t$ hat.  Diese Funktion genügt den folgenden beiden Bedingungen:
        \;\Rightarrow\; (\textsl{a} \rightarrow \alpha) \in \textsl{parseTable}(\textsl{a},t)$.
 \end{enumerate}
 Eine Grammatik ist genau dann eine $LL(1)$-Grammatik, wenn die Menge
-$\textsl{parseTable}(\textsl{a},t)$ für jede syntaktische Variable $\textsl{a}$ und jedes Token $t$ maximal
-eine Regel enthält:
+$\textsl{parseTable}(\textsl{a},t)$ f\"ur jede syntaktische Variable $\textsl{a}$ und jedes Token $t$ maximal
+eine Regel enth\"alt:
 \\[0.2cm]
 \hspace*{1.3cm} $G$ ist LL(1) \quad g.d.w. \quad  
 $\forall \textsl{a} \in V: \forall t \in T: \textsl{card}\bigl(\textsl{parseTable}(\textsl{a},t)\bigr) \leq 1$.
 \\[0.2cm]
-Falls die Menge $\textsl{parseTable}(\textsl{a},t)$ leer ist, so heißt dies einfach, dass wir beim
-Parsen von $\textsl{a}$ nicht auf das Token $t$ stoßen können.  Parsen wir also ein $\textsl{a}$ und sehen
+Falls die Menge $\textsl{parseTable}(\textsl{a},t)$ leer ist, so hei{\ss}t dies einfach, dass wir beim
+Parsen von $\textsl{a}$ nicht auf das Token $t$ sto{\ss}en k\"onnen.  Parsen wir also ein $\textsl{a}$ und sehen
 als erstes Zeichen das Token $t$, so muss ein Syntax-Fehler vorliegen.  
 
 \section{LL(k)-Grammatiken}
@@ -712,14 +712,14 @@ als erstes Zeichen das Token $t$, so muss ein Syntax-Fehler vorliegen.
 
   \end{minipage}}}
   \end{center}
-  \caption{Arithmetische Ausdrücke mit Funktions-Aufrufen.}
+  \caption{Arithmetische Ausdr\"ucke mit Funktions-Aufrufen.}
   \label{fig:Expr4}
 \end{figure}
 
 \noindent
 Viele interessante Grammatiken sind keine $LL(1)$-Grammatiken.
-Abbildung \ref{fig:Expr4} zeigt ein Beispiel.  Bei dieser Grammatik werden für arithmetische
-Ausdrücke auch Funktionsaufrufe der Form
+Abbildung \ref{fig:Expr4} zeigt ein Beispiel.  Bei dieser Grammatik werden f\"ur arithmetische
+Ausdr\"ucke auch Funktionsaufrufe der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $f(a_1, \cdots, a_n)$
@@ -731,12 +731,12 @@ unterscheiden ist.  Dadurch gibt es zwischen den beiden Regeln
 $\textsl{factor} \rightarrow \textsc{Identifier}$ \quad und \quad
 $\textsl{factor} \rightarrow \textsc{Identifier} \quoted{(} \textsl{argList} \quoted{)}$ 
 \\[0.2cm]
-einen Konflikt:  Soll ein \textsl{factor} geparst werden und ist das nächste zu lesende Zeichen ein 
+einen Konflikt:  Soll ein \textsl{factor} geparst werden und ist das n\"achste zu lesende Zeichen ein 
 \textsc{Identifier}, so ist nicht klar, welche der beiden Regeln angewendet werden soll.
-Es gibt hier zwei mögliche Lösungen:  Einerseits könnten wir die Grammatik durch eine
-Links-Faktorisierung umschreiben.  Andererseits ist es auch möglich, das Problem dadurch zu lösen,
-dass wir bei der Entscheidung, welche der Grammatik-Regeln verwendet werden soll, zusätzlich das
-zweite Zeichen berücksichtigen:  Handelt es sich dabei um das Zeichen $\quoted{(}$, so ist offenbar die Regel
+Es gibt hier zwei m\"ogliche L\"osungen:  Einerseits k\"onnten wir die Grammatik durch eine
+Links-Faktorisierung umschreiben.  Andererseits ist es auch m\"oglich, das Problem dadurch zu l\"osen,
+dass wir bei der Entscheidung, welche der Grammatik-Regeln verwendet werden soll, zus\"atzlich das
+zweite Zeichen ber\"ucksichtigen:  Handelt es sich dabei um das Zeichen $\quoted{(}$, so ist offenbar die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{factor} \rightarrow \textsc{Identifier} \quoted{(} \textsl{argList} \quoted{)}$ 
@@ -750,7 +750,7 @@ verwendet werden.
 
 Im allgemeinen Fall kann das Verfahren so erweitert werden, dass $k$ Token bei der Entscheidung,
 welche Regel zu verwenden ist, als Lookahead herangezogen werden.  
-Wir skizzieren die Grundzüge dieser Theorie.
+Wir skizzieren die Grundz\"uge dieser Theorie.
 Als erstes verallgemeinern wir die Definition der Funktion $\textsl{First}()$.  
 
 \begin{Definition}[$\textsl{First}(k,\alpha)$]
@@ -759,9 +759,9 @@ Als erstes verallgemeinern wir die Definition der Funktion $\textsl{First}()$.
   \hspace*{1.3cm}
   $\textsl{First}: \mathbb{N} \times (V \cup T)^* \rightarrow 2^{T^*}$,
   \\[0.2cm]
-  so dass $\textsl{First}(k,\alpha)$ für eine natürliche Zahl $k$ und einen String $\alpha$, der aus
+  so dass $\textsl{First}(k,\alpha)$ f\"ur eine nat\"urliche Zahl $k$ und einen String $\alpha$, der aus
   Terminalen und syntaktischen Variablen besteht, die Menge der Token-Strings berechnet, die
-  höchstens die Länge $k$ haben und die Präfix eines von $\alpha$ abgeleiteten Strings sind.  Formal
+  h\"ochstens die L\"ange $k$ haben und die Pr\"afix eines von $\alpha$ abgeleiteten Strings sind.  Formal
   lautet die Definition:
   \\[0.2cm]
   \hspace*{1.3cm}
@@ -771,8 +771,8 @@ Als erstes verallgemeinern wir die Definition der Funktion $\textsl{First}()$.
 \end{Definition}
 
 \example
-Abbildung \ref{fig:expr-id.g} zeigt eine Grammatik für arithmetische Ausdrücke.
-Berechnen wir für die in dieser Grammatik auftretenden Variablen $v$ die Mengen
+Abbildung \ref{fig:expr-id.g} zeigt eine Grammatik f\"ur arithmetische Ausdr\"ucke.
+Berechnen wir f\"ur die in dieser Grammatik auftretenden Variablen $v$ die Mengen
 $\textsl{First}(2,v)$, so erhalten wir beispielsweise:
 \begin{enumerate}
 \item $\textsl{First}(2, \textsl{expr}) = 
@@ -810,7 +810,7 @@ $\textsl{First}(2,v)$, so erhalten wir beispielsweise:
 
   \end{minipage}}}
   \end{center}
-  \caption{Eine Beispiel-Grammatik für arithmetische Ausdrücke.}
+  \caption{Eine Beispiel-Grammatik f\"ur arithmetische Ausdr\"ucke.}
   \label{fig:expr-id.g}
 \end{figure}
 
@@ -821,10 +821,10 @@ $\textsl{First}(2,v)$, so erhalten wir beispielsweise:
   \hspace*{1.3cm}
   $\textsl{Follow}: \mathbb{N} \times V \rightarrow 2^{T^*}$,
   \\[0.2cm]
-  so dass $\textsl{Follow}(k,\textsl{a})$ für eine natürliche Zahl $k$ und eine syntaktische
+  so dass $\textsl{Follow}(k,\textsl{a})$ f\"ur eine nat\"urliche Zahl $k$ und eine syntaktische
   Variable $\textsl{a}$ die Menge der Token-Strings berechnet, die
-  höchstens die Länge $k$ haben und in einer Ableitung, die vom Start-Symbol $S$ ausgeht,
-  auf $\textsl{a}$ folgen können.  Formal
+  h\"ochstens die L\"ange $k$ haben und in einer Ableitung, die vom Start-Symbol $S$ ausgeht,
+  auf $\textsl{a}$ folgen k\"onnen.  Formal
   lautet die Definition:
   \\[0.2cm]
   \hspace*{1.3cm}
@@ -834,7 +834,7 @@ $\textsl{First}(2,v)$, so erhalten wir beispielsweise:
 \end{Definition}
 
 \example
-Setzen wir das letzte Beispiel sinngemäß fort, so erhalten wir:
+Setzen wir das letzte Beispiel sinngem\"a{\ss} fort, so erhalten wir:
 \begin{enumerate}
 \item $\textsl{Follow}(2, \textsl{expr}) = 
       \bigl\{\, \varepsilon,\, 
@@ -887,7 +887,7 @@ Setzen wir das letzte Beispiel sinngemäß fort, so erhalten wir:
 
 \begin{Definition}[Starke $LL(k)$-Grammatik]
   Eine kontextfreie Grammatik $G = \langle V, T, R, S \rangle$ ist eine 
-  \emph{starke $LL(k)$-Grammatik} genau dann, wenn für je zwei verschiedene Grammatik-Regeln
+  \emph{starke $LL(k)$-Grammatik} genau dann, wenn f\"ur je zwei verschiedene Grammatik-Regeln
   \\[0.2cm]
   \hspace*{1.3cm}
   $\textsl{a} \rightarrow \beta$ \quad und \quad $\textsl{a} \rightarrow \gamma$
@@ -898,52 +898,52 @@ Setzen wir das letzte Beispiel sinngemäß fort, so erhalten wir:
   $\forall \sigma, \tau \in \textsl{Follow}(k, \textsl{a}): 
    \textsl{First}(k, \beta \sigma) \cap \textsl{First}(k, \gamma \tau) = \{\}$
   \\[0.2cm]
-  erfüllt ist. \eox
+  erf\"ullt ist. \eox
 \end{Definition}
 
 \noindent
-\textbf{Erklärung}:  Um die obige Definition zu verstehen, nehmen wir an, wir wollten ein $\textsl{a}$ parsen.
-Wenn wir einen $LL(k)$-Parser bauen wollen, dürfen wir die nächsten $k$ Symbole der Eingabe lesen
-und müssen entscheiden, welche der Regeln von $\textsl{a}$ in Frage kommen.  Diese $k$ Symbole können das
+\textbf{Erkl\"arung}:  Um die obige Definition zu verstehen, nehmen wir an, wir wollten ein $\textsl{a}$ parsen.
+Wenn wir einen $LL(k)$-Parser bauen wollen, d\"urfen wir die n\"achsten $k$ Symbole der Eingabe lesen
+und m\"ussen entscheiden, welche der Regeln von $\textsl{a}$ in Frage kommen.  Diese $k$ Symbole k\"onnen das
 Resultat der Ableitung von $\beta$ oder $\gamma$ sein.  Wenn die von $\beta$ oder $\gamma$
-abgeleiteten Strings kürzer als $k$ sind, so kann es sich aber auch schon um Token
+abgeleiteten Strings k\"urzer als $k$ sind, so kann es sich aber auch schon um Token
 handeln, die in einer Ableitung auf $\textsl{a}$ folgen, die also Elemente der Menge
-$\textsl{Follow}(k,\textsl{a})$ sind.  Für eine Regel
+$\textsl{Follow}(k,\textsl{a})$ sind.  F\"ur eine Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{a} \rightarrow \beta$
 \\[0.2cm]
 und einen String $\sigma \in \textsl{Follow}(k,\textsl{a})$
-enthält die Menge $\textsl{First}(k, \beta \sigma)$ alle die Strings der Länge
+enth\"alt die Menge $\textsl{First}(k, \beta \sigma)$ alle die Strings der L\"ange
 $\leq k$, die in einer Ableitung von $\textsl{a}$, welche die Regel $\textsl{a} \rightarrow \beta$ benutzt,
-folgen können.  Sind diese Mengen für verschiedene Regeln disjunkt, so lässt sich anhand der
+folgen k\"onnen.  Sind diese Mengen f\"ur verschiedene Regeln disjunkt, so l\"asst sich anhand der
 $k$ folgenden Token entscheiden, welche der Regeln angewendet werden muss.
 \vspace*{0.2cm}
 
 \noindent
 \textbf{Bemerkung}:
 In der theoretischen Informatik gibt es neben dem Begriff der \emph{starken} $LL(k)$-Grammatik auch
-noch den Begriff der (einfachen) $LL(k)$-Grammatik.  Bei einer solchen $LL(k)$-Grammatik dürfen bei
-der Auswahl der Regel nicht nur die nächsten $k$ Eingabe-Token berücksichtigt werden, sondern
-zusätzlich kann der Parser alle bisher gelesenen Token mit zu Rate ziehen.  
-Dadurch kann in bestimmten Fällen zu gegebener Variable und gegebenem Lookahead auch dann
-noch eine Regel ausgewählt werden, wenn das Kriterium der starken $LL(k)$-Grammatik nicht
-erfüllt ist.
+noch den Begriff der (einfachen) $LL(k)$-Grammatik.  Bei einer solchen $LL(k)$-Grammatik d\"urfen bei
+der Auswahl der Regel nicht nur die n\"achsten $k$ Eingabe-Token ber\"ucksichtigt werden, sondern
+zus\"atzlich kann der Parser alle bisher gelesenen Token mit zu Rate ziehen.  
+Dadurch kann in bestimmten F\"allen zu gegebener Variable und gegebenem Lookahead auch dann
+noch eine Regel ausgew\"ahlt werden, wenn das Kriterium der starken $LL(k)$-Grammatik nicht
+erf\"ullt ist.
 Da dieser Begriff
 wesentlich komplexer ist als der Begriff der
 starken $LL(k)$-Grammatik, verzichten wir auf eine formale Darstellung des
 allgemeineren Begriffs.  
-Die dem allgemeineren Begriff zu Grunde liegende Theorie ist sehr ausführlich in
+Die dem allgemeineren Begriff zu Grunde liegende Theorie ist sehr ausf\"uhrlich in
 \cite{aho:72} dargestellt. 
 
 \subsection{Berechnung von $\textsl{First}()$ und $\textsl{Follow}()$}
 In diesem Abschnitt zeigen wir, wir die Funktionen $\textsl{First}(k, \alpha)$ und
-$\textsl{Follow}(k, \textsl{a})$ berechnet werden können.  Dazu benötigen wir verschiedene
+$\textsl{Follow}(k, \textsl{a})$ berechnet werden k\"onnen.  Dazu ben\"otigen wir verschiedene
 Hilfsfunktionen, die wir vorab definieren.
 \begin{enumerate}
-\item Die Funktion $\textsl{prefix}(k, w)$ berechnet für eine natürliche Zahl $k$
-      und einen String $w$ den Präfix von $w$ mit der Länge $k$.  Ist die Länge von $w$
-      kleiner oder gleich $k$, so wird $w$ zurück gegeben:
+\item Die Funktion $\textsl{prefix}(k, w)$ berechnet f\"ur eine nat\"urliche Zahl $k$
+      und einen String $w$ den Pr\"afix von $w$ mit der L\"ange $k$.  Ist die L\"ange von $w$
+      kleiner oder gleich $k$, so wird $w$ zur\"uck gegeben:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{prefix}(k, w) = \left\{
@@ -956,8 +956,8 @@ Hilfsfunktionen, die wir vorab definieren.
       \\[0.2cm]
       Hier bezeichnet die Notation $w[1\!:\!k]$ den Teilstring von $w$, der 
       aus den ersten $k$ Buchstaben von $w$ besteht.
-\item Der Operator $+_k$ verkettet zwei Strings und bildet anschließend das Päfix der
-      Länge $k$:
+\item Der Operator $+_k$ verkettet zwei Strings und bildet anschlie{\ss}end das P\"afix der
+      L\"ange $k$:
       \\[0.2cm]
       \hspace*{1.3cm}
       $v +_k w = \textsl{prefix}(k, vw)$.
@@ -983,27 +983,27 @@ $. \qed
 \vspace*{0.2cm}
 
 \noindent
-Die Berechnung von $\textsl{First}(k,\alpha)$ für $\alpha \in (V \cup T)^*$ wird auf die
-Berechnung von $\textsl{First}(k, X)$ mit $X \in V \cup T$ zurück geführt,
+Die Berechnung von $\textsl{First}(k,\alpha)$ f\"ur $\alpha \in (V \cup T)^*$ wird auf die
+Berechnung von $\textsl{First}(k, X)$ mit $X \in V \cup T$ zur\"uck gef\"uhrt,
 denn es gilt
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{First}(k, X_1 X_2 \cdots X_n) = 
  \textsl{First}(k, X_1) +_k \textsl{First}(k, X_2) +_k \cdots +_k \textsl{First}(k, X_n)$.
 \\[0.2cm]
-Für ein Terminal $t \in T$ gilt offenbar
+F\"ur ein Terminal $t \in T$ gilt offenbar
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{First}(k, t) = \{ t \}$.
 \\[0.2cm]
-Die Berechnung der Menge $\textsl{First}(k, \textsl{a})$ für eine syntaktische Variable $\textsl{a} \in V$
-erfolgt iterativ über folgenden Fixpunkt-Algorithmus:
+Die Berechnung der Menge $\textsl{First}(k, \textsl{a})$ f\"ur eine syntaktische Variable $\textsl{a} \in V$
+erfolgt iterativ \"uber folgenden Fixpunkt-Algorithmus:
 \begin{enumerate}
-\item Zunächst werden alle Mengen $\textsl{First}(k, \textsl{a})$ mit der leeren Menge initialisiert:
+\item Zun\"achst werden alle Mengen $\textsl{First}(k, \textsl{a})$ mit der leeren Menge initialisiert:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{First}(k, \textsl{a}) := \{\}$.
-\item Anschließend wird für jede Grammatik-Regel der Form 
+\item Anschlie{\ss}end wird f\"ur jede Grammatik-Regel der Form 
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{a} \rightarrow \beta$
@@ -1012,47 +1012,47 @@ erfolgt iterativ über folgenden Fixpunkt-Algorithmus:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{First}(k, \textsl{a}) := \textsl{First}(k, \textsl{a}) \cup \textsl{First}(k,\beta)$.
-\item Der zweite Schritt wird in einer Schleife solange durchgeführt, bis sich keine
+\item Der zweite Schritt wird in einer Schleife solange durchgef\"uhrt, bis sich keine
       der Mengen $\textsl{First}(k, \textsl{a})$ mehr durch die Hinzunahme von
-      $\textsl{First}(k,\beta)$ ändert.
+      $\textsl{First}(k,\beta)$ \"andert.
 \end{enumerate}
-Sind die Mengen $\textsl{First}(k, \textsl{a})$ berechnet, so können wir anschließend die Mengen 
-$\textsl{Follow}(k, \textsl{a})$ für alle syntaktischen Variablen berechnen.  Auch die Berechnung
+Sind die Mengen $\textsl{First}(k, \textsl{a})$ berechnet, so k\"onnen wir anschlie{\ss}end die Mengen 
+$\textsl{Follow}(k, \textsl{a})$ f\"ur alle syntaktischen Variablen berechnen.  Auch die Berechnung
 der Mengen $\textsl{Follow}(k, \textsl{a})$ ist iterativ.  Sie erfolgt nach dem folgenden
 Schema:
 \begin{enumerate}
-\item Zunächst werden alle Mengen $\textsl{Follow}(k, \textsl{a})$ mit der leeren Menge initialisiert:
+\item Zun\"achst werden alle Mengen $\textsl{Follow}(k, \textsl{a})$ mit der leeren Menge initialisiert:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{Follow}(k, \textsl{a}) = \{\}$.
       \\[0.2cm]
-      Anschließend setzen wir für das Start-Symbol $S$ der Grammatik
+      Anschlie{\ss}end setzen wir f\"ur das Start-Symbol $S$ der Grammatik
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{Follow}(k, S) = \{ \symbol{36} \}$.
       \\[0.2cm]
-      Hier steht ``$\symbol{36}$'' für das Ende der Eingabe.  Die Idee ist, dass hinter dem
+      Hier steht ``$\symbol{36}$'' f\"ur das Ende der Eingabe.  Die Idee ist, dass hinter dem
       Start-Symbol keine weitere Eingabe mehr kommen kann.  Beachten Sie, dass in diesem
       Fall der String ``$\symbol{36}$'' nicht aus $k$ Zeichen besteht, sondern nur aus
       einem Zeichen.
-\item Für jede Grammatik-Regel der Form
+\item F\"ur jede Grammatik-Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{a} \rightarrow Y_1 Y_2 \cdots Y_l$,
       \\[0.2cm]
-      für die $Y_l$ eine syntaktische Variable ist, erweitern wir die Menge
+      f\"ur die $Y_l$ eine syntaktische Variable ist, erweitern wir die Menge
       $\textsl{Follow}(k, Y_l)$ wie folgt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{Follow}(k, Y_l) := \textsl{Follow}(k, Y_l) \cup \textsl{Follow}(k, \textsl{a})$,
       \\[0.2cm]
       denn alles, was auf ein $\textsl{a}$ folgen kann, kann auch auf ein $Y_l$ folgen.
-\item Für jede Grammatik-Regel der Form
+\item F\"ur jede Grammatik-Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{a} \rightarrow Y_1 Y_2 \cdots Y_i Y_{i+1} \cdots Y_l$,
       \\[0.2cm]
-      und jeden Index $i \in \{1, \cdots, l-1\}$, für den $Y_i$ eine syntaktische Variable
+      und jeden Index $i \in \{1, \cdots, l-1\}$, f\"ur den $Y_i$ eine syntaktische Variable
       ist, erweitern wir die Menge $\textsl{Follow}(k, Y_i)$ wie folgt:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -1060,14 +1060,14 @@ Schema:
        \bigl(\textsl{First}(k, Y_{i+1} \cdots Y_l) +_k \textsl{Follow}(k,\textsl{a})\bigr) 
       $.
       \\[0.2cm]
-      Der Grund, warum wir hier noch die Menge $\textsl{Follow}(k,\textsl{a})$ anhängen ist der,
+      Der Grund, warum wir hier noch die Menge $\textsl{Follow}(k,\textsl{a})$ anh\"angen ist der,
       dass die Strings aus  der Menge $\textsl{First}(k, Y_{i+1} \cdots Y_l)$ eventuell
-      kürzer als $k$ sind.  In diesem Fall müssen noch die Präfixe von
-      $\textsl{Follow}(k, \textsl{a})$ angehängt werden.
+      k\"urzer als $k$ sind.  In diesem Fall m\"ussen noch die Pr\"afixe von
+      $\textsl{Follow}(k, \textsl{a})$ angeh\"angt werden.
 
       \textbf{Bemerkung}:  Beachten Sie, dass der zweite Schritt ein Spezialfall des
       dritten Schritts ist, denn wenn wir im dritten Schritt $i := l$ setzen, dann ist
-      der String $Y_{i+1} \cdots Y_l$ leer und somit enthält die Menge
+      der String $Y_{i+1} \cdots Y_l$ leer und somit enth\"alt die Menge
       $\textsl{First}(k, Y_{i+1}\cdots Y_l)$ dann nur den leeren String $\varepsilon$, so
       dass der Ausdruck
       \\[0.2cm]
@@ -1077,8 +1077,8 @@ Schema:
       \\[0.2cm]
       vereinfacht werden kann.  Bei der Implementierung werden wir daher nur den dritten
       Schritt umsetzen.
-\item Der zweite und der dritte Schritt werden in einer Schleife solange durchgeführt, bis sich keine
-      der Mengen $\textsl{Follow}(k, \textsl{a})$ mehr ändert.
+\item Der zweite und der dritte Schritt werden in einer Schleife solange durchgef\"uhrt, bis sich keine
+      der Mengen $\textsl{Follow}(k, \textsl{a})$ mehr \"andert.
 \end{enumerate}
 
 \subsection{Implementation in \textsc{SetlX}}

--- a/Lecture-Notes/lr-parser.tex
+++ b/Lecture-Notes/lr-parser.tex
@@ -1,16 +1,16 @@
 \section{SLR-Parser}
-In diesem Abschnitt zeigen wir, wie wir für eine gegebene kontextfreie Grammatik $G$ 
+In diesem Abschnitt zeigen wir, wie wir f\"ur eine gegebene kontextfreie Grammatik $G$ 
 die im letzten Abschnitt verwendeten Funktionen 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{action}: Q \times T \rightarrow \textsl{Action}$ \quad and \quad $\textsl{goto}: Q \times V \rightarrow Q$
 \\[0.2cm]
-berechnen können.  Dazu klären wir als erstes, welche Informationen die in der Menge $Q$ enthaltenen Zustände 
-enthalten sollen.  Wir werden diese Zustände so definieren, dass sie die Information enthalten,
+berechnen k\"onnen.  Dazu kl\"aren wir als erstes, welche Informationen die in der Menge $Q$ enthaltenen Zust\"ande 
+enthalten sollen.  Wir werden diese Zust\"ande so definieren, dass sie die Information enthalten,
 welche Regel der Shift-Reduce-Parser anzuwenden versucht, welcher Teil der rechten Seite einer Grammatik-Regel 
 bereits erkannt worden ist und was noch erwartet wird.  Zu diesem Zweck definieren wir den Begriff
 einer \emph{markierten Regel}.   In der englischen Originalliteratur \cite{knuth:65} wird hier
-unglücklicherweise der inhaltsleere Begriff ``\emph{item}'' verwendet.
+ungl\"ucklicherweise der inhaltsleere Begriff ``\emph{item}'' verwendet.
 
 \begin{Definition}[markierte Regel]
   Eine \emph{markierte Regel} einer Grammatik $G = \langle V, T, R, s \rangle$ ist ein Tripel
@@ -18,7 +18,7 @@ unglücklicherweise der inhaltsleere Begriff ``\emph{item}'' verwendet.
   \hspace*{1.3cm}
   $\langle a, \beta, \gamma \rangle$,
   \\[0.2cm]
-  für das gilt
+  f\"ur das gilt
   \\[0.2cm]
   \hspace*{1.3cm}
   $(a \rightarrow \beta \gamma) \in R$.
@@ -30,65 +30,65 @@ unglücklicherweise der inhaltsleere Begriff ``\emph{item}'' verwendet.
 \end{Definition}
 
 \noindent
-Die markierte Regel $a \rightarrow \beta \bullet \gamma$ drückt aus, dass der Parser versucht,
+Die markierte Regel $a \rightarrow \beta \bullet \gamma$ dr\"uckt aus, dass der Parser versucht,
 mit der Regel $a \rightarrow \beta \gamma$ ein $a$ zu parsen, dabei schon $\beta$ gesehen
-hat und als nächstes versucht, $\gamma$ zu erkennen.  Das Zeichen $\bullet$ markiert also die
+hat und als n\"achstes versucht, $\gamma$ zu erkennen.  Das Zeichen $\bullet$ markiert also die
 Position innerhalb der rechten Seite der Regel, bis zu der wir die rechte Seite der Regel
 schon gelesen haben.
-Die Idee ist jetzt, dass wir die Zustände eines SLR-Parsers als Mengen von markierten Regeln
-darstellen können.  Um diese Idee zu verschaulichen, betrachten wir ein konkretes Beispiel:
+Die Idee ist jetzt, dass wir die Zust\"ande eines SLR-Parsers als Mengen von markierten Regeln
+darstellen k\"onnen.  Um diese Idee zu verschaulichen, betrachten wir ein konkretes Beispiel:
 Wir gehen von der in Abbildung \ref{fig:Expr.grammar} auf Seite \pageref{fig:Expr.grammar}
 gezeigten Grammatik aus, wobei wir diese Grammatik noch um ein neues Start-Symbol $\widehat{s}$
 und die Regel
 \\[0.2cm]
 \hspace*{1.3cm} $\widehat{s} \rightarrow  \textsl{expr}\;\textsc{Eof}$
 \\[0.2cm]
-erweitern.  Der Start-Zustand enthält offenbar die markierte Regel
+erweitern.  Der Start-Zustand enth\"alt offenbar die markierte Regel
 \\[0.2cm]
 \hspace*{1.3cm} $\widehat{s} \rightarrow \varepsilon \bullet \textsl{expr}\, \textsc{Eof}$,
 \\[0.2cm]
 denn am Anfang versuchen wir ja, das Start-Symbol $\widehat{s}$ herzuleiten.  Die Komponente
-$\varepsilon$ drückt aus, dass wir bisher noch nichts verarbeitet haben.  Neben dieser
-markierten Regel muss der Start-Zustand dann außerdem die markierten Regeln
+$\varepsilon$ dr\"uckt aus, dass wir bisher noch nichts verarbeitet haben.  Neben dieser
+markierten Regel muss der Start-Zustand dann au{\ss}erdem die markierten Regeln
 \begin{enumerate}
 \item $\textsl{expr} \rightarrow \varepsilon \bullet \textsl{expr} \quoted{+} \textsl{product}$,
 \item $\textsl{expr} \rightarrow \varepsilon \bullet \textsl{expr} \quoted{-} \textsl{product}$
       \qquad und
 \item $\textsl{expr} \rightarrow \varepsilon \bullet \textsl{product}$
 \end{enumerate}
-enthalten, denn es könnte ja beispielsweise sein, dass wir die Regel
+enthalten, denn es k\"onnte ja beispielsweise sein, dass wir die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{expr} \rightarrow \textsl{expr} \quoted{+} \textsl{product}$
 \\[0.2cm]  
-verwenden müssen, um die gesuchte \textsl{expr} herzuleiten.  Genauso gut könnte es natürlich sein,
+verwenden m\"ussen, um die gesuchte \textsl{expr} herzuleiten.  Genauso gut k\"onnte es nat\"urlich sein,
 dass wir statt dessen die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{expr} \rightarrow \textsl{product}$
 \\[0.2cm]
-benutzen müssen.  Das erklärt, warum wir die markierte Regel
+benutzen m\"ussen.  Das erkl\"art, warum wir die markierte Regel
 \\[0.2cm]
 \hspace*{1.3cm}
  $\textsl{expr} \rightarrow \varepsilon \bullet \textsl{product}$
 \\[0.2cm]
-in den Start-Zustand aufnehmen müssen, denn 
-da wir am Anfang noch gar nicht wissen können, welche Regel wir benötigen, muss
+in den Start-Zustand aufnehmen m\"ussen, denn 
+da wir am Anfang noch gar nicht wissen k\"onnen, welche Regel wir ben\"otigen, muss
 der Start-Zustand daher alle diese Regeln enthalten.  Haben wir erst die markierte Regel
 \\[0.2cm]
 \hspace*{1.3cm}
  $\textsl{expr} \rightarrow \varepsilon \bullet \textsl{product}$ 
 \\[0.2cm]
-zum Start-Zustand hinzugefügt, so sehen wir, dass wir eventuell als nächstes ein $\textsl{product}$
-lesen müssen.  Daher sehen wir,  dass der Start-Zustand außerdem noch die folgenden markierten
-Regeln enthält:  
+zum Start-Zustand hinzugef\"ugt, so sehen wir, dass wir eventuell als n\"achstes ein $\textsl{product}$
+lesen m\"ussen.  Daher sehen wir,  dass der Start-Zustand au{\ss}erdem noch die folgenden markierten
+Regeln enth\"alt:  
 \begin{enumerate}
 \item[4.] $\textsl{product} \rightarrow \bullet\; \textsl{product} \quoted{*} \textsl{factor}$,
 \item[5.] $\textsl{product} \rightarrow \bullet\; \textsl{product} \quoted{/} \textsl{factor}$,
 \item[6.] $\textsl{product} \rightarrow \bullet\; \textsl{factor}$,
 
           Nun zeigt die sechste Regel, dass wir eventuell als erstes einen \textsl{factor}
-          lesen werden.  Daher fügen wir zu dem Start-Zustand auch die folgenden beiden markierten
+          lesen werden.  Daher f\"ugen wir zu dem Start-Zustand auch die folgenden beiden markierten
           Regeln hinzu: 
 \item[7.] $\textsl{factor} \rightarrow \bullet \quoted{(} \textsl{expr} \quoted{)}$,
 \item[8.] $\textsl{factor} \rightarrow \bullet\; \textsc{Number}$.
@@ -100,11 +100,11 @@ Regeln.
 
 \begin{Definition}[$\textsl{closure}(\mathcal{M})$]
   Es sei $\mathcal{M}$ eine Menge markierter Regeln.  Dann definieren wir den \emph{Abschluss} dieser Menge
-  als die kleinste Menge $\mathcal{K}$ markierter Regeln, für die folgendes gilt:
+  als die kleinste Menge $\mathcal{K}$ markierter Regeln, f\"ur die folgendes gilt:
   \begin{enumerate}
   \item $\mathcal{M} \subseteq \mathcal{K}$,
 
-        der Abschluss umfasst also die ursprüngliche Regel-Menge.
+        der Abschluss umfasst also die urspr\"ungliche Regel-Menge.
   \item Ist einerseits
         \\[0.2cm]
         \hspace*{1.3cm}
@@ -138,21 +138,21 @@ Regeln.
 \noindent
 \textbf{Bemerkung}: Wenn Sie sich an den Earley-Algorithmus erinnern, dann sehen Sie, dass bei der
 Berechnung des Abschlusses dieselbe Berechnung wie bei der Vorhersage-Operation
-des  Earley-Algorithmus durchgeführt wird.  \eox
+des  Earley-Algorithmus durchgef\"uhrt wird.  \eox
 \vspace*{0.3cm}
 
 \noindent
-Für eine gegebene Menge $\mathcal{M}$ von markierten Regeln, kann die Berechnung von
+F\"ur eine gegebene Menge $\mathcal{M}$ von markierten Regeln, kann die Berechnung von
 $\mathcal{K} := \textsl{closure}(\mathcal{M})$ iterativ erfolgen:
 \begin{enumerate}
-\item Zunächst setzen wir $\mathcal{K} := \mathcal{M}$.
-\item Anschließend suchen wir alle Regeln der Form
+\item Zun\"achst setzen wir $\mathcal{K} := \mathcal{M}$.
+\item Anschlie{\ss}end suchen wir alle Regeln der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $a \rightarrow \beta \bullet c\, \delta$
       \\[0.2cm]
-      aus der Menge $\mathcal{K}$, für die $c$ eine syntaktische Variable ist und fügen dann
-      für alle Regeln der Form $c \rightarrow \gamma$ die neue markierte Regel
+      aus der Menge $\mathcal{K}$, f\"ur die $c$ eine syntaktische Variable ist und f\"ugen dann
+      f\"ur alle Regeln der Form $c \rightarrow \gamma$ die neue markierte Regel
       \\[0.2cm]
       \hspace*{1.3cm}
       $c \rightarrow \bullet\gamma$
@@ -170,7 +170,7 @@ die Menge
 \[ \mathcal{M} := 
    \bigl\{ \textsl{product} \rightarrow \textsl{product} \quoted{*}\! \bullet \textsl{factor} \bigr\}
 \]
-Für die Menge $\textsl{closure}(\mathcal{M})$ finden wir dann
+F\"ur die Menge $\textsl{closure}(\mathcal{M})$ finden wir dann
 \\[0.2cm]
 \hspace*{1.3cm}
 $ 
@@ -186,23 +186,23 @@ $
 
 
 \noindent
-Unser Ziel ist es, für eine gegebene kontextfreie Grammatik $G = \langle V, T, R, s \rangle$ einen
+Unser Ziel ist es, f\"ur eine gegebene kontextfreie Grammatik $G = \langle V, T, R, s \rangle$ einen
 Shift-Reduce-Parser 
 \\[0.2cm]
 \hspace*{1.3cm}
 $P = \langle Q, q_0, \textsl{action}, \textsl{goto} \rangle$
 \\[0.2cm]
-zu definieren.  Um dieses Ziel zu erreichen, müssen wir uns als erstes überlegen,
-wie wir die Menge $Q$ der Zustände definieren wollen, denn dann funktioniert die Definition der
-restlichen Komponenten fast von alleine.  Die Idee ist, dass wir die Zustände
+zu definieren.  Um dieses Ziel zu erreichen, m\"ussen wir uns als erstes \"uberlegen,
+wie wir die Menge $Q$ der Zust\"ande definieren wollen, denn dann funktioniert die Definition der
+restlichen Komponenten fast von alleine.  Die Idee ist, dass wir die Zust\"ande
 als Mengen von markierten Regeln definieren.
-Wir definieren zunächst
+Wir definieren zun\"achst
 \\[0.2cm]
 \hspace*{1.3cm}
 $\Gamma := \bigl\{ a \rightarrow \beta \bullet \gamma \mid (a \rightarrow \alpha \gamma) \in R \bigr\}$
 \\[0.2cm]
 als die Menge aller markierten Regeln der Grammatik.  Nun ist es allerdings nicht sinnvoll,
-beliebige Teilmengen von $\Gamma$ als Zustände zuzulassen:  Eine Teilmenge $\mathcal{M}
+beliebige Teilmengen von $\Gamma$ als Zust\"ande zuzulassen:  Eine Teilmenge $\mathcal{M}
 \subseteq \Gamma$ kommt nur dann als Zustand in Betracht, wenn die Menge $\mathcal{M}$ unter
 der Funktion $\textsl{closure}()$ \emph{abgeschlossen} ist, wenn also
 $\textsl{closure}(\mathcal{M}) = \mathcal{M}$ gilt.  Wir definieren daher
@@ -211,12 +211,12 @@ $\textsl{closure}(\mathcal{M}) = \mathcal{M}$ gilt.  Wir definieren daher
 $Q := \bigl\{ \mathcal{M} \in 2^\Gamma \mid \textsl{closure}(\mathcal{M}) = \mathcal{M} \bigr\}$.
 \\[0.2cm]
 Die Interpretation der Mengen $\mathcal{M} \in Q$ ist die, dass ein Zustand $\mathcal{M}$ genau die
-markierten Grammatik-Regeln enthält, die in der durch den Zustand beschriebenen Situation
-angewendet werden können.
+markierten Grammatik-Regeln enth\"alt, die in der durch den Zustand beschriebenen Situation
+angewendet werden k\"onnen.
 
 
 Zur Vereinfachung der folgenden Konstruktionen erweitern wir die
-Grammatik $G = \langle V, T, R, s \rangle$ durch Einführung eines neuen Start-Symbols $\widehat{s}$
+Grammatik $G = \langle V, T, R, s \rangle$ durch Einf\"uhrung eines neuen Start-Symbols $\widehat{s}$
 und eines neuen Tokens \textsc{Eof} zu der Grammatik 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -224,15 +224,15 @@ $\widehat{G} =
  \Bigl\langle V \cup \{ \widehat{s} \}, T \cup \{\textsc{Eof}\}, R \cup \{ \widehat{s} \rightarrow s\, \textsc{Eof} \}, \widehat{s} \Bigr\rangle
 $.
 \\[0.2cm]
-Das Token \textsc{Eof} steht dabei als Abkürzung für \emph{\underline{e}end \underline{o}f \underline{f}ile}.
+Das Token \textsc{Eof} steht dabei als Abk\"urzung f\"ur \emph{\underline{e}end \underline{o}f \underline{f}ile}.
 Die Grammatik $\widehat{G}$ bezeichnen wir als die \emph{augmentierte Grammatik}.  Die Verwendung der
-augmentierten Grammatik ermöglicht die nun folgende Definition des Start-Zustands.
-Wir setzen nämlich:
+augmentierten Grammatik erm\"oglicht die nun folgende Definition des Start-Zustands.
+Wir setzen n\"amlich:
 \\[0.2cm]
 \hspace*{1.3cm}
 $ q_0 := \textsl{closure}\Bigl( \bigl\{ \widehat{s} \rightarrow \bullet s\,\textsc{Eof} \bigr\} \Bigr)$.
 \\[0.2cm]
-Als nächstes konstruieren wir die Funktion $\textsl{goto}()$.  Die Definition lautet:
+Als n\"achstes konstruieren wir die Funktion $\textsl{goto}()$.  Die Definition lautet:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{goto}(\mathcal{M}, c) := \textsl{closure}\Bigl( \bigl\{ 
@@ -248,12 +248,12 @@ der Teilstring $\beta$ erkannt wurde.  Dieser Zustand wird durch die markierte R
 $a \rightarrow \beta \bullet c\, \delta$ 
 \\[0.2cm] 
 beschrieben.  Wird nun ein $c$ erkannt, so kann der Parser von dem Zustand, der die 
-Regel $a \rightarrow \beta \bullet c\, \delta$ enthält in einen Zustand, der die Regel 
+Regel $a \rightarrow \beta \bullet c\, \delta$ enth\"alt in einen Zustand, der die Regel 
 $a \rightarrow \beta\, c \bullet \delta$ 
-enthält, übergehen.  Daher erhalten wir die oben angegebene Definition der Funktion $\textsl{goto}(\mathcal{M},c)$.
-Für die gleich folgende Definition der Funktion $\textsl{action}(\mathcal{M}, t)$ ist es
-nützlich, die Definition der Funktion $\textsl{goto}$ auf Terminale zu erweitern.  
-Für Terminale $t \in T$ setzen wir:
+enth\"alt, \"ubergehen.  Daher erhalten wir die oben angegebene Definition der Funktion $\textsl{goto}(\mathcal{M},c)$.
+F\"ur die gleich folgende Definition der Funktion $\textsl{action}(\mathcal{M}, t)$ ist es
+n\"utzlich, die Definition der Funktion $\textsl{goto}$ auf Terminale zu erweitern.  
+F\"ur Terminale $t \in T$ setzen wir:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{goto}(\mathcal{M}, t) := \textsl{closure}\Bigl( \bigl\{ 
@@ -261,38 +261,38 @@ $\textsl{goto}(\mathcal{M}, t) := \textsl{closure}\Bigl( \bigl\{
    \bigr\} \Bigr)
 $.
 \\[0.2cm]
-Als Letztes spezifizieren wir, wie die Funktion $\textsl{action}(\mathcal{M},t)$ für eine Menge von
+Als Letztes spezifizieren wir, wie die Funktion $\textsl{action}(\mathcal{M},t)$ f\"ur eine Menge von
 markierten Regeln $\mathcal{M}$ und ein Token $t$ berechnet wird.  
-Bei der Definition von $\textsl{action}(\mathcal{M},t)$ unterscheiden wir vier Fälle.
+Bei der Definition von $\textsl{action}(\mathcal{M},t)$ unterscheiden wir vier F\"alle.
 \pagebreak
 
 \begin{enumerate}
 \item Falls $\mathcal{M}$ eine markierte Regel der Form $a \rightarrow \beta \bullet t\, \delta$
-      enthält, setzen wir
+      enth\"alt, setzen wir
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{action}(\mathcal{M},t) := \langle \texttt{shift}, \textsl{goto}(\mathcal{M},t) \rangle$,
       \\[0.2cm]
       denn in diesem Fall versucht der Parser ein $a$ mit Hilfe der Regel $a \rightarrow \beta\, t \delta$
       zu erkennen und hat von der rechten Seite dieser Regel bereits $\beta$ erkannt.
-      Ist nun das nächste Token im Eingabe-String tatsächlich das Token $t$, so kann der Parser
+      Ist nun das n\"achste Token im Eingabe-String tats\"achlich das Token $t$, so kann der Parser
       dieses $t$ lesen und geht dabei von dem Zustand $a \rightarrow \beta \bullet t\, \delta$ in den Zustand 
-      $a \rightarrow \beta\, t \bullet \delta$ über, der von der Funktion $\textsl{goto}(\mathcal{M},t)$
+      $a \rightarrow \beta\, t \bullet \delta$ \"uber, der von der Funktion $\textsl{goto}(\mathcal{M},t)$
       berechnet wird.  Insgesamt haben wir also
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{action}(\mathcal{M},t) := \langle \texttt{shift}, \textsl{goto}(\mathcal{M},t) \rangle
          \quad \mbox{falls} \quad (a \rightarrow \beta \bullet t\, \delta) \in \mathcal{M}
       $.
-\item Falls $\mathcal{M}$ eine markierte Regel der Form $a \rightarrow \beta \bullet$ enthält
-      und wenn zusätzlich $t \in \textsl{Follow}(a)$ gilt, dann setzen wir
+\item Falls $\mathcal{M}$ eine markierte Regel der Form $a \rightarrow \beta \bullet$ enth\"alt
+      und wenn zus\"atzlich $t \in \textsl{Follow}(a)$ gilt, dann setzen wir
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{action}(\mathcal{M},t) := \langle \texttt{reduce}, a \rightarrow \beta \rangle$,
       \\[0.2cm]
       denn in diesem Fall versucht der Parser ein $a$ mit Hilfe der Regel $a \rightarrow \beta$
-      zu erkennen und hat bereits $\beta$ erkannt. Ist nun das nächste Token im Eingabe-String das Token
-      $t$ und ist darüber hinaus $t$ ein Token, dass auf $a$ folgen kann, gilt also 
+      zu erkennen und hat bereits $\beta$ erkannt. Ist nun das n\"achste Token im Eingabe-String das Token
+      $t$ und ist dar\"uber hinaus $t$ ein Token, dass auf $a$ folgen kann, gilt also 
       $t \in \textsl{Follow}(a)$, so kann der Parser die Regel $a \rightarrow \beta$ anwenden und den
       Symbol-Stack mit dieser Regel reduzieren.  Wir haben dann
       \\[0.2cm]
@@ -301,14 +301,14 @@ Bei der Definition von $\textsl{action}(\mathcal{M},t)$ unterscheiden wir vier F
       \quad falls 
       $(a \rightarrow \beta\bullet) \in \mathcal{M}$, $a \not= \widehat{s}$ 
       und $t \in \textsl{Follow}(a)$ gilt.
-\item Falls $\mathcal{M}$ die markierte Regel $\widehat{s} \rightarrow s \bullet \textsc{Eof}$ enthält und
-      wir den zu parsenden String vollständig gelesen haben, setzen wir
+\item Falls $\mathcal{M}$ die markierte Regel $\widehat{s} \rightarrow s \bullet \textsc{Eof}$ enth\"alt und
+      wir den zu parsenden String vollst\"andig gelesen haben, setzen wir
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{action}(\mathcal{M},\textsc{Eof}) := \texttt{accept}$,
       \\[0.2cm]
       denn in diesem Fall versucht der Parser, $\widehat{s}$ mit Hilfe der Regel $\widehat{s} \rightarrow s\,\textsc{Eof}$
-      zu erkennen und hat also bereits $s$ erkannt. Ist nun das nächste Token im Eingabe-String 
+      zu erkennen und hat also bereits $s$ erkannt. Ist nun das n\"achste Token im Eingabe-String 
       das Datei-Ende-Zeichen \textsc{Eof}, 
       so liegt der zu parsende String in der durch die Grammatik $G$ spezifizierten Sprache
       $L(G)$.  Wir haben daher
@@ -316,7 +316,7 @@ Bei der Definition von $\textsl{action}(\mathcal{M},t)$ unterscheiden wir vier F
       \hspace*{1.3cm}
       $\textsl{action}(\mathcal{M},\textsc{Eof}) := \texttt{accept}$,
       \quad falls $(\widehat{s} \rightarrow s\bullet\textsc{Eof}) \in \mathcal{M}$.
-\item In den restlichen Fällen setzen wir
+\item In den restlichen F\"allen setzen wir
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{action}(\mathcal{M},t) := \texttt{error}$.
@@ -325,20 +325,20 @@ Zwischen den ersten beiden Regeln kann es Konflikte geben.
 Wir unterscheiden zwischen zwei Arten von Konflikten.
 \begin{enumerate}
 \item Ein \textsl{Shift-Reduce-Konflikt} tritt auf, wenn sowohl der erste Fall als auch der zweite Fall
-      vorliegt.   In diesem Fall enthält die Menge $\mathcal{M}$ also zum einen eine markierte Regel
+      vorliegt.   In diesem Fall enth\"alt die Menge $\mathcal{M}$ also zum einen eine markierte Regel
       der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $a \rightarrow \beta \bullet t\, \gamma$,
       \\[0.2cm]
-      zum anderen enthält $\mathcal{M}$ eine Regel der Form
+      zum anderen enth\"alt $\mathcal{M}$ eine Regel der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $c \rightarrow \delta \bullet$ \quad mit $t \in \textsl{follow}(c)$.
       \\[0.2cm]
-      Wenn dann das nächste Token den Wert $t$ hat, ist nicht klar, ob dieses Token auf den Symbol-Stack 
+      Wenn dann das n\"achste Token den Wert $t$ hat, ist nicht klar, ob dieses Token auf den Symbol-Stack 
       geschoben und der Parser in einen Zustand mit der markierten Regel 
-      $a \rightarrow \beta\, t \bullet \gamma$ übergehen soll, oder ob statt dessen der Symbol-Stack mit 
+      $a \rightarrow \beta\, t \bullet \gamma$ \"ubergehen soll, oder ob statt dessen der Symbol-Stack mit 
       der Regel $c \rightarrow \delta$ reduziert werden muss.
 \item Eine \textsl{Reduce-Reduce-Konflikt} liegt vor, wenn die Menge $\mathcal{M}$ zwei verschiedene
       markierte Regeln der Form
@@ -346,36 +346,36 @@ Wir unterscheiden zwischen zwei Arten von Konflikten.
       \hspace*{1.3cm}
       $c_1 \rightarrow \gamma_1 \bullet$ \quad  und \quad $c_2 \rightarrow \gamma_2 \bullet$
       \\[0.2cm]
-      enthält und wenn gleichzeitig $t \in \textsl{Follow}(c_1) \cap \textsl{Follow}(c_2)$ ist,
+      enth\"alt und wenn gleichzeitig $t \in \textsl{Follow}(c_1) \cap \textsl{Follow}(c_2)$ ist,
       denn dann ist nicht klar, welche
-      der beiden Regeln der Parser anwenden soll, wenn das nächste zu lesende Token den Wert $t$ hat.
+      der beiden Regeln der Parser anwenden soll, wenn das n\"achste zu lesende Token den Wert $t$ hat.
 \end{enumerate}
 Falls einer dieser beiden Konflikte auftritt, dann sagen wir, dass die Grammatik keine
 SLR-Grammatik ist.  Eine solche Grammatik kann mit Hilfe eines SLR-Parsers nicht geparst
-werden.  Wir werden später noch Beispiele für die beiden Arten von Konflikten angeben, aber
-zunächst wollen wir eine Grammatik untersuchen, bei der keine Konflikte auftreten und wollen für
-diese Grammatik die Funktionen $\textsl{goto}()$ und $\textsl{action}()$ auch tatsächlich
+werden.  Wir werden sp\"ater noch Beispiele f\"ur die beiden Arten von Konflikten angeben, aber
+zun\"achst wollen wir eine Grammatik untersuchen, bei der keine Konflikte auftreten und wollen f\"ur
+diese Grammatik die Funktionen $\textsl{goto}()$ und $\textsl{action}()$ auch tats\"achlich
 berechnen.  Wir nehmen als Grundlage die  in Abbildung
 \ref{fig:Expr.grammar} gezeigte Grammatik.
 Da die syntaktische Variable \textsl{expr} auf der rechten Seite von
-Grammatik-Regeln auftritt, definieren wir \textsl{start} als neues Start-Symbol und fügen
+Grammatik-Regeln auftritt, definieren wir \textsl{start} als neues Start-Symbol und f\"ugen
 in der Grammatik die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{start} \rightarrow \textsl{expr}\; \textsc{Eof}$
 \\[0.2cm]
-ein.  Dieser Schritt entspricht dem früher diskutierten \emph{Augmentieren} der Grammatik.
-Als erstes berechnen wir die Menge der Zustände $Q$.  Wir hatten dafür oben die
+ein.  Dieser Schritt entspricht dem fr\"uher diskutierten \emph{Augmentieren} der Grammatik.
+Als erstes berechnen wir die Menge der Zust\"ande $Q$.  Wir hatten daf\"ur oben die
 folgende Formel angegeben:
 \\[0.2cm]
 \hspace*{1.3cm}
 $Q := \bigl\{ \mathcal{M} \in 2^\Gamma \mid \textsl{closure}(\mathcal{M}) = \mathcal{M} \bigr\}$.
 \\[0.2cm]
-Diese Menge enthält allerdings auch Zustände, die von dem Start-Zustand über die Funktion
-$\textsl{goto}()$ gar nicht erreicht werden können.  Wir berechnen daher nur die Zustände,
-die sich auch tatsächlich vom Start-Zustand mit Hilfe der Funktion $\textsl{goto}()$
-erreichen lassen.  Damit die Rechnung nicht zu unübersichtlich
-wir führen wir die folgenden Abkürzungen ein:
+Diese Menge enth\"alt allerdings auch Zust\"ande, die von dem Start-Zustand \"uber die Funktion
+$\textsl{goto}()$ gar nicht erreicht werden k\"onnen.  Wir berechnen daher nur die Zust\"ande,
+die sich auch tats\"achlich vom Start-Zustand mit Hilfe der Funktion $\textsl{goto}()$
+erreichen lassen.  Damit die Rechnung nicht zu un\"ubersichtlich
+wir f\"uhren wir die folgenden Abk\"urzungen ein:
 \\[0.2cm]
 \hspace*{1.3cm}
 $s := \textsl{start},\; e := \textsl{expr},\; p := \textsl{product},\; 
@@ -567,7 +567,7 @@ s_{15} & := & \textsl{goto}(s_{8}, p) \\
 \end{array}
 $
 \end{enumerate}
-Weitere Rechnungen führen nicht mehr auf neue Zustände.  Berechnen wir beispielsweise
+Weitere Rechnungen f\"uhren nicht mehr auf neue Zust\"ande.  Berechnen wir beispielsweise
 $\textsl{goto}(s_8, \quoted{(})$, so finden wir
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -588,18 +588,18 @@ $
 \end{array}
 $
 \\[0.2cm]
-Damit ist die Menge der Zustände des Shift-Reduce-Parsers durch
+Damit ist die Menge der Zust\"ande des Shift-Reduce-Parsers durch
 \\[0.2cm]
 \hspace*{1.3cm}
 $ Q := \{ s_0, s_1, s_2, s_3, s_4, s_5, s_6, s_7, s_8, s_9, s_{10}, s_{11}, s_{12}, s_{13}, s_{14}, s_{15} \} $
 \\[0.2cm]
-gegeben.  Wir untersuchen als nächstes, ob es Konflikte gibt und betrachten exemplarisch die 
+gegeben.  Wir untersuchen als n\"achstes, ob es Konflikte gibt und betrachten exemplarisch die 
 Menge $s_{15}$.  Aufgrund der markierten Regel 
 \\[0.2cm]
 \hspace*{1.3cm}
 $ p \rightarrow p \bullet \quoted{*} f $
 \\[0.2cm]
-muss im Zustand $s_{15}$ geshiftet werden, wenn das nächste Token den Wert $\quoted{*}$ hat.
+muss im Zustand $s_{15}$ geshiftet werden, wenn das n\"achste Token den Wert $\quoted{*}$ hat.
 Auf der anderen Seite beinhaltet der Zustand $s_{15}$ die Regel
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -607,7 +607,7 @@ $ e \rightarrow e \quoted{+} p \bullet. $
 \\[0.2cm]
 Diese Regel sagt, dass der Symbol-Stack mit der Grammatik-Regel $e \rightarrow e \quoted{+} p$ reduziert
 werden muss, falls in der Eingabe ein Zeichen aus der Menge $\textsl{Follow}(e)$ auftritt.
-Falls nun $\squoted{*} \in \textsl{Follow}(e)$ liegen würde, so hätten wir einen Shift-Reduce-Konflikt.
+Falls nun $\squoted{*} \in \textsl{Follow}(e)$ liegen w\"urde, so h\"atten wir einen Shift-Reduce-Konflikt.
 Es gilt aber 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -617,8 +617,8 @@ und daraus folgt $\squoted{*} \not\in \textsl{Follow}(e)$, so dass hier kein Shi
 vorliegt.  Eine Untersuchung der anderen Mengen zeigt, dass dort ebenfalls keine Shift-Reduce- oder
 Reduce-Reduce-Konflikte auftreten.
 
-Als nächstes berechnen wir die Funktion $\textsl{action}$.  Wir betrachten exemplarisch
-zwei Fälle.
+Als n\"achstes berechnen wir die Funktion $\textsl{action}$.  Wir betrachten exemplarisch
+zwei F\"alle.
 \begin{enumerate}
 \item Als erstes berechnen wir $\textsl{action}(s_1, \quoted{+})$.  Es gilt
       \\[0.2cm]
@@ -632,7 +632,7 @@ zwei Fälle.
       $
 \\[0.2cm]
       denn wir haben $\squoted{+} \in \textsl{Follow}(P)$.
-\item Als nächstes berechnen wir  $\textsl{action}(s_4, \quoted{+})$.  Es gilt
+\item Als n\"achstes berechnen wir  $\textsl{action}(s_4, \quoted{+})$.  Es gilt
       \\[0.2cm]
 \hspace*{1.3cm}
 $ 
@@ -647,15 +647,15 @@ $
       $
 \\[0.2cm]
 \end{enumerate}
-Würden wir diese Rechnungen fortführen, so würden wir die Tabelle \ref{tab:action} erhalten, denn 
-wir haben die Namen der Zustände so gewählt, dass diese mit den Namen der entsprechenden Zustände
-in den Tabellen \ref{tab:action} und \ref{tab:goto} übereinstimmen.
+W\"urden wir diese Rechnungen fortf\"uhren, so w\"urden wir die Tabelle \ref{tab:action} erhalten, denn 
+wir haben die Namen der Zust\"ande so gew\"ahlt, dass diese mit den Namen der entsprechenden Zust\"ande
+in den Tabellen \ref{tab:action} und \ref{tab:goto} \"ubereinstimmen.
 
 \exercise
-Berechnen Sie die Menge der SLR-Zustände für die in Abbildung \ref{fig:BoolExpr.grammar} gezeigte
+Berechnen Sie die Menge der SLR-Zust\"ande f\"ur die in Abbildung \ref{fig:BoolExpr.grammar} gezeigte
 Grammatik und geben Sie die Funktionen $\textsl{action}$ und $\textsl{goto}$ an.
-Kürzen Sie die Namen der syntaktischen Variablen und Terminale mit $s$, $c$, $d$, $l$ und $I$
-ab, wobei $s$ für das neu eingeführte Start-Symbol steht.  \eox
+K\"urzen Sie die Namen der syntaktischen Variablen und Terminale mit $s$, $c$, $d$, $l$ und $I$
+ab, wobei $s$ f\"ur das neu eingef\"uhrte Start-Symbol steht.  \eox
 \vspace*{0.2cm}
 
 \begin{figure}[htbp]
@@ -675,7 +675,7 @@ ab, wobei $s$ für das neu eingeführte Start-Symbol steht.  \eox
 
   \end{minipage}}}
   \end{center}
-  \caption{Eine Grammatik für Boole'sche Ausdrücke in konjunktiver Normalform.}
+  \caption{Eine Grammatik f\"ur Boole'sche Ausdr\"ucke in konjunktiver Normalform.}
   \label{fig:BoolExpr.grammar}
 \end{figure}
 
@@ -684,9 +684,9 @@ ab, wobei $s$ für das neu eingeführte Start-Symbol steht.  \eox
 In diesem Abschnitt untersuchen wir Shift-Reduce- und Reduce-Reduce-Konflikte genauer und betrachten
 dazu zwei Beispiele.  Das erste Beispiel zeigt einen Shift-Reduce-Konflikt.
 Die in Abbildung \ref{fig:shift-reduce-conflict.grammar} gezeigte Grammatik ist mehrdeutig, denn sie
-legt nicht fest, ob der Operator $\squoted{+}$ stärker oder schwächer bindet als der Operator
-$\squoted{*}$:  Interpretieren wir das Nicht-Terminal $N$ als eine Abküzung für \textsc{Number},
-so können wir mit dieser Grammatik den Ausdruck $1 + 2 * 3$ sowohl als
+legt nicht fest, ob der Operator $\squoted{+}$ st\"arker oder schw\"acher bindet als der Operator
+$\squoted{*}$:  Interpretieren wir das Nicht-Terminal $N$ als eine Abk\"uzung f\"ur \textsc{Number},
+so k\"onnen wir mit dieser Grammatik den Ausdruck $1 + 2 * 3$ sowohl als
 \\[0.2cm]
 \hspace*{1.3cm}
 $(1 + 2) * 3$ \quad als auch als \quad $1 + (2 *3)$ \quad 
@@ -715,7 +715,7 @@ lesen.
   \label{fig:shift-reduce-conflict.grammar}
 \end{figure}
 
-Wir berechnen zunächst den Start-Zustand $s_0$.
+Wir berechnen zun\"achst den Start-Zustand $s_0$.
 \\[0.2cm]
 \hspace*{1.3cm}
 $\begin{array}[t]{lcl}
@@ -728,7 +728,7 @@ $\begin{array}[t]{lcl}
  \end{array}
 $
 \\[0.2cm] 
-Als nächstes berechnen wir $s_1 := \textsl{goto}(s_0, e)$:
+Als n\"achstes berechnen wir $s_1 := \textsl{goto}(s_0, e)$:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\begin{array}[t]{lcl}
@@ -759,7 +759,7 @@ $
 \end{array}
 $
 \\[0.2cm] 
-Als nächstes berechnen wir $s_3 := \textsl{goto}(s_2, e)$:
+Als n\"achstes berechnen wir $s_3 := \textsl{goto}(s_2, e)$:
 \\[0.2cm]
 \hspace*{1.3cm}
 $ 
@@ -787,7 +787,7 @@ dass das Token $\squoted{*}$ auf den Stack geschoben wird, andererseits haben wi
 \hspace*{1.3cm}
 $\textsl{Follow}(e) = \{ \;\squoted{+}, \;\squoted{*}, \;\squoted{\symbol{36}}\; \}$, 
 \\[0.2cm]
-so dass, falls das nächste zu lesende Token den Wert $\squoted{*}$ hat, der Symbol-Stack mit der
+so dass, falls das n\"achste zu lesende Token den Wert $\squoted{*}$ hat, der Symbol-Stack mit der
 Regel 
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -797,16 +797,16 @@ reduziert werden sollte.
 
 \exercise
 Bei der in Abbildung \ref{fig:shift-reduce-conflict.grammar} gezeigten Grammatik treten noch weitere
-Shift-Reduce-Konflikte auf.  Berechnen Sie alle Zustände und geben Sie dann die restlichen
+Shift-Reduce-Konflikte auf.  Berechnen Sie alle Zust\"ande und geben Sie dann die restlichen
 Shift-Reduce-Konflikte an. \eox
 \vspace*{0.3cm}
 
 \noindent
 \textbf{Bemerkung}: Es ist nicht weiter verwunderlich, dass wir bei der oben angegebenen
 Grammatik einen Konflikt gefunden haben, denn diese Grammatik ist nicht eindeutig.
-Demgegenüber kann gezeigt werden, dass jede SLR-Grammatik eindeutig sein muss.  Folglich
+Demgegen\"uber kann gezeigt werden, dass jede SLR-Grammatik eindeutig sein muss.  Folglich
 ist eine mehrdeutige Grammatik niemals eine SLR-Grammatik.  Die Umkehrung dieser Aussage gilt
-jedoch nicht.  Dies werden wir im nächsten Beispiel sehen.
+jedoch nicht.  Dies werden wir im n\"achsten Beispiel sehen.
 \eox
 \pagebreak
 
@@ -833,7 +833,7 @@ jedoch nicht.  Dies werden wir im nächsten Beispiel sehen.
   \label{fig:reduce-reduce-conflict.grammar}
 \end{figure}
 
-Wir untersuchen als nächstes eine Grammatik, die keine SLR-Grammatik ist, weil
+Wir untersuchen als n\"achstes eine Grammatik, die keine SLR-Grammatik ist, weil
 Reduce-Reduce-Konflikte auftreten.  
 Wir betrachten dazu die in Abbildung \ref{fig:reduce-reduce-conflict.grammar}
 gezeigte Grammatik.   Diese Grammatik ist eindeutig, denn es gilt
@@ -841,11 +841,11 @@ gezeigte Grammatik.   Diese Grammatik ist eindeutig, denn es gilt
 \hspace*{1.3cm}
 $L(s) = \{\; \squoted{xy}, \;\squoted{yx} \;\}$
 \\[0.2cm]
-und der String \qote{xy} lässt sich nur mit der Regel $s \rightarrow  a \quoted{x} a \quoted{y}$
-herleiten, während sich der String \qote{yx} nur mit der Regel 
-$s \rightarrow b \quoted{y} b \quoted{x}$ erzeugen lässt.
-Um zu zeigen, dass diese Grammatik Shift-Reduce-Konflikte enthält,
-berechnen wir den Start-Zustand eines SLR-Parsers für diese Grammatik.
+und der String \qote{xy} l\"asst sich nur mit der Regel $s \rightarrow  a \quoted{x} a \quoted{y}$
+herleiten, w\"ahrend sich der String \qote{yx} nur mit der Regel 
+$s \rightarrow b \quoted{y} b \quoted{x}$ erzeugen l\"asst.
+Um zu zeigen, dass diese Grammatik Shift-Reduce-Konflikte enth\"alt,
+berechnen wir den Start-Zustand eines SLR-Parsers f\"ur diese Grammatik.
 \\[0.2cm]
 $\hspace*{1.3cm}
 \begin{array}[t]{lcl}
@@ -882,7 +882,7 @@ auf, denn wir haben
 $\textsl{Follow}(a) = \bigl\{ \squoted{x}, \squoted{y} \bigr\} = \textsl{Follow}(b)$.
 \\[0.2cm]
 und damit ist dann nicht klar, mit welcher dieser Regeln der Parser die Eingabe im Zustand $s_0$
-reduzieren soll, wenn das nächste gelesene Token den Wert $\squoted{x}$ hat, denn dieses Token ist
+reduzieren soll, wenn das n\"achste gelesene Token den Wert $\squoted{x}$ hat, denn dieses Token ist
 sowohl ein Element der Menge $\textsl{Follow}(a)$ als auch der Menge $\textsl{Follow}(b)$.
 
 Es ist interessant zu bemerken, dass die obige Grammatik die $LL(1)$-Eigenschaft hat, denn es gilt
@@ -898,7 +898,7 @@ $\textsl{First}(a \quoted{x} a \quoted{y}) \cap \textsl{First}(b \quoted{y} b \q
  \{ \squoted{x} \} \cap \{ \squoted{y} \} = \{\}. 
 $
 \\[0.2cm]
-Dieses Beispiel zeigt, dass SLR-Grammatiken im Allgemeinen nicht ausdruckstärker sind als
+Dieses Beispiel zeigt, dass SLR-Grammatiken im Allgemeinen nicht ausdruckst\"arker sind als
 LL(1)-Grammatiken.  In der Praxis zeigt sich jedoch, dass viele Grammatiken, die nicht die
 LL(1)-Eigenschaft haben, SLR-Grammatiken sind.
 
@@ -912,7 +912,7 @@ action table of a given grammar. \eox
 
 \section{Kanonische LR-Parser}
 Der Reduce-Reduce-Konflikt, der in der in Abbildung \ref{fig:reduce-reduce-conflict.grammar}
-gezeigten Grammatik auftritt, kann wie folgt gelöst werden:  In dem Zustand
+gezeigten Grammatik auftritt, kann wie folgt gel\"ost werden:  In dem Zustand
 \\[0.2cm]
 \hspace*{1.3cm}
 $
@@ -934,9 +934,9 @@ $s \rightarrow \bullet\, a \quoted{x} a \quoted{y} \quad \mbox{und} \quad
  s \rightarrow \bullet\, b \quoted{y} b \quoted{x}$.
 \\[0.2cm]
 Bei der ersten Regel ist klar, dass auf das erste $a$ ein $\squoted{x}$ folgen muss, bei der zweiten Regel
-sehen wir, dass auf das erste $b$ ein $\squoted{y}$ folgt.  Diese Information geht über die Information
+sehen wir, dass auf das erste $b$ ein $\squoted{y}$ folgt.  Diese Information geht \"uber die Information
 hinaus, die in den Mengen $\textsl{Follow}(a)$ bzw.~$\textsl{Follow}(b)$ enthalten ist, denn jetzt
-berücksichtigen wir den Kontext, in dem die syntaktische Variable auftaucht.  Damit können wir die
+ber\"ucksichtigen wir den Kontext, in dem die syntaktische Variable auftaucht.  Damit k\"onnen wir die
 Funktion $\textsl{action}(s_0, \squoted{x})$ und $\textsl{action}(s_0, \squoted{y})$ wie folgt definieren:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -944,12 +944,12 @@ $\textsl{action}(s_0, \squoted{x}) = \langle \texttt{reduce}, a \rightarrow \var
 \quad \mbox{und} \quad 
 $\textsl{action}(s_0, \squoted{y}) = \langle \texttt{reduce}, b \rightarrow \varepsilon \rangle$. 
 \\[0.2cm]
-Durch diese Definition wird der Reduce-Reduce-Konflikt gelöst.  Die zentrale Idee ist,
+Durch diese Definition wird der Reduce-Reduce-Konflikt gel\"ost.  Die zentrale Idee ist,
 bei der Berechnung des Abschlusses den Kontext, in dem eine Regel auftritt, mit einzubeziehen.
-Dazu erweitern wir zunächst die Definition einer markierten Regel.
+Dazu erweitern wir zun\"achst die Definition einer markierten Regel.
 
 \begin{Definition}[erweiterte markierte Regel]
-  Eine \emph{erweiterte markierte Regel} (abgekürzt: \emph{e.m.R.}) einer Grammatik 
+  Eine \emph{erweiterte markierte Regel} (abgek\"urzt: \emph{e.m.R.}) einer Grammatik 
   $G = \langle V, T, R, s \rangle$ ist ein Quadrupel 
   \\[0.2cm]
   \hspace*{1.3cm}
@@ -980,24 +980,24 @@ in dem folgendes gilt:
       erkennen.
 \item Dabei wurde bereits $\beta$ erkannt.  Damit die Regel $a \rightarrow \beta \gamma$
       angewendet werden kann, muss nun  $\gamma$ erkannt werden.
-\item Wir wissen zusätzlich, dass auf die syntaktische Variable $a$ ein Token aus der Menge $L$
+\item Wir wissen zus\"atzlich, dass auf die syntaktische Variable $a$ ein Token aus der Menge $L$
       folgen muss.
 
       Die Menge $L$ bezeichnen wir daher als die Menge der \emph{Folge-Token}.
 \end{enumerate}
 
-Mit erweiterten markierten Regeln arbeitet sich ganz ähnlich wie mit markierten Regeln, allerdings
-müssen wir die Definitionen der Funktionen $\textsl{closure}$, $\textsl{goto}$ und $\textsl{action}$
+Mit erweiterten markierten Regeln arbeitet sich ganz \"ahnlich wie mit markierten Regeln, allerdings
+m\"ussen wir die Definitionen der Funktionen $\textsl{closure}$, $\textsl{goto}$ und $\textsl{action}$
 etwas modifizieren.  Wir beginnen mit der Funktion $\textsl{closure}$.
 
 \begin{Definition}[$\textsl{closure}(\mathcal{M})$]
   Es sei $\mathcal{M}$ eine Menge erweiterter markierter Regeln.  Dann definieren wir den
   \emph{Abschluss} von $\mathcal{M}$
-  als die kleinste Menge $\mathcal{K}$ markierter Regeln, für die folgendes gilt:
+  als die kleinste Menge $\mathcal{K}$ markierter Regeln, f\"ur die folgendes gilt:
   \begin{enumerate}
   \item $\mathcal{M} \subseteq \mathcal{K}$,
 
-        der Abschluss umfasst also die ursprüngliche Regel-Menge.
+        der Abschluss umfasst also die urspr\"ungliche Regel-Menge.
   \item Ist einerseits
         \\[0.2cm]
         \hspace*{1.3cm}
@@ -1014,7 +1014,7 @@ etwas modifizieren.  Wir beginnen mit der Funktion $\textsl{closure}$.
         \hspace*{1.3cm}
         $c \rightarrow \bullet\, \gamma: \bigcup \{ \textsl{First}(\delta\, t) \mid t \in L \}$
         \\[0.2cm]
-        ein Element der Menge $\mathcal{K}$.  Die Funktion $\textsl{First}(\alpha)$ berechnet dabei für
+        ein Element der Menge $\mathcal{K}$.  Die Funktion $\textsl{First}(\alpha)$ berechnet dabei f\"ur
         einen String $\alpha \in (T \cup V)^*$ die Menge aller Token $t$, mit denen ein String
         beginnen kann, der von $\alpha$ abgeleitet worden ist.
   \end{enumerate}
@@ -1023,23 +1023,23 @@ etwas modifizieren.  Wir beginnen mit der Funktion $\textsl{closure}$.
 \end{Definition}
 
 \noindent
-\textbf{Bemerkung}:  Gegenüber der alten Definition ist nur die Berechnung der Menge
+\textbf{Bemerkung}:  Gegen\"uber der alten Definition ist nur die Berechnung der Menge
 der Folge-Token hinzu gekommen.  Der Kontext, in dem das $c$ auftritt, das mit der Regel
-$c \rightarrow \gamma$ erkannt werden soll, ist zunächst durch den String $\delta$ gegeben,
+$c \rightarrow \gamma$ erkannt werden soll, ist zun\"achst durch den String $\delta$ gegeben,
 der in der Regel $a \rightarrow \beta \bullet c\, \delta:L$ auf das $c$ folgt.
-Möglicherweise leitet $\delta$  den leeren String $\varepsilon$ ab.  In diesen Fall  
+M\"oglicherweise leitet $\delta$  den leeren String $\varepsilon$ ab.  In diesen Fall  
 spielen auch die Folge-Token aus der Menge $L$ eine Rolle, denn falls
 $\delta \Rightarrow^* \varepsilon$ gilt, kann auf das $c$ auch ein Folge-Token $t$ aus der
 Menge $L$ folgen. \hspace*{\fill} $\Box$
 \vspace*{0.1cm}
 
-Für eine gegebene e.m.R.-Menge $\mathcal{M}$ kann die Berechnung von 
+F\"ur eine gegebene e.m.R.-Menge $\mathcal{M}$ kann die Berechnung von 
 $\mathcal{K} := \textsl{closure}(\mathcal{M})$ iterativ erfolgen.  Abbildung \ref{fig:closure} zeigt die
-Berechnung von $\textsl{closure}(\mathcal{M})$.  Der wesentliche Unterschied gegenüber der
-früheren Berechnung von $\textsl{closure}()$ ist, dass wir bei den e.m.R.s, die wir für
+Berechnung von $\textsl{closure}(\mathcal{M})$.  Der wesentliche Unterschied gegen\"uber der
+fr\"uheren Berechnung von $\textsl{closure}()$ ist, dass wir bei den e.m.R.s, die wir f\"ur
 eine Variable $c$ mit in $\textsl{closure}(\mathcal{M})$ aufnehmen, bei der Menge der
-Folge-Token den Kontext berücksichtigen, in dem $c$ auftritt.
-Dadurch gelingt es,  die Zustände des Parsers präziser zu beschreiben, als dies bei
+Folge-Token den Kontext ber\"ucksichtigen, in dem $c$ auftritt.
+Dadurch gelingt es,  die Zust\"ande des Parsers pr\"aziser zu beschreiben, als dies bei
 markierten Regeln der Fall ist.
 
 \begin{figure}[!ht]
@@ -1073,8 +1073,8 @@ markierten Regeln der Fall ist.
 
 \noindent
 \textbf{Bemerkung}: Der Ausdruck $\bigcup\{\textsl{First}(\delta\,t)\mid{}t\in{}L\}$
-sieht komplizierter aus, als er tatsächlich ist.  Wollen wir diesen Ausdruck berechnen, so
-ist es zweckmäßig eine Fallunterscheidung danach durchzuführen, ob $\delta$ den leeren
+sieht komplizierter aus, als er tats\"achlich ist.  Wollen wir diesen Ausdruck berechnen, so
+ist es zweckm\"a{\ss}ig eine Fallunterscheidung danach durchzuf\"uhren, ob $\delta$ den leeren
 String $\varepsilon$ ableiten kann oder nicht, denn es gilt
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1087,25 +1087,25 @@ $\bigcup\{\textsl{First}(\delta\,t)\mid{}t\in{}L\} =
 \right.
 $
 \\[0.2cm]
-Die Berechnung von $\textsl{goto}(\mathcal{M},t)$ für eine Menge $\mathcal{M}$ von erweiterten Regeln und
-ein Zeichen $x$ ändert sich gegenüber der Berechnung im Falle einfacher markierter Regeln
-nur durch das Anfügen der Menge von \emph{Folge-Tokens}, die aber selbst unverändert bleibt:
+Die Berechnung von $\textsl{goto}(\mathcal{M},t)$ f\"ur eine Menge $\mathcal{M}$ von erweiterten Regeln und
+ein Zeichen $x$ \"andert sich gegen\"uber der Berechnung im Falle einfacher markierter Regeln
+nur durch das Anf\"ugen der Menge von \emph{Folge-Tokens}, die aber selbst unver\"andert bleibt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{goto}(\mathcal{M}, x) := \textsl{closure}\Bigl( \bigl\{ 
    a \rightarrow \beta\, x \bullet \delta:L \mid (a \rightarrow \beta \bullet x\, \delta:L) \in \mathcal{M} 
    \bigr\} \Bigr)$. 
 \\[0.2cm]
-Ähnlich wie bei der Theorie der SLR-Parser augmentieren wir unsere Grammatik $G$, indem wir
+\"Ahnlich wie bei der Theorie der SLR-Parser augmentieren wir unsere Grammatik $G$, indem wir
 der Menge der Variable eine neue Start-Variable $\widehat{s}$ und der Menge der Regeln die
-neue Regel $\widehat{s} \rightarrow s$ hinzufügen.  Weiter fügen wir den Token das Symbol
+neue Regel $\widehat{s} \rightarrow s$ hinzuf\"ugen.  Weiter f\"ugen wir den Token das Symbol
 \textsc{Eof} hinzu.  Dann hat der Start-Zustand die  Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $q_0 := \textsl{closure}\bigr(\bigl\{ \widehat{s} \rightarrow \bullet\, s:\textsc{Eof}\bigr\}\bigr)$,
 \\[0.2cm]
 denn auf das Start-Symbol muss das Datei-Ende ``\textsc{Eof}'' folgen.
-Als letztes zeigen wir, wie die Definition der Funktion $\textsl{action}()$ geändert werden muss.
+Als letztes zeigen wir, wie die Definition der Funktion $\textsl{action}()$ ge\"andert werden muss.
 Wir spezifizieren die Berechnung dieser Funktion durch die folgenden bedingten Gleichungen.
 \begin{enumerate}
 \item $(a \rightarrow \beta \bullet t\, \delta:L) \in \mathcal{M} \;\Longrightarrow\;
@@ -1118,7 +1118,7 @@ Wir spezifizieren die Berechnung dieser Funktion durch die folgenden bedingten G
 \item Sonst: \quad $\textsl{action}(\mathcal{M},t) := \texttt{error}$. 
 \end{enumerate}
 Falls es bei diesen Gleichungen zu einem Konflikt kommt, weil gleichzeitig die Bedingung
-der ersten Gleichung als auch die Bedingung der zweiten Gleichung erfüllt ist, so sprechen
+der ersten Gleichung als auch die Bedingung der zweiten Gleichung erf\"ullt ist, so sprechen
 wir wieder von einem \emph{Shift-Reduce-Konflikt}.  
 Ein Shift-Reduce-Konflikt liegt also bei der Berechnung von
 $\textsl{action}(\mathcal{M},t)$ dann vor, wenn es zwei e.m.R.s 
@@ -1132,7 +1132,7 @@ soll, oder ob statt dessen der Symbol-Stack mit der Regel $c \rightarrow \gamma$
 \vspace*{0.2cm}
 
 \noindent
-\textbf{Bemerkung}:  Gegenüber einem SLR-Parser ist die Möglichkeit von
+\textbf{Bemerkung}:  Gegen\"uber einem SLR-Parser ist die M\"oglichkeit von
 Shift-Reduce-Konflikten verringert, denn  bei einem SLR-Parser liegt bereits dann ein
 Shift-Reduce-Konflikt vor, wenn $t \in \textsl{Follow}(c)$ gilt und die Menge $L_2$ ist in der Regel kleiner als die
 Menge $\textsl{Follow}(c)$.  \eox 
@@ -1145,22 +1145,22 @@ $(a \rightarrow \beta\, \bullet:L_1) \in \mathcal{M}$ \quad \mbox{und} \quad
 $(c \rightarrow \delta\, \bullet:L_2) \in \mathcal{M}$ \quad \mbox{mit} \quad $L_1 \cap L_2 \not= \{\}$
 \\[0.2cm]
 gibt, denn dann ist nicht klar, mit welcher dieser beiden Regeln der Symbol-Stack reduziert werden soll,
-wenn das nächste Token ein Element der Schnittmenge $L_1 \cap L_2$ ist.
+wenn das n\"achste Token ein Element der Schnittmenge $L_1 \cap L_2$ ist.
 \vspace*{0.2cm}
 
 \noindent
-\textbf{Bemerkung}:  Gegenüber einem SLR-Parser ist die Möglichkeit von
+\textbf{Bemerkung}:  Gegen\"uber einem SLR-Parser ist die M\"oglichkeit von
 Reduce-Reduce-Konflikten verringert, denn  bei einem SLR-Parser liegt bereits dann ein
 Reduce-Reduce-Konflikt vor, wenn es ein $t$ in der Menge
- $\textsl{Follow}(a) \cap \textsl{Follow}(c)$ gibt und die $\textsl{Follow}$-Mengen sind oft größer als die Mengen
+ $\textsl{Follow}(a) \cap \textsl{Follow}(c)$ gibt und die $\textsl{Follow}$-Mengen sind oft gr\"o{\ss}er als die Mengen
 $L_1$ und $L_2$.  \eox
 \vspace*{0.3cm}
 
 
 \example
 Wir greifen das Beispiel der in Abbildung \ref{fig:reduce-reduce-conflict.grammar} gezeigten Grammatik
-wieder auf und berechnen zunächst die Menge aller Zustände.  Um die Schreibweise zu
-vereinfachen, schreiben wir an Stelle von ``\textsc{Eof}'' kürzer ``$\symbol{36}$''.
+wieder auf und berechnen zun\"achst die Menge aller Zust\"ande.  Um die Schreibweise zu
+vereinfachen, schreiben wir an Stelle von ``\textsc{Eof}'' k\"urzer ``$\symbol{36}$''.
 
 \begin{enumerate}
 \item $\begin{array}[t]{lcl}
@@ -1251,7 +1251,7 @@ vereinfachen, schreiben wir an Stelle von ``\textsc{Eof}'' kürzer ``$\symbol{36}
        \end{array}
        $
 \end{enumerate}
-Als nächstes untersuchen wir, ob es bei den Zuständen Konflikte gibt.
+Als n\"achstes untersuchen wir, ob es bei den Zust\"anden Konflikte gibt.
 Beim Start-Zustand $s_0$ hatten wir im letzten Abschnitt einen Reduce-Reduce-Konflikt zwischen den
 beiden Regeln $a \rightarrow \varepsilon$ und $b \rightarrow \varepsilon$ gefunden, weil 
 \\[0.2cm]
@@ -1265,11 +1265,11 @@ $a \rightarrow \bullet\,: \squoted{x}$ \quad \mbox{und} \quad
 $b \rightarrow \bullet\,: \squoted{y}$
 \\[0.2cm]
 gibt es wegen $\squoted{x} \not= \squoted{y}$ keinen Konflikt.  Es ist leicht zu sehen, dass auch bei den
-anderen Zustände keine Konflikte auftreten.
+anderen Zust\"ande keine Konflikte auftreten.
 
 
 \exercise
-Berechnen Sie die Menge der Zustände eines LR-Parsers für die folgende Grammatik:
+Berechnen Sie die Menge der Zust\"ande eines LR-Parsers f\"ur die folgende Grammatik:
   \begin{eqnarray*}
   e & \rightarrow & e \quoted{+} p           \\
     & \mid        & p                        \\[0.2cm]
@@ -1278,7 +1278,7 @@ Berechnen Sie die Menge der Zustände eines LR-Parsers für die folgende Grammatik
   f & \rightarrow & \squoted{(} e \quoted{)} \\
     & \mid        & \textsl{Number}             
   \end{eqnarray*}
-Untersuchen Sie außerdem, ob es bei dieser Grammatik Shift-Reduce-Konflikte oder
+Untersuchen Sie au{\ss}erdem, ob es bei dieser Grammatik Shift-Reduce-Konflikte oder
 Reduce-Reduce-Konflikte gibt.
 \vspace*{0.2cm}
 
@@ -1298,20 +1298,20 @@ His theory is described in the paper
 \pagebreak
 
 \section{LALR-Parser}
-Die Zahl der Zustände eines LR-Parsers ist oft erheblich größer als die Zahl der Zustände, die ein
-SLR-Parser derselben Grammatik hätte.  Beispielsweise kommt ein SLR-Parser für die
+Die Zahl der Zust\"ande eines LR-Parsers ist oft erheblich gr\"o{\ss}er als die Zahl der Zust\"ande, die ein
+SLR-Parser derselben Grammatik h\"atte.  Beispielsweise kommt ein SLR-Parser f\"ur die
 \href{https://github.com/karlstroetmann/Formal-Languages/blob/master/SetlX/Examples/c-grammar.g}{\texttt{C}-Grammatik} 
-mit 349 Zuständen aus.  Da die Sprache \texttt{C} keine SLR-Sprache ist, gibt es beim Erzeugen
-einer SLR-Parse-Tabelle für \texttt{C} allerdings eine Reihe von 
+mit 349 Zust\"anden aus.  Da die Sprache \texttt{C} keine SLR-Sprache ist, gibt es beim Erzeugen
+einer SLR-Parse-Tabelle f\"ur \texttt{C} allerdings eine Reihe von 
 \href{https://github.com/karlstroetmann/Formal-Languages/blob/master/SetlX/Examples/c-grammar-slr-table.txt}{Konflikten},
-so dass ein SLR-Parser für die Sprache \texttt{C} nicht funktioniert.  Demgegenüber kommt ein
-LR-Parser für die Sprache \texttt{C} auf 1572 Zustände, wie Sie 
+so dass ein SLR-Parser f\"ur die Sprache \texttt{C} nicht funktioniert.  Demgegen\"uber kommt ein
+LR-Parser f\"ur die Sprache \texttt{C} auf 1572 Zust\"ande, wie Sie 
 \href{https://github.com/karlstroetmann/Formal-Languages/blob/master/SetlX/Examples/c-grammar-lr-table.txt}{hier}
-sehen können.  Anfangs, als der zur Verfügung stehenden
+sehen k\"onnen.  Anfangs, als der zur Verf\"ugung stehenden
 Haupt-Speicher der meisten Rechner noch bescheidener dimensioniert waren, als dies heute
-der Fall ist, hatten LR-Parser daher eine für die Praxis problematische
-Größe.  Eine genaue Analyse der Menge der Zustände von LR-Parsern zeigte, dass es oft möglich ist, 
-bestimmte Zustände zusammen zu fassen.  Dadurch kann die Menge der Zustände in den meisten Fällen
+der Fall ist, hatten LR-Parser daher eine f\"ur die Praxis problematische
+Gr\"o{\ss}e.  Eine genaue Analyse der Menge der Zust\"ande von LR-Parsern zeigte, dass es oft m\"oglich ist, 
+bestimmte Zust\"ande zusammen zu fassen.  Dadurch kann die Menge der Zust\"ande in den meisten F\"allen
 deutlich verkleinert werden.  Wir illustrieren das Konzept an einem Beispiel und betrachten die in
 Abbildung \ref{fig:dragon-book.grammar} gezeigt Grammatik, die ich dem \emph{Drachenbuch}
 \cite{aho:2006} entnommen habe.  (Das ``Drachenbuch'' ist das Standardwerk im Bereich Compilerbau.)
@@ -1343,14 +1343,14 @@ Abbildung \ref{fig:dragon-book.grammar} gezeigt Grammatik, die ich dem \emph{Dra
 \begin{figure}[!ht]
 \centering
       \epsfig{file=Abbildungen/cc-LR.eps, scale=0.5}
-      \caption{LR-Goto-Graph für die Grammatik aus Abbildung \ref{fig:dragon-book.grammar}.}
+      \caption{LR-Goto-Graph f\"ur die Grammatik aus Abbildung \ref{fig:dragon-book.grammar}.}
   \label{fig:cc-LR.eps}
 \end{figure}
 
 
-Abbildung \ref{fig:cc-LR.eps} zeigt den sogenannten \emph{LR-Goto-Graphen} für diese Grammatik.
-Die Knoten dieses Graphen sind die Zustände.  
-Betrachten wir den LR-Goto-Graphen, so stellen wir fest, dass die Zustände $s_6$ und
+Abbildung \ref{fig:cc-LR.eps} zeigt den sogenannten \emph{LR-Goto-Graphen} f\"ur diese Grammatik.
+Die Knoten dieses Graphen sind die Zust\"ande.  
+Betrachten wir den LR-Goto-Graphen, so stellen wir fest, dass die Zust\"ande $s_6$ und
 $s_3$ sich nur in den Mengen der Folge-Token unterscheiden, denn es gilt einerseits
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1367,9 +1367,9 @@ $s_3 = \Bigl\{ s \rightarrow \squoted{x} \bullet c: \{ \squoted{x}, \squoted{y} 
                  c \rightarrow \bullet\, \quoted{y}:    \{ \squoted{x}, \squoted{y} \}  
        \Bigr\}$.
 \\[0.2cm]
-Offenbar entsteht die Menge $s_3$ aus der Menge $s_6$ indem überall $\squoted{\symbol{36}}$
+Offenbar entsteht die Menge $s_3$ aus der Menge $s_6$ indem \"uberall $\squoted{\symbol{36}}$
 durch die Menge $\{ \squoted{x}, \squoted{y}\}$ ersetzt wird.  Genauso kann die Menge $s_7$ in $s_4$
-und $s_9$ in $s_8$ überführt werden.  Die entscheidende Erkenntnis ist nun, dass die
+und $s_9$ in $s_8$ \"uberf\"uhrt werden.  Die entscheidende Erkenntnis ist nun, dass die
 Funktion $\textsl{goto}()$ unter dieser Art von Transformation invariant ist, denn bei der
 Definition dieser Funktion spielt die Menge der Folge-Token keine Rolle.  So sehen wir zum
 Beispiel, dass einerseits
@@ -1378,33 +1378,33 @@ Beispiel, dass einerseits
 $\textsl{goto}(s_3, c) = s_8$ \quad und \quad und 
 $\textsl{goto}(s_6, c) = s_9$ 
 \\[0.2cm]
-gilt und dass andererseits der Zustand $s_9$ in den Zustand $s_8$ übergeht, wenn wir
-überall in $s_9$ das Terminal $\squoted{\symbol{36}}$ durch die Menge 
+gilt und dass andererseits der Zustand $s_9$ in den Zustand $s_8$ \"ubergeht, wenn wir
+\"uberall in $s_9$ das Terminal $\squoted{\symbol{36}}$ durch die Menge 
  $\{ \squoted{x}, \squoted{y}\}$ ersetzen.  Definieren wir den \emph{Kern}
 einer Menge von erweiterten markierten Regeln dadurch, dass wir in jeder Regel die Menge
-der Folgetoken wegstreichen, und fassen dann Zustände mit dem selben Kern zusammen, so
+der Folgetoken wegstreichen, und fassen dann Zust\"ande mit dem selben Kern zusammen, so
 erhalten wir den in 
 Abbildung \ref{fig:cc-LALR.eps} gezeigten Goto-Graphen.
 
 \begin{figure}[!ht]
 \centering
   \hspace*{-0.6cm} \epsfig{file=Abbildungen/cc-LALR, scale=0.5}
-  \caption{Der LALR-Goto-Graph für die Grammatik aus Abbildung \ref{fig:dragon-book.grammar}.}
+  \caption{Der LALR-Goto-Graph f\"ur die Grammatik aus Abbildung \ref{fig:dragon-book.grammar}.}
   \label{fig:cc-LALR.eps}
 \end{figure}
 
 Um die Beobachtungen, die wir bei der Betrachtung der in Abbildung
 \ref{fig:dragon-book.grammar} gezeigten Grammatik gemacht gaben, verallgemeinern und formalisieren zu
-können, definieren wir ein Funktion 
+k\"onnen, definieren wir ein Funktion 
 $\textsl{core}()$, die den Kern einer Menge von e.m.R.s berechnet und damit diese Menge in
-eine Menge markierter Regeln überführt: 
+eine Menge markierter Regeln \"uberf\"uhrt: 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{core}(\mathcal{M}) := 
    \{ a \rightarrow \beta \bullet \gamma \mid (a \rightarrow \beta \bullet \gamma:L) \in \mathcal{M} \}$. 
 \\[0.2cm]
 Die Funktion $\textsl{core}()$ entfernt also einfach die Menge der Folge-Tokens von den e.m.R.s.
-Wir hatten die Funktion $\textsl{goto}()$ für eine Menge $\mathcal{M}$ von erweiterten
+Wir hatten die Funktion $\textsl{goto}()$ f\"ur eine Menge $\mathcal{M}$ von erweiterten
 markierten Regeln und ein Symbol $x$ durch
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1414,7 +1414,7 @@ $\textsl{goto}(\mathcal{M}, x) := \textsl{closure}\Bigl( \bigl\{
 $.
 \\[0.2cm]
 definiert.  Offenbar spielt die Menge der Folge-Token bei der Berechnung von
-$\textsl{goto}(\mathcal{M}, x)$ keine Rolle, formal gilt für zwei e.m.R.-Mengen
+$\textsl{goto}(\mathcal{M}, x)$ keine Rolle, formal gilt f\"ur zwei e.m.R.-Mengen
 $\mathcal{M}_1$ und $\mathcal{M}_2$ und ein Symbol $x$ die Formel:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1424,7 +1424,7 @@ $\textsl{core}(\mathcal{M}_1) = \textsl{core}(\mathcal{M}_2) \;\Rightarrow\;
 $.
 \vspace*{0.2cm}
 
-Für zwei e.m.R.-Mengen $\mathcal{M}$ und $\mathcal{N}$, die
+F\"ur zwei e.m.R.-Mengen $\mathcal{M}$ und $\mathcal{N}$, die
 den gleichen Kern haben, definieren wir die \emph{erweiterte Vereinigung}  
 $\mathcal{M} \uplus \mathcal{N}$ von $\mathcal{M}$ und $\mathcal{N}$ als
 \\[0.2cm]
@@ -1441,12 +1441,12 @@ die auf einer Menge von Mengen von e.m.R.s definiert ist: Ist $\frak{I}$
 eine Menge von Mengen von e.m.R.s, die alle den gleichen Kern haben, gilt also
 \[ \frak{I} = \{ \mathcal{M}_1, \cdots, \mathcal{M}_k \} \quad \mbox{mit} \quad
    \textsl{core}(\mathcal{M}_i) = \textsl{core}(\mathcal{M}_j) \quad 
-   \mbox{für alle $i,j\in\{1,\cdots,k\}$,} 
+   \mbox{f\"ur alle $i,j\in\{1,\cdots,k\}$,} 
 \]
 so definieren wir
 \[ \biguplus \frak{I} := \mathcal{M}_1 \uplus \cdots \uplus \mathcal{M}_k. 
 \]
-Es sei nun $\Delta$ die Menge aller Zustände eines LR-Parsers.  Dann ist die Menge der Zustände des
+Es sei nun $\Delta$ die Menge aller Zust\"ande eines LR-Parsers.  Dann ist die Menge der Zust\"ande des
 entsprechenden LALR-Parsers durch die erweiterte Vereinigung der Menge aller der Teilmengen 
 von $\Delta$ gegeben, deren Elemente den gleichen Kern haben:
 \[ \frak{Q} := \left\{ \biguplus \frak{I} \mid \frak{I} \in 2^\Delta \wedge 
@@ -1454,13 +1454,13 @@ von $\Delta$ gegeben, deren Elemente den gleichen Kern haben:
       \wedge \mbox{und $\frak{I}$ maximal} 
    \right\}. 
 \]
-Die Forderung ``$\frak{I}$ maximal'' drückt in der obigen Definition aus, dass in $\frak{I}$ tatsächlich
+Die Forderung ``$\frak{I}$ maximal'' dr\"uckt in der obigen Definition aus, dass in $\frak{I}$ tats\"achlich
 \underline{alle} Mengen aus $\Delta$ zusamengefasst sind, die den selben Kern haben.
-Die so definierte Menge $\frak{Q}$ ist die Menge der LALR-Zustände.  
+Die so definierte Menge $\frak{Q}$ ist die Menge der LALR-Zust\"ande.  
 
-Als nächstes überlegen wir, wie sich die Berechnung von $\textsl{goto}(\mathcal{M},X)$
-ändern muss, wenn $\mathcal{M}$ ein Element der Menge $\frak{Q}$ der LALR-Zustände ist.  
-Zur Berechnung von $\textsl{goto}(\mathcal{M},X)$ berechnen wir zunächst die Menge
+Als n\"achstes \"uberlegen wir, wie sich die Berechnung von $\textsl{goto}(\mathcal{M},X)$
+\"andern muss, wenn $\mathcal{M}$ ein Element der Menge $\frak{Q}$ der LALR-Zust\"ande ist.  
+Zur Berechnung von $\textsl{goto}(\mathcal{M},X)$ berechnen wir zun\"achst die Menge
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{closure}\Bigl( \bigl\{  
@@ -1469,9 +1469,9 @@ $\textsl{closure}\Bigl( \bigl\{
 $.
 \\[0.2cm]
 Das Problem ist, dass diese Menge im Allgemeinen kein Element der Menge $\frak{Q}$ ist,
-denn die Zustände in $\frak{Q}$ entstehen ja durch die Zusammenfassung mehrerer LR-Zustände.
-Die Zustände, die bei der Berechnung von $\frak{Q}$ zusammengefasst werden, haben aber alle den selben
-Kern.  Daher enthält die  Menge
+denn die Zust\"ande in $\frak{Q}$ entstehen ja durch die Zusammenfassung mehrerer LR-Zust\"ande.
+Die Zust\"ande, die bei der Berechnung von $\frak{Q}$ zusammengefasst werden, haben aber alle den selben
+Kern.  Daher enth\"alt die  Menge
 \\[0.2cm]
 \hspace*{1.3cm}
 $\Bigl\{ q \in \frak{Q} \mid \textsl{core}(q) =
@@ -1482,7 +1482,7 @@ $\Bigl\{ q \in \frak{Q} \mid \textsl{core}(q) =
 $
 \\[0.2cm]
 genau ein Element und dieses Element ist der Wert von $\textsl{goto}(\mathcal{M}, X)$.  Folglich
-können wir  
+k\"onnen wir  
 \\[0.2cm]
 \hspace*{1.3cm}
 $\ds\textsl{goto}(\mathcal{M}, X) := \textsl{arb}\Bigl(\Bigl\{ q \in \frak{Q} \mid \textsl{core}(q) =
@@ -1493,9 +1493,9 @@ $\ds\textsl{goto}(\mathcal{M}, X) := \textsl{arb}\Bigl(\Bigl\{ q \in \frak{Q} \m
 $
 \\[0.2cm]
 setzen.  Die hier verwendete Funktion $\textsl{arb}()$ dient dazu, ein beliebiges Element aus einer Menge
-zu extrahieren.  Da die Menge, aus der hier das Element extrahiert wird, genau ein Element enthält, ist
+zu extrahieren.  Da die Menge, aus der hier das Element extrahiert wird, genau ein Element enth\"alt, ist
 $\textsl{goto}(\mathcal{M}, x)$ wohldefiniert.
-Die Berechnung des Ausdrucks $\textsl{action}(\mathcal{M}, t)$ ändert sich gegenüber der Berechnung für
+Die Berechnung des Ausdrucks $\textsl{action}(\mathcal{M}, t)$ \"andert sich gegen\"uber der Berechnung f\"ur
 einen LR-Parser nicht. 
 
 \section{Vergleich von SLR-, LR- und LALR-Parsern}
@@ -1510,22 +1510,22 @@ Die Begriffe \emph{kanonische LR-Sprache} und \emph{LALR-Sprache} werden analog 
 \hspace*{\fill} $(\star)$
 \\[0.2cm]
 Diese Inklusionen sind leicht zu verstehen:  Bei der Definition der LR-Parser hatten wir
-zu den markierten Regeln  Mengen von Folge-Token hinzugefügt.  Dadurch war
-es möglich, in bestimmten Fällen Shift-Reduce- und Reduce-Reduce-Konflikte zu vermeiden.
-Da die Zustands-Mengen der kanonischen LR-Parser unter Umständen sehr groß werden können,
+zu den markierten Regeln  Mengen von Folge-Token hinzugef\"ugt.  Dadurch war
+es m\"oglich, in bestimmten F\"allen Shift-Reduce- und Reduce-Reduce-Konflikte zu vermeiden.
+Da die Zustands-Mengen der kanonischen LR-Parser unter Umst\"anden sehr gro{\ss} werden k\"onnen,
 hatten wir dann wieder solche Mengen von erweiterten markierten Regeln zusammengefasst,
-für die die Menge der Folge-Token identisch war.  So hatten wir die LALR-Parser
-erhalten.  Durch die Zusammenfassung von Regel-Menge können wir
-uns allerdings in bestimmten Fällen Reduce-Reduce-Konflikte einhandeln, so dass die 
+f\"ur die die Menge der Folge-Token identisch war.  So hatten wir die LALR-Parser
+erhalten.  Durch die Zusammenfassung von Regel-Menge k\"onnen wir
+uns allerdings in bestimmten F\"allen Reduce-Reduce-Konflikte einhandeln, so dass die 
 Menge der LALR-Sprachen eine Untermenge der kanonischen LR-Sprachen ist.
 
 Wir werden in den folgenden Unterabschnitten zeigen, dass die Inklusionen in $(\star)$ echt sind.  
 
 \subsection{\emph{SLR-Sprache} $\subsetneq$ \emph{LALR-Sprache}}
-Die Zustände eines LALR-Parsers enthalten gegenüber den Zuständen eines SLR-Parsers noch
-Mengen von Folge-Token.  Damit sind LALR-Parser mindestens genauso mächtig wie SLR-Parser.
-Wir zeigen nun, dass LALR-Parser tatsächlich mächtiger als SLR-Parser sind.  Um diese
-Behauptung zu belegen, präsentieren wir eine Grammatik, für die es zwar einen LALR-Parser,
+Die Zust\"ande eines LALR-Parsers enthalten gegen\"uber den Zust\"anden eines SLR-Parsers noch
+Mengen von Folge-Token.  Damit sind LALR-Parser mindestens genauso m\"achtig wie SLR-Parser.
+Wir zeigen nun, dass LALR-Parser tats\"achlich m\"achtiger als SLR-Parser sind.  Um diese
+Behauptung zu belegen, pr\"asentieren wir eine Grammatik, f\"ur die es zwar einen LALR-Parser,
 aber keinen SLR-Parser gibt.  Wir hatten auf Seite \pageref{fig:reduce-reduce-conflict.grammar}
 gesehen, dass die Grammatik
 \\[0.2cm]
@@ -1534,11 +1534,11 @@ $s \;\rightarrow\; a \quoted{x} a \quoted{y} \mid b \quoted{y} b \quoted{x}$, \q
 $a \;\rightarrow\;\varepsilon$, \quad
 $b \;\rightarrow\; \varepsilon$
 \\[0.2cm]
-keine SLR-Grammatik ist.  Später hatten wir gesehen, dass diese Grammatik von einem
+keine SLR-Grammatik ist.  Sp\"ater hatten wir gesehen, dass diese Grammatik von einem
 kanonischen LR-Parser geparst werden kann.  Wir zeigen nun, dass diese Grammatik auch von
-einem LALR-Parser geparst werden kann.  Dazu berechnen wir die Menge der LALR-Zustände.
-Dazu ist zunächst die Menge der kanonischen LR-Zustände zu berechnen.  Diese Berechnung
-hatten wir bereits früher durchgeführt und dabei die folgenden Zustände erhalten:
+einem LALR-Parser geparst werden kann.  Dazu berechnen wir die Menge der LALR-Zust\"ande.
+Dazu ist zun\"achst die Menge der kanonischen LR-Zust\"ande zu berechnen.  Diese Berechnung
+hatten wir bereits fr\"uher durchgef\"uhrt und dabei die folgenden Zust\"ande erhalten:
 \begin{enumerate}
 \item $s_0  = \bigl\{ \widehat{s} \rightarrow \bullet\, s:\symbol{36},
                      s \rightarrow \bullet\, a \squoted{x} a \squoted{y}:\symbol{36},
@@ -1563,19 +1563,19 @@ hatten wir bereits früher durchgeführt und dabei die folgenden Zustände erhalten
 \item $s_8 = \bigl\{ s \rightarrow a \squoted{x} a \bullet \squoted{y}:\symbol{36} \bigr\}$,
 \item $s_9 = \bigl\{ s \rightarrow a \squoted{x} a \squoted{y} \bullet :\symbol{36} \bigr\}$.
 \end{enumerate}
-Wir stellen fest, dass die Kerne aller hier aufgelisteten Zustände verschieden sind.
-Damit stimmt bei dieser Grammatik die Menge der Zustände des LALR-Parser mit der Menge der
-Zustände des kanonischen LR-Parsers überein.  Daraus folgt, dass es auch bei
-den LALR-Zuständen keine Konflikte gibt, denn beim Übergang von kanonischen LR-Parsern zu
-LALR-Parsern haben wir lediglich Zustände mit gleichem Kern zusammengefasst, die
-Definition der Funktionen $\textsl{goto}()$ und $\textsl{action}()$ blieb unverändert.
+Wir stellen fest, dass die Kerne aller hier aufgelisteten Zust\"ande verschieden sind.
+Damit stimmt bei dieser Grammatik die Menge der Zust\"ande des LALR-Parser mit der Menge der
+Zust\"ande des kanonischen LR-Parsers \"uberein.  Daraus folgt, dass es auch bei
+den LALR-Zust\"anden keine Konflikte gibt, denn beim \"Ubergang von kanonischen LR-Parsern zu
+LALR-Parsern haben wir lediglich Zust\"ande mit gleichem Kern zusammengefasst, die
+Definition der Funktionen $\textsl{goto}()$ und $\textsl{action}()$ blieb unver\"andert.
 
 \subsection{\emph{LALR-Sprache} $\subsetneq$ \emph{kanonische LR-Sprache}}
-Wir hatten LALR-Parser dadurch definiert, dass wir verschiedene Zustände eines kanonischen LR-Parsers
-zusammengefasst haben.  Damit ist klar, dass kanonische LR-Parser mindestens so mächtig
-sind wie LALR-Parser.  Um zu zeigen, dass kanonische LR-Parser tatsächlich mächtiger sind
-als LALR-Parser, benötigen wir eine Grammatik, für die sich zwar ein kanonischer LR-Parser,
-aber kein LALR-Parser erzeugen lässt.  Abbildung \ref{fig:lr-but-notlalr.g} zeigt eine
+Wir hatten LALR-Parser dadurch definiert, dass wir verschiedene Zust\"ande eines kanonischen LR-Parsers
+zusammengefasst haben.  Damit ist klar, dass kanonische LR-Parser mindestens so m\"achtig
+sind wie LALR-Parser.  Um zu zeigen, dass kanonische LR-Parser tats\"achlich m\"achtiger sind
+als LALR-Parser, ben\"otigen wir eine Grammatik, f\"ur die sich zwar ein kanonischer LR-Parser,
+aber kein LALR-Parser erzeugen l\"asst.  Abbildung \ref{fig:lr-but-notlalr.g} zeigt eine
 solche Grammatik, die ich dem Drachenbuch entnommen habe.
 
 \begin{figure}[htbp]
@@ -1603,7 +1603,7 @@ solche Grammatik, die ich dem Drachenbuch entnommen habe.
   \label{fig:lr-but-notlalr.g}
 \end{figure}
 
-Wir berechnen zunächst die Menge der Zustände eines kanonischen LR-Parsers für diese
+Wir berechnen zun\"achst die Menge der Zust\"ande eines kanonischen LR-Parsers f\"ur diese
 Grammatik.  Wir erhalten dabei die folgende Mengen von erweiterten markierten Regeln:
 \begin{enumerate}
 \item $s_0 = \textsl{closure}(\widehat{s} \rightarrow \bullet\, \;s: \symbol{36}) =
@@ -1656,25 +1656,25 @@ Grammatik.  Wir erhalten dabei die folgende Mengen von erweiterten markierten Re
 \item $s_{13} = \textsl{goto}(s_{12}, \quoted{y}) =
                 \{ s \rightarrow \squoted{w} b \squoted{y} \bullet: \symbol{36} \}$.
 \end{enumerate}
-Die einzigen Zustände, bei denen es Konflikte geben könnte, sind die Mengen $s_4$ und
+Die einzigen Zust\"ande, bei denen es Konflikte geben k\"onnte, sind die Mengen $s_4$ und
 $s_5$, denn hier sind prinzipiell sowohl Reduktionen mit der Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $a \rightarrow \squoted{x}$ \quad als auch mit \quad
 $b \rightarrow \squoted{x}$
 \\[0.2cm]
-möglich.  Da allerdings die Mengen der Folge-Token einen leeren Durchschnitt haben, gibt
-es tatsächlich keinen Konflikt und die Grammatik ist eine kanonische LR-Grammatik.
+m\"oglich.  Da allerdings die Mengen der Folge-Token einen leeren Durchschnitt haben, gibt
+es tats\"achlich keinen Konflikt und die Grammatik ist eine kanonische LR-Grammatik.
 
-Wir berechnen als nächstes die LALR-Zustände der oben angegebenen Grammatik.  Die einzigen
-Zustände, die einen gemeinsamen Kern haben, sind die beiden Zustände $s_4$ und $s_5$, denn
+Wir berechnen als n\"achstes die LALR-Zust\"ande der oben angegebenen Grammatik.  Die einzigen
+Zust\"ande, die einen gemeinsamen Kern haben, sind die beiden Zust\"ande $s_4$ und $s_5$, denn
 es gilt
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{core}(s_4) = \{ a \rightarrow \squoted{x} \bullet,\;
                 b \rightarrow \squoted{x} \bullet \} = \textsl{core}(s_5)$.
 \\[0.2cm]
-Bei der Berechnung der LALR-Zustände werden diese beiden Zustände zu einem Zustand
+Bei der Berechnung der LALR-Zust\"ande werden diese beiden Zust\"ande zu einem Zustand
 $s_{\{4,5\}}$ zusammengefasst.  Dieser neue Zustand hat die Form
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1693,7 +1693,7 @@ $\textsl{action}(s_{\{4,5\}}, \squoted{y}) = \pair(\textsl{reduce}, B \rightarro
 
 \exercise
 Es sei $G = \langle V, T, R, s \rangle$ eine LR-Grammatik und $\mathcal{N}$ sei die Menge der
-LALR-Zustände der Grammatik.  Überlegen Sie, warum es in der Menge $\mathcal{N}$ keine
+LALR-Zust\"ande der Grammatik.  \"Uberlegen Sie, warum es in der Menge $\mathcal{N}$ keine
 Shift-Reduce-Konflikte geben kann.  \eox
 
 
@@ -1703,28 +1703,28 @@ invention,  the space savings of LALR parsing in comparison to LR parsing were c
 
 
 \subsection{Bewertung der verschiedenen Methoden}
-Für die Praxis sind SLR-Parser nicht ausreichend, denn es gibt eine Reihe praktisch
-relevanter Sprach-Konstrukte, für die sich kein SLR-Parser erzeugen lässt.  Kanonische
-LR-Parser sind wesentlich mächtiger, benötigen allerdings oft deutlich mehr Zustände. 
+F\"ur die Praxis sind SLR-Parser nicht ausreichend, denn es gibt eine Reihe praktisch
+relevanter Sprach-Konstrukte, f\"ur die sich kein SLR-Parser erzeugen l\"asst.  Kanonische
+LR-Parser sind wesentlich m\"achtiger, ben\"otigen allerdings oft deutlich mehr Zust\"ande. 
 Hier stellen LALR-Parser einen Kompromiss dar:  Einerseits sind LALR-Sprachen fast so
 ausdrucksstark  wie kanonische LR-Sprachen, andererseits liegt der Speicherbedarf von
-LALR-Parsern in der gleichen Größenordnung wie der Speicherbedarf von SLR-Parsern.  Beispielsweise
-hat die SLR-Parse-Tabelle für die Sprache \texttt{C} insgesamt 349 Zustände, die entsprechende
-LR-Parse-Tabelle kommt auf 1572 Zustände, während der LALR-Parser mit 350 Zuständen auskommt und damit nur
+LALR-Parsern in der gleichen Gr\"o{\ss}enordnung wie der Speicherbedarf von SLR-Parsern.  Beispielsweise
+hat die SLR-Parse-Tabelle f\"ur die Sprache \texttt{C} insgesamt 349 Zust\"ande, die entsprechende
+LR-Parse-Tabelle kommt auf 1572 Zust\"ande, w\"ahrend der LALR-Parser mit 350 Zust\"anden auskommt und damit nur
 einen Zustand mehr als der SLR-Parser hat.  
-In den heute in der Regel zur Verfügung stehenden Hauptspeichern lassen sich allerdings
-auch kanonische LR-Parser meist mühelos unterbringen, so dass es eigentlich keinen zwingenden
+In den heute in der Regel zur Verf\"ugung stehenden Hauptspeichern lassen sich allerdings
+auch kanonische LR-Parser meist m\"uhelos unterbringen, so dass es eigentlich keinen zwingenden
 Grund mehr gibt, statt eines LR-Parsers einen LALR-Parser einzusetzen.  
 
 Andererseits wird niemand einen LALR-Parser oder einen kanonischen LR-Parser von Hand
-programmieren wollen.  Statt dessen werden Sie später einen Parser-Generator wie \textsl{Bison}
+programmieren wollen.  Statt dessen werden Sie sp\"ater einen Parser-Generator wie \textsl{Bison}
 oder \textsl{JavaCup} einsetzen, der Ihnen einen  Parser generiert.  Das Werkzeug Bison
-ist ein Parser-Generator für \texttt{C}, \texttt{C++} und bietet auch eine, allerdings leider noch
-experimentelle, Unterstützung für \textsl{Java},
-während \textsl{JavaCup} auf die Sprache \textsl{Java} beschränkt ist.  Falls Sie
+ist ein Parser-Generator f\"ur \texttt{C}, \texttt{C++} und bietet auch eine, allerdings leider noch
+experimentelle, Unterst\"utzung f\"ur \textsl{Java},
+w\"ahrend \textsl{JavaCup} auf die Sprache \textsl{Java} beschr\"ankt ist.  Falls Sie
 \textsl{JavaCup} benutzen, haben Sie keine Wahl, denn dieses Werkzeug erzeugt immer einen
 LALR-Parser.  Bei \href{http://www.gnu.org/software/bison/manual/bison.html}{\textsl{Bison}} ist es
-ab der Version 3.0  auch möglich, einen LR-Parser zu erzeugen.
+ab der Version 3.0  auch m\"oglich, einen LR-Parser zu erzeugen.
 
 
 

--- a/Lecture-Notes/minimization.tex
+++ b/Lecture-Notes/minimization.tex
@@ -1,28 +1,28 @@
 \chapter[Minimierung von FSMs$^*$]{Minimierung endlicher Automaten$^*$}
-In diesem Abschnitt zeigen wir ein Verfahren, mit dem die Anzahl der Zustände eines deterministischen
+In diesem Abschnitt zeigen wir ein Verfahren, mit dem die Anzahl der Zust\"ande eines deterministischen
 endlichen Automaten 
 \\[0.2cm]
 \hspace*{1.3cm}
 $A = \langle Q, \Sigma, \delta, q_0, F \rangle$
 \\[0.2cm]
-minimiert werden kann.  Ohne Beschränkung der Allgemeinheit wollen wir dabei voraussetzen,
-dass der Automat $A$ vollständig ist: Wir nehmen also an, dass der Ausdruck $\delta(q, c)$
-für jeden Zustand $q \in Q$ und jeden Buchstaben $c \in \Sigma$ als Ergebnis einen Zustand
+minimiert werden kann.  Ohne Beschr\"ankung der Allgemeinheit wollen wir dabei voraussetzen,
+dass der Automat $A$ vollst\"andig ist: Wir nehmen also an, dass der Ausdruck $\delta(q, c)$
+f\"ur jeden Zustand $q \in Q$ und jeden Buchstaben $c \in \Sigma$ als Ergebnis einen Zustand
 aus $Q$ liefert. Wir suchen dann einen deterministischen
 endlichen Automaten 
 \\[0.2cm]
 \hspace*{1.3cm}
 $A^- = \langle Q^-, \Sigma, \delta^-, q_0, F^- \rangle$,
 \\[0.2cm]
-der dieselbe Sprache akzeptiert wie der Automat $A$, für den also
+der dieselbe Sprache akzeptiert wie der Automat $A$, f\"ur den also
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(A^-) = L(A)$
 \\[0.2cm]
-gilt und für den die Anzahl der Zustände der Menge $Q^-$ minimal ist.  
+gilt und f\"ur den die Anzahl der Zust\"ande der Menge $Q^-$ minimal ist.  
 Um diese
-Konstruktion durchführen zu können, müssen wir etwas ausholen.
-Zunächst erweitern wir die Funktion 
+Konstruktion durchf\"uhren zu k\"onnen, m\"ussen wir etwas ausholen.
+Zun\"achst erweitern wir die Funktion 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\delta: Q \times \Sigma \rightarrow Q$
@@ -35,7 +35,7 @@ $\hat{\delta} : Q \times \Sigma^* \rightarrow Q$.
 \\[0.2cm]
 Der Funktions-Aufruf $\hat{\delta}(q,s)$ soll den Zustand $p$ berechnen, in den der Automat $A$ gelangt,
 wenn der Automat im Zustand $q$ den String $s$ liest.
-Die Definition von $\hat{\delta}(q,s)$ erfolgt durch Induktion über die Länge des Strings $s$:
+Die Definition von $\hat{\delta}(q,s)$ erfolgt durch Induktion \"uber die L\"ange des Strings $s$:
 \begin{enumerate}
 \item[I.A.:] $\hat{\delta}(q,\varepsilon) = q$,
 \item[I.S.:] $\hat{\delta}(q,cs) = \hat{\delta}\bigl(\delta(q,c),s\bigr)$, 
@@ -44,34 +44,34 @@ Die Definition von $\hat{\delta}(q,s)$ erfolgt durch Induktion über die Länge de
 Da die Funktion $\hat{\delta}$ eine Verallgemeinerung der Funktion $\delta$ ist, werden wir in der
 Notation nicht zwischen $\delta$ und $\hat{\delta}$ unterscheiden und einfach nur $\delta$ schreiben.
 
-Offensichtlich können wir in einem endlichen Automaten 
-$A = \langle Q, \Sigma, \delta, q_0, F \rangle$  alle die Zustände $p \in Q$ entfernen,
+Offensichtlich k\"onnen wir in einem endlichen Automaten 
+$A = \langle Q, \Sigma, \delta, q_0, F \rangle$  alle die Zust\"ande $p \in Q$ entfernen,
 die vom Start-Zustand aus nicht 
-\emph{erreichbar} sind.  Dabei heißt ein Zustand $p$ \emph{erreichbar} genau dann, wenn es
+\emph{erreichbar} sind.  Dabei hei{\ss}t ein Zustand $p$ \emph{erreichbar} genau dann, wenn es
 einen String $w \in \Sigma^*$ gibt, so dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $\delta(q_0, w) = p$
 \\[0.2cm]
-gilt.  Wir wollen im Folgenden daher voraussetzen, dass alle Zustände des betrachteten
+gilt.  Wir wollen im Folgenden daher voraussetzen, dass alle Zust\"ande des betrachteten
 endlichen Automaten vom Start-Zustand aus erreichbar sind.
 
 
 \begin{figure}[!ht]
   \centering
   \epsfig{file=Abbildungen/nicht-gleichwertig.eps, scale=0.6}
-   \caption{Ein endlicher Automat mit äquivalenten Zuständen.}
+   \caption{Ein endlicher Automat mit \"aquivalenten Zust\"anden.}
   \label{fig:nicht-gleichwertig.dot}
 \end{figure}
 
-Im Allgemeinen können wir einen Automaten dadurch minimieren, dass wir bestimmte Zustände
+Im Allgemeinen k\"onnen wir einen Automaten dadurch minimieren, dass wir bestimmte Zust\"ande
 identifizieren.  Betrachten wir beispielsweise den in Abbildung
-\ref{fig:nicht-gleichwertig.dot} gezeigten Automaten, so können wir dort die Zustände $q_1$
+\ref{fig:nicht-gleichwertig.dot} gezeigten Automaten, so k\"onnen wir dort die Zust\"ande $q_1$
 und $q_2$ sowie $q_3$ und $q_4$ identifizieren, ohne dass sich dadurch die Sprache des
-Automaten ändert.  
+Automaten \"andert.  
 Die zentrale Idee bei der Minimierung eines Automaten besteht darin, dass wir uns
-überlegen, welche Zustände wir auf keinen Fall identifizieren dürfen und einfach alle
-anderen Zustände als äquivalent betrachten.
+\"uberlegen, welche Zust\"ande wir auf keinen Fall identifizieren d\"urfen und einfach alle
+anderen Zust\"ande als \"aquivalent betrachten.
 
 \begin{Definition}[Separable States]
 Assume $A = \langle Q, \Sigma, \delta, q_0, F \rangle$ is a deterministic finite state machine.
@@ -98,18 +98,18 @@ function $\delta$ in a way that the new version of $\delta$ will return
 $p_1$ in all those cases where the old version of $\delta$ had returned $p_2$.
 
 
-Es bleibt die Frage zu klären, wie wir feststellen können, welche Zustände unterscheidbar sind.
-Eine Möglichkeit besteht darin, eine Menge $V$ von Paaren von Zustände anzulegen.  Wir fügen
+Es bleibt die Frage zu kl\"aren, wie wir feststellen k\"onnen, welche Zust\"ande unterscheidbar sind.
+Eine M\"oglichkeit besteht darin, eine Menge $V$ von Paaren von Zust\"ande anzulegen.  Wir f\"ugen
 das Paar $\langle p, q \rangle$ in die Menge $V$ ein, wenn wir erkannt haben, dass $p$ und $q$
 unterscheidbar sind.  Wir erkennen $p$ und $q$ als unterscheidbar, wenn es einen Buchstaben 
-$c\in\Sigma$ und zwei Zustände $s$ und $t$ gibt, so dass 
+$c\in\Sigma$ und zwei Zust\"ande $s$ und $t$ gibt, so dass 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\delta(p,c) = s$, $\delta(q,c) = t$ und $\langle s, t \rangle \in V$
 \\[0.2cm]
 gilt.  Diese Idee liefert einen Algorithmus, der aus zwei Schritten besteht:
 \begin{enumerate}
-\item Zunächst initialisieren wir $V$ mit alle den Paaren $\pair(p,q)$, für die entweder
+\item Zun\"achst initialisieren wir $V$ mit alle den Paaren $\pair(p,q)$, f\"ur die entweder
       $p$ ein akzeptierender Zustand und $q$ kein akzeptierender Zustand ist, oder
       umgekehrt $q$ ein akzeptierender Zustand und $p$ kein akzeptierender Zustand ist,
       denn ein akzeptierender Zustand kann durch den leeren String $\varepsilon$ von einem
@@ -118,9 +118,9 @@ gilt.  Diese Idee liefert einen Algorithmus, der aus zwei Schritten besteht:
       \hspace*{1.3cm}
       $V := \bigl\{\pair(p,q) \in Q \times Q \mid (p \in F \wedge q \notin F) \vee 
                                                (p \notin F \wedge q \in F) \bigr\}$
-\item Solange wir ein neues Paar $\pair(p,q) \in Q \times Q$ finden, für dass es einen 
-      Buchstaben $c$ gibt, so dass die Zustäne $\delta(p,c)$ und $\delta(q,c)$ 
-      bereits unterscheidbar sind, fügen wir dieses Paar zur Menge $V$ hinzu: 
+\item Solange wir ein neues Paar $\pair(p,q) \in Q \times Q$ finden, f\"ur dass es einen 
+      Buchstaben $c$ gibt, so dass die Zust\"ane $\delta(p,c)$ und $\delta(q,c)$ 
+      bereits unterscheidbar sind, f\"ugen wir dieses Paar zur Menge $V$ hinzu: 
       \\[0.2cm]
       \hspace*{1.3cm} 
       \texttt{while ($\exists \pair(p,q) \in Q \times Q: \exists c \in \Sigma:\langle\delta(p,c),
@@ -136,10 +136,10 @@ gilt.  Diese Idee liefert einen Algorithmus, der aus zwei Schritten besteht:
       \hspace*{1.3cm}
       \texttt{\}}
 \end{enumerate}
-Haben wir alle Paare $\pair(p,q)$ von unterscheidbaren Zuständen gefunden,
-so können wir anschließend alle Zustände $p$ und $q$  identifizieren, die nicht
-unterscheidbar sind, für die also $\langle p, q \rangle \not\in V$ gilt.
-Es lässt sich zeigen, dass der so konstruierte Automat tatsächlich minimal ist.
+Haben wir alle Paare $\pair(p,q)$ von unterscheidbaren Zust\"anden gefunden,
+so k\"onnen wir anschlie{\ss}end alle Zust\"ande $p$ und $q$  identifizieren, die nicht
+unterscheidbar sind, f\"ur die also $\langle p, q \rangle \not\in V$ gilt.
+Es l\"asst sich zeigen, dass der so konstruierte Automat tats\"achlich minimal ist.
 \pagebreak
 
 \vspace*{-0.5cm}
@@ -147,14 +147,14 @@ Es lässt sich zeigen, dass der so konstruierte Automat tatsächlich minimal ist.
 Wir betrachten den in Abbildung \ref{fig:nicht-gleichwertig.dot} gezeigten endlichen
 Automaten und wenden den oben skizzierten Algorithmus auf diesen Automaten an.
 Wir bedienen uns dazu einer Tabelle, deren Spalten und Zeilen mit den verschiedenen
-Zuständen durchnummeriert sind.  Wenn wir im ersten Schritt erkannt haben,
-dass die Zustände $i$ und $j$ unterscheidbar sind, so fügen wir in dieser Tabelle
+Zust\"anden durchnummeriert sind.  Wenn wir im ersten Schritt erkannt haben,
+dass die Zust\"ande $i$ und $j$ unterscheidbar sind, so f\"ugen wir in dieser Tabelle
  in der $i$-ten Zeile und der $j$-ten Spalte eine $1$ ein.
-Da mit den Zuständen $i$ und $j$ auch die Zustände $j$ und $i$ unterscheidbar sind,
-fügen wir außerdem in der $j$-ten Zeile und der $i$-ten Spalte ebenfalls eine $1$ ein.
+Da mit den Zust\"anden $i$ und $j$ auch die Zust\"ande $j$ und $i$ unterscheidbar sind,
+f\"ugen wir au{\ss}erdem in der $j$-ten Zeile und der $i$-ten Spalte ebenfalls eine $1$ ein.
 \begin{enumerate}
-\item Im ersten Schritt erkennen wir, dass die beiden akzeptierenden Zustände
-      $q_3$ und $q_4$ von allen nicht-akzeptierenden Zuständen unterscheidbar sind.
+\item Im ersten Schritt erkennen wir, dass die beiden akzeptierenden Zust\"ande
+      $q_3$ und $q_4$ von allen nicht-akzeptierenden Zust\"anden unterscheidbar sind.
       Also sind die Paare 
       $\pair(q_0,q_3)$,
       $\pair(q_0,q_4)$,
@@ -181,13 +181,13 @@ fügen wir außerdem in der $j$-ten Zeile und der $i$-ten Spalte ebenfalls eine $1
       \hline
       \end{tabular}
       \end{center}
-\item Als nächstes erkennen wir, dass die Zustände $q_0$ und $q_1$ unterscheidbar sind,
+\item Als n\"achstes erkennen wir, dass die Zust\"ande $q_0$ und $q_1$ unterscheidbar sind,
       denn es gilt 
       \\[0.2cm]
       \hspace*{1.3cm}
       $\delta(q_0,a) = q_1$, \quad $\delta(q_1,a) = q_3$ \quad und \quad $q_1 \not\sim q_3$.
       \\[0.2cm]
-      Genauso sehen wir, dass die Zustände $0$ und $2$ unterscheidbar sind, 
+      Genauso sehen wir, dass die Zust\"ande $0$ und $2$ unterscheidbar sind, 
       denn es gilt 
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -215,27 +215,27 @@ fügen wir außerdem in der $j$-ten Zeile und der $i$-ten Spalte ebenfalls eine $1
       \hline
       \end{tabular}
       \end{center}
-\item Nun finden wir keine weiteren Paare von unterscheidbaren Zuständen mehr,
+\item Nun finden wir keine weiteren Paare von unterscheidbaren Zust\"anden mehr,
       denn wenn wir das Paar $\pair(q_1,q_2)$ betrachten, sehen wir
       \\[0.2cm]
       \hspace*{1.3cm}
       $\delta(q_1,\texttt{a}) = q_3$ \quad und \quad $\delta(q_2,\texttt{a}) = q_4$, 
       \\[0.2cm]
-      aber da die Zustände $3$ und $4$ bisher nicht unterscheidbar sind,
+      aber da die Zust\"ande $3$ und $4$ bisher nicht unterscheidbar sind,
       liefert dies kein neues unterscheidbares Paar.  Genausowenig liefert
       \\[0.2cm]
       \hspace*{1.3cm}
       $\delta(q_1,\texttt{b}) = q_3$ \quad und \quad $\delta(q_2,\texttt{b}) = q_4$, 
       \\[0.2cm]
-      ein neues unterscheidbares Paar.  Jetzt bleiben noch die beiden Zustände
+      ein neues unterscheidbares Paar.  Jetzt bleiben noch die beiden Zust\"ande
       $q_3$ und $q_4$.  Hier finden wir
       \\[0.2cm]
       \hspace*{1.3cm}
-      $\delta(q_3,c) = q_1$ \quad und \quad $\delta(q_4,c) = q_2$ \quad für alle $c \in \{\texttt{a}, \texttt{b}\}$
+      $\delta(q_3,c) = q_1$ \quad und \quad $\delta(q_4,c) = q_2$ \quad f\"ur alle $c \in \{\texttt{a}, \texttt{b}\}$
       \\[0.2cm]
-      und da die Zustände $q_1$ und $q_2$ bisher nicht als unterscheidbar bekannt sind,
-      haben wir keine neuen unterscheidbaren Zustände gefunden.
-      Damit können wir die äquivalenten Zustände aus der Tabelle ablesen, es gilt:
+      und da die Zust\"ande $q_1$ und $q_2$ bisher nicht als unterscheidbar bekannt sind,
+      haben wir keine neuen unterscheidbaren Zust\"ande gefunden.
+      Damit k\"onnen wir die \"aquivalenten Zust\"ande aus der Tabelle ablesen, es gilt:
       \begin{enumerate}
       \item $q_1 \sim q_2$
       \item $q_3 \sim q_4$
@@ -260,7 +260,7 @@ $L\bigl(a \cdot (b \cdot a)^*\bigr)$ erkennt.  Gehen Sie dazu in folgenden Schri
 \item[(a)] Berechnen Sie einen nicht-deterministischen endlichen Automaten, der diese Sprache
            erkennt.
 \item[(b)] Transformieren Sie diesen Automaten in einen deterministischen Automaten.
-\item[(c)] Minimieren Sie die Zahl der Zustände dieses Automaten mit dem oben angegebenen Algorithmus.
+\item[(c)] Minimieren Sie die Zahl der Zust\"ande dieses Automaten mit dem oben angegebenen Algorithmus.
 \end{enumerate}
 
 \section{Implementing  the Minimization  of Finite Automata in \textsc{SetlX}}

--- a/Lecture-Notes/operators.tex
+++ b/Lecture-Notes/operators.tex
@@ -32,7 +32,7 @@
 \newcommand{\solution}{\vspace*{0.1cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 
 \newcommand{\example}{\vspace*{0.2cm}
 
@@ -73,33 +73,33 @@
 \newcounter{aufgabe}
 
 
-\title{Eindeutige kontextfreie Grammatiken zur Festlegung von Operator-Präzedenzen}
+\title{Eindeutige kontextfreie Grammatiken zur Festlegung von Operator-Pr\"azedenzen}
 \author{Karl Stroetmann}
 
 \begin{document}
 \maketitle
 
-In den meisten Programmiersprachen gibt es eine größere Zahl von Operatoren, für die 
-unterschiedliche Bindungsstärken festgelegt werden.  Wir nehmen an, dass im allgemeinen
+In den meisten Programmiersprachen gibt es eine gr\"o{\ss}ere Zahl von Operatoren, f\"ur die 
+unterschiedliche Bindungsst\"arken festgelegt werden.  Wir nehmen an, dass im allgemeinen
 Dall eine Menge \textsl{Operators} von Operatoren gegeben ist, die folgende Form hat:
 \[ 
    \textsl{Operators} = 
    \bigl\{ \oplus_{i,j} \mid i \in \{1,\cdots,n\} \wedge j \in \{ 1, \cdots, n(i) \} \bigl\}
 \]
-Die Idee ist dabei, dass es $n$ verschieden Prioritäts-Stufen gibt:  Für ein gegebenes 
+Die Idee ist dabei, dass es $n$ verschieden Priorit\"ats-Stufen gibt:  F\"ur ein gegebenes 
 $i \in \{1,\cdots,n\}$ gibt es $n(i)$ verschieden Operatoren, die in der der Menge
 $\bigl\{ \oplus_{i,j} \mid j \in \{ 1, \cdots, n(i) \} \bigl\}$
-zusammengefasst sind.  Alle diese  Operatoren $\oplus_{i,j}$ haben die Präzedenz $i$.
+zusammengefasst sind.  Alle diese  Operatoren $\oplus_{i,j}$ haben die Pr\"azedenz $i$.
 Eine einfache Grammatik, welche die von diesen Operatoren erzeugte Sprache beschreibt,
 besteht aus folgenden Regeln:
 \begin{enumerate}
 \item $\textsl{Expr} \rightarrow \textsl{Expr} \;\oplus_{i,j}\, \textsl{Expr}$
 
-      für alle $i \in \{ 1, \cdots, n \}$ und alle $j \in \{ 1, \cdots, n(i) \}$.
+      f\"ur alle $i \in \{ 1, \cdots, n \}$ und alle $j \in \{ 1, \cdots, n(i) \}$.
 \item $\textsl{Expr} \rightarrow \squoted{(} \;\textsl{Expr}\; \squoted{)}$
 \item $\textsl{Expr} \rightarrow \textsl{Simple}$
 
-      Hier steht \textsl{Simple} für eine syntaktische Variable, die beispielsweise
+      Hier steht \textsl{Simple} f\"ur eine syntaktische Variable, die beispielsweise
       Zahlen und Strings erzeugt.
 \end{enumerate}
 Diese Grammatik ist allerdings mehrdeutig und zum Parsen daher nicht geeignet.
@@ -124,7 +124,7 @@ Diese Grammatik ist allerdings mehrdeutig und zum Parsen daher nicht geeignet.
   \vspace*{-0.5cm}
   \end{minipage}}}
   \end{center}
-  \caption{Grammatik für arithmetische Ausdrücke ohne Links-Rekursion.}
+  \caption{Grammatik f\"ur arithmetische Ausdr\"ucke ohne Links-Rekursion.}
   \label{fig:Expr2}
 \end{figure}
 

--- a/Lecture-Notes/register.tex
+++ b/Lecture-Notes/register.tex
@@ -1,36 +1,36 @@
 \chapter{Register-Zuordnung}
-Die Übersetzung eines Integer-\texttt{C}-Programms in \textsl{Java}-Byte-Code ist deswegen einfach, weil
-wir uns keine Gedanken darüber machen müssen, wie wir die Variablen auf Register verteilen, denn bei der
-\textsc{Ijvm} gibt es keine für den Benutzer sichtbaren Register, so dass alle Variablen und auch die
-Zwischenergebnisse auf dem Stack abgelegt werden müssen.  In diesem Kapitel ist unser Ziel,
-als Endergebnis ein Assembler-Programm für den \textsc{Srp}-Prozessor zu erzeugen.  Dazu müssen wir
-uns überlegen, wie wir die einzelnen Variablen auf die verschiedenen Register verteilen.
-Wir geben zunächst ein Verfahren an, mit dessen Hilfe wir die Anzahl der Register
-bestimmen können,  die für die Speicherung von Zwischenergebnissen, die bei der Auswertung
-arithmetischer Ausdrücke auftreten, benötigt werden.
+Die \"Ubersetzung eines Integer-\texttt{C}-Programms in \textsl{Java}-Byte-Code ist deswegen einfach, weil
+wir uns keine Gedanken dar\"uber machen m\"ussen, wie wir die Variablen auf Register verteilen, denn bei der
+\textsc{Ijvm} gibt es keine f\"ur den Benutzer sichtbaren Register, so dass alle Variablen und auch die
+Zwischenergebnisse auf dem Stack abgelegt werden m\"ussen.  In diesem Kapitel ist unser Ziel,
+als Endergebnis ein Assembler-Programm f\"ur den \textsc{Srp}-Prozessor zu erzeugen.  Dazu m\"ussen wir
+uns \"uberlegen, wie wir die einzelnen Variablen auf die verschiedenen Register verteilen.
+Wir geben zun\"achst ein Verfahren an, mit dessen Hilfe wir die Anzahl der Register
+bestimmen k\"onnen,  die f\"ur die Speicherung von Zwischenergebnissen, die bei der Auswertung
+arithmetischer Ausdr\"ucke auftreten, ben\"otigt werden.
   Die Parameter und lokalen Variablen einer Funktion verteilen wir dann auf die
-verbleibenden Register oder, falls nicht genügend Register vorhanden sind, allokieren wir
+verbleibenden Register oder, falls nicht gen\"ugend Register vorhanden sind, allokieren wir
 die lokalen Variablen auf dem Stack.
 
 \section{Die Ershov-Zahlen}
-Das Verfahren, mit dem Register für die Auswertung arithmetischer Ausdrücke zugeordnet werden können,
-berechnet zunächst für einen gegebenen arithmetischen Ausdruck $e$ die Anzahl $\textsl{ershov}(e)$
-der Register, die benötigt werden, um den Ausdruck auszuwerten.  Es ist nach dem russischen
+Das Verfahren, mit dem Register f\"ur die Auswertung arithmetischer Ausdr\"ucke zugeordnet werden k\"onnen,
+berechnet zun\"achst f\"ur einen gegebenen arithmetischen Ausdruck $e$ die Anzahl $\textsl{ershov}(e)$
+der Register, die ben\"otigt werden, um den Ausdruck auszuwerten.  Es ist nach dem russischen
 Informatiker A.~P.~Ershov benannt, der die Idee des  Verfahrens in \cite{ershov:58} publiziert hat.
 Wir spezifizieren die Funktion
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{ershov}: \mathtt{Expr} \rightarrow \mathbb{N}$,
 \\[0.2cm]
-die für einen gegebenen arithmetischen Ausdruck $e$ die Anzahl der zur Auswertung benötigten
+die f\"ur einen gegebenen arithmetischen Ausdruck $e$ die Anzahl der zur Auswertung ben\"otigten
 Register angibt, durch eine Fallunterscheidung nach dem Aufbau des Ausdrucks.
 \begin{enumerate}
-\item Um eine Konstante auszuwerten, benötigen wir genau ein Register, in dem wir diese
-      Konstante speichern können:
+\item Um eine Konstante auszuwerten, ben\"otigen wir genau ein Register, in dem wir diese
+      Konstante speichern k\"onnen:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{isNumber}(c) \rightarrow \textsl{ershov}(c) = 1$.
-\item Analog benötigen wir zur Auswertung einer Variablen genau ein Register, in dem der Wert der
+\item Analog ben\"otigen wir zur Auswertung einer Variablen genau ein Register, in dem der Wert der
       Variablen abgelegt wird:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -40,40 +40,40 @@ Register angibt, durch eine Fallunterscheidung nach dem Aufbau des Ausdrucks.
       \hspace*{1.3cm}
       $\textsl{op}\; e$,
       \\[0.2cm] 
-      bei dem der unäre Operator \textsl{op} auf den Ausdruck $e$ angewendet wird, benötigen wir
-      genau so viele Register, wie wir zur Auswertung des Ausdrucks $e$ benötigen, denn wenn das
-      Ergebnis der Auswertung von $e$ in einem Register $Rx$ liegt, so können wir anschließend
-      dieses Register überschreiben um das Endergebnis der Auswertung abzuspeichern:
+      bei dem der un\"are Operator \textsl{op} auf den Ausdruck $e$ angewendet wird, ben\"otigen wir
+      genau so viele Register, wie wir zur Auswertung des Ausdrucks $e$ ben\"otigen, denn wenn das
+      Ergebnis der Auswertung von $e$ in einem Register $Rx$ liegt, so k\"onnen wir anschlie{\ss}end
+      dieses Register \"uberschreiben um das Endergebnis der Auswertung abzuspeichern:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{ershov}(\textsl{op}\; e) = \textsl{ershov}(e)$.
       \\[0.2cm]
       \textbf{Bemerkung}: Bei dem \textsc{Risc}-Prozessor, den wir in der Rechnertechnik-Vorlesung
-      besprochen haben, hatten wir als einzigen unären Operator die bitweise Negation, aber
-      prinzipiell sind auch andere unäre Operatoren denkbar.
-\item Bei der Auswertung eines binären Ausdrucks der Form
+      besprochen haben, hatten wir als einzigen un\"aren Operator die bitweise Negation, aber
+      prinzipiell sind auch andere un\"are Operatoren denkbar.
+\item Bei der Auswertung eines bin\"aren Ausdrucks der Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $e_1 \;\textsl{op}\; e_2$
       \\[0.2cm]
-      sind drei Fälle zu unterscheiden.
+      sind drei F\"alle zu unterscheiden.
       \begin{enumerate}
       \item $\textsl{ershov}(e_1) < \textsl{ershov}(e_2)$.
 
-            In diesem Fall berechnen wir zunächst den Ausdruck $e_2$ und benötigen dazu
+            In diesem Fall berechnen wir zun\"achst den Ausdruck $e_2$ und ben\"otigen dazu
             $\textsl{ershov}(e_2)$ Register.  Das letzte dieser Register, nennen wir es
-            $R_y$,             enthält dann das Ergebnis
-            der Auswertung von $e_2$, alle anderen Register können für die Berechnung von $e_1$
+            $R_y$,             enth\"alt dann das Ergebnis
+            der Auswertung von $e_2$, alle anderen Register k\"onnen f\"ur die Berechnung von $e_1$
             verwendet werden.  Da $\textsl{ershov}(e_1) < \textsl{ershov}(e_2)$ ist, reichen diese
             Register auch aus und das Ergebnis von $e_1$ wird in einem dieser Register, sagen
-            wir mal $R_x$, abgespeichert.  Anschließend führen wir dann noch den Befehl
+            wir mal $R_x$, abgespeichert.  Anschlie{\ss}end f\"uhren wir dann noch den Befehl
             \\[0.2cm]
             \hspace*{1.3cm}
             \textsl{op} $R_y$, $R_x$, $R_y$ 
             \\[0.2cm]
             aus, bei dem wir das Ergebnis des Ausdrucks $e_1 \;\textsl{op}\; e_2$ berechnen und in
             dem Register $R_y$ abspeichern.  Wir sehen, dass wir in diesem Fall zur Berechnung
-            von $e_1 \;\textsl{op}\; e_2$ nicht mehr Register benötigen als zur Berechnung von $e_2$
+            von $e_1 \;\textsl{op}\; e_2$ nicht mehr Register ben\"otigen als zur Berechnung von $e_2$
             und halten die folgende Formel fest:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -81,17 +81,17 @@ Register angibt, durch eine Fallunterscheidung nach dem Aufbau des Ausdrucks.
              \textsl{ershov}(e_1 \;\textsl{op}\; e_2) = \textsl{ershov}(e_2)$.
       \item $\textsl{ershov}(e_1) = \textsl{ershov}(e_2)$.
 
-            In diesem Fall berechnen wir den Ausdruck $e_1$ und benötigen dafür
-            $\textsl{ershov}(e_1)$ viele Register.  Bis auf das letzte dabei benötigte Register, 
-            nennen wir es $R_x$, in dem wir das Ergebnis dieser Rechnung speichern müssen, können
-            wir alle diese Register für die Berechnung des Ausdrucks $e_2$ wiederverwenden.
-            Folglich benötigen wir für die Berechnung von $e_2$ also ein weiteres Register, das wir
-            jetzt mit $R_y$ bezeichnen.  Das Endergebnis können wir nun mit dem Befehl
+            In diesem Fall berechnen wir den Ausdruck $e_1$ und ben\"otigen daf\"ur
+            $\textsl{ershov}(e_1)$ viele Register.  Bis auf das letzte dabei ben\"otigte Register, 
+            nennen wir es $R_x$, in dem wir das Ergebnis dieser Rechnung speichern m\"ussen, k\"onnen
+            wir alle diese Register f\"ur die Berechnung des Ausdrucks $e_2$ wiederverwenden.
+            Folglich ben\"otigen wir f\"ur die Berechnung von $e_2$ also ein weiteres Register, das wir
+            jetzt mit $R_y$ bezeichnen.  Das Endergebnis k\"onnen wir nun mit dem Befehl
             \\[0.2cm]
             \hspace*{1.3cm}
             \textsl{op} $R_y$, $R_x$, $R_y$ 
             \\[0.2cm]
-            berechnen, so dass wir an dieser Stelle kein weiteres Register mehr benötigen.
+            berechnen, so dass wir an dieser Stelle kein weiteres Register mehr ben\"otigen.
             Wir halten fest:
             \\[0.2cm]
             \hspace*{1.3cm}
@@ -110,11 +110,11 @@ Register angibt, durch eine Fallunterscheidung nach dem Aufbau des Ausdrucks.
       \hspace*{1.3cm}
       $f(e_1, \cdots, e_n)$
       \\[0.2cm]
-      gelingt in Registern nur dann, wenn die einzelnen Ausdrücke $e_1$, $\cdots$, $e_n$
+      gelingt in Registern nur dann, wenn die einzelnen Ausdr\"ucke $e_1$, $\cdots$, $e_n$
       selber keine Funktions-Aufrufe mehr enthalten.  Wir werden daher unsere Grammatik so
-      einschränken, dass wir nur solche Funktions-Aufrufe betrachten, bei denen dies der
+      einschr\"anken, dass wir nur solche Funktions-Aufrufe betrachten, bei denen dies der
       Fall ist.  Des Weiteren werden wir Funktions-Aufrufe nur auf der rechten Seite einer
-      Zuweisungen zulassen.  Dann können wir jedes der Argumente von $f$ getrennt
+      Zuweisungen zulassen.  Dann k\"onnen wir jedes der Argumente von $f$ getrennt
       auswerten.  Da die Ergebnisse dieser Auswertungen ohnehin auf den Stack geschrieben
       werden, ist es nicht erforderlich, diese Ergebnisse in Registern zu speichern.
       Daher haben wir
@@ -125,44 +125,44 @@ Register angibt, durch eine Fallunterscheidung nach dem Aufbau des Ausdrucks.
 \end{enumerate}
 
 \exercise
-Geben Sie an, wie groß ein Ausdruck $e$ mindestens sein muss, damit 
+Geben Sie an, wie gro{\ss} ein Ausdruck $e$ mindestens sein muss, damit 
 $\textsl{ershov}(e) = n$ gilt.
 
 
 
-\section{Implementierung eines Compilers für den \textsc{SRP}}
-Nach den Vorüberlegungen aus dem letzten Abschnitt entwickeln wir 
-in diesem Abschnitt einen Compiler, der Code für den \textsc{Srp} erzeugt.
-Wir gehen dabei wieder von der Sprache Integer-\texttt{C} aus, für die wir 
+\section{Implementierung eines Compilers f\"ur den \textsc{SRP}}
+Nach den Vor\"uberlegungen aus dem letzten Abschnitt entwickeln wir 
+in diesem Abschnitt einen Compiler, der Code f\"ur den \textsc{Srp} erzeugt.
+Wir gehen dabei wieder von der Sprache Integer-\texttt{C} aus, f\"ur die wir 
 im letzten Kapitel einen Compiler in Byte-Code entwicklet haten.
   Diese Grammatik hatten wir in Abbildung \ref{fig:compiler.cup} gezeigt.
 
-Die Idee bei der Entwicklung eines Compilers für den \textsc{Srp} ist, dass wir zunächst
-berechnen, wieviele Register wir benötigen, um die 
-Zwischenergebnisse, die bei der Auswertung arithmetischer Ausdrücke entstehen, zu
-speichern.  Die restlichen Register können dann für die lokalen Variablen genutzt werden.
+Die Idee bei der Entwicklung eines Compilers f\"ur den \textsc{Srp} ist, dass wir zun\"achst
+berechnen, wieviele Register wir ben\"otigen, um die 
+Zwischenergebnisse, die bei der Auswertung arithmetischer Ausdr\"ucke entstehen, zu
+speichern.  Die restlichen Register k\"onnen dann f\"ur die lokalen Variablen genutzt werden.
 Sollten wir mehr lokale Variablen als freie Register haben, so speichern wir die
-überzähligen lokalen Variablen auf dem Stack.
+\"uberz\"ahligen lokalen Variablen auf dem Stack.
 Wir werden nur die Register \texttt{R1} bis \texttt{R29} benutzen, denn  wir gehen davon 
 aus,  dass folgendes gilt:
 \begin{enumerate}
 \item Das Register \texttt{R0}  speichert die Konstante $0$.
 \item Das Register \texttt{R30} speichert den Stack-Pointer.
-\item Das Register \texttt{R31} ist für die Berechnung von Sprungadressen und
+\item Das Register \texttt{R31} ist f\"ur die Berechnung von Sprungadressen und
       Speicherstellen reserviert.  
 \end{enumerate}
 In der Rechnertechnik-Vorlesung hatten wir eine Unterscheidung in solche
-Register, die beim Aufruf einer Funktion gesichert werden müssen und solche Register, die
-nicht gesichert werden, durchgeführt.  Diese Unterscheidung lassen wir fallen und
+Register, die beim Aufruf einer Funktion gesichert werden m\"ussen und solche Register, die
+nicht gesichert werden, durchgef\"uhrt.  Diese Unterscheidung lassen wir fallen und
 vereinbaren statt dessen, dass bei einem Funktionsaufruf alle Register, die von der
-Funktion verändert werden, gesichert werden müssen.  
+Funktion ver\"andert werden, gesichert werden m\"ussen.  
 Das vereinfacht die Entwicklung des Compilers etwas.
 
 \subsection{Diskussion der verschiedenen Klassen}
-Die Struktur des \textsc{SRP}-Compilers ist ähnlich zu der Struktur des
-\textsl{Java}-Byte-Code-Compilers:  Wir erzeugen zunächst einen abstrakten Syntax-Baum und
+Die Struktur des \textsc{SRP}-Compilers ist \"ahnlich zu der Struktur des
+\textsl{Java}-Byte-Code-Compilers:  Wir erzeugen zun\"achst einen abstrakten Syntax-Baum und
 haben dann in allen Klassen eine Methode $\textsl{compile}()$, die Code erzeugt, der den jeweils
-dargestellten Ausdruck übersetzt.  Die Erzeugung des Codes ist allerdings deutlich
+dargestellten Ausdruck \"ubersetzt.  Die Erzeugung des Codes ist allerdings deutlich
 komplexer als bei dem Byte-Code-Compiler.
 
 
@@ -267,7 +267,7 @@ Wir beginnen unsere Diskussion des \textsc{Srp}-Compilers mit der Klasse
 \ref{fig:Function.java-SRP-4} gezeigt ist.
 Abbildung \ref{fig:Function.java-SRP-1} auf Seite \pageref{fig:Function.java-SRP-1} zeigt die
 Member-Variablen der Klasse \texttt{Function}, den Konstruktor, sowie die Methode
-$\textsl{compile}()$.  Die Klasse repräsentiert eine Funktions-Definition der Form
+$\textsl{compile}()$.  Die Klasse repr\"asentiert eine Funktions-Definition der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{int $f$($p_1, \cdots, p_n$) \{ \textsl{decls}\ \textsl{body} \}}
@@ -275,16 +275,16 @@ $\textsl{compile}()$.  Die Klasse repräsentiert eine Funktions-Definition der Fo
 Die Member-Variablen haben folgende Bedeutung:
 \begin{enumerate}
 \item \texttt{mName} entspricht dem Funktions-Namen $f$.
-\item \texttt{mParameterList} entspricht den Übergabe-Parametern $p_1, \cdots, p_n$.
+\item \texttt{mParameterList} entspricht den \"Ubergabe-Parametern $p_1, \cdots, p_n$.
 \item \texttt{mDeclarations} ist die Liste der Deklarationen aller lokalen Variablen.
 \item \texttt{mBody} ist die Liste der Befehle im Rumpf der Funktion.
 \item \texttt{mNumberUsedRegs} ist die Anzahl der Register, die von dieser Funktion
       benutzt werden.
 \item \texttt{mNumberVarsOnStack} ist die Anzahl der lokalen Variablen, die auf dem Stack
-      gespeichert werden müssen, weil in den Registern kein Platz mehr für diese Variablen ist.
-\item \texttt{mSymbolTable} gibt für jede lokale Variable den Ort an, wo diese lokale
+      gespeichert werden m\"ussen, weil in den Registern kein Platz mehr f\"ur diese Variablen ist.
+\item \texttt{mSymbolTable} gibt f\"ur jede lokale Variable den Ort an, wo diese lokale
       Variable gespeichert ist.  Zur Spezifikation dieses Ortes haben wir die abstrakte
-      Klasse \texttt{Location} eingeführt, die über die Gleichung
+      Klasse \texttt{Location} eingef\"uhrt, die \"uber die Gleichung
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{Location = Memory(Integer offset) + Register(Integer number);}
@@ -299,39 +299,39 @@ Die Member-Variablen haben folgende Bedeutung:
       \texttt{SP + offset}
       \\[0.2cm]
       gespeichert.  Dabei gehen wir davon aus, dass der Stackpointer \texttt{SP} immer auf
-      die Rücksprung-Adresse der Funktion zeigt, so dass wir die Adresse der lokalen
-      Variablen tatsächlich immer nach der obigen Formel berechnen können.
-\item Zusätzlich hat die Klasse eine statische Variable \texttt{sName}, die den Namen
-      der Funktion enthält, die gerade geparst wird.
+      die R\"ucksprung-Adresse der Funktion zeigt, so dass wir die Adresse der lokalen
+      Variablen tats\"achlich immer nach der obigen Formel berechnen k\"onnen.
+\item Zus\"atzlich hat die Klasse eine statische Variable \texttt{sName}, die den Namen
+      der Funktion enth\"alt, die gerade geparst wird.
 \end{enumerate}
 Der Konstruktor der Klasse \texttt{Function} speichert die Member-Variablen, die den
-abstrakten Syntax-Baum repräsentieren und die bereits vom Parser erzeugt werden können.
+abstrakten Syntax-Baum repr\"asentieren und die bereits vom Parser erzeugt werden k\"onnen.
 
-Interessanter ist die Methode $\textsl{compile}()$, die diese Funktion übersetzt.
+Interessanter ist die Methode $\textsl{compile}()$, die diese Funktion \"ubersetzt.
 Im Gegensatz zu unserer Implementierung des \textsl{Java}-Byte-Code-Compilers behandeln
-wir bei dieser Implementierung die Sonderfälle, die bei den Funktionen 
+wir bei dieser Implementierung die Sonderf\"alle, die bei den Funktionen 
 $\textsl{putchar()}$ und $\textsl{getchar}()$ auftreten, nicht sondern gehen davon aus,
-dass diese Funktionen bereits in einer Bibliothek zur Verfügung gestellt werden und dann
-später von einem Linker eingebunden werden.  Die Funktion $\textsl{compile}()$ arbeitet
+dass diese Funktionen bereits in einer Bibliothek zur Verf\"ugung gestellt werden und dann
+sp\"ater von einem Linker eingebunden werden.  Die Funktion $\textsl{compile}()$ arbeitet
 dann wie folgt:
 \begin{enumerate}
-\item Zunächst berechnen wir für die Parameter und die lokalen Variablen der Funktion,
+\item Zun\"achst berechnen wir f\"ur die Parameter und die lokalen Variablen der Funktion,
       wo diese abgespeichert werden.  Diese Berechnung wird von der Methode
-      $\textsl{initTable}()$ durchgeführt.  Das Ergebnis dieser Rechnung wird
-      in der Variablen \texttt{mSymbolTable} abgelegt.  Zusätzlich initialisiert diese
+      $\textsl{initTable}()$ durchgef\"uhrt.  Das Ergebnis dieser Rechnung wird
+      in der Variablen \texttt{mSymbolTable} abgelegt.  Zus\"atzlich initialisiert diese
       Methode die Member-Variablen \texttt{mNumberUsedRegs} und \texttt{mNumberVarsOnStack}. 
-\item Anschließend erzeugen wir eine Liste von Assembler-Befehlen, die mit der Assembler-Deklaration
+\item Anschlie{\ss}end erzeugen wir eine Liste von Assembler-Befehlen, die mit der Assembler-Deklaration
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{PROC} \textsl{mName}
       \\[0.2cm]
       beginnt.  Als erstes sichert die Prozedur dann alle die Register, die von der Prozedur
-      eventuell verändert werden.  Die dafür notwendigen Assembler-Befehle werden von der
+      eventuell ver\"andert werden.  Die daf\"ur notwendigen Assembler-Befehle werden von der
       Funktion $\textsl{saveRegisters}()$ erzeugt.
-\item Danach werden die Übergabe-Parameter, die wir in Registern speichern wollen,
-      in die entsprechenden Register geladen.  Der dafür notwendige Code wird von der
+\item Danach werden die \"Ubergabe-Parameter, die wir in Registern speichern wollen,
+      in die entsprechenden Register geladen.  Der daf\"ur notwendige Code wird von der
       Methode $\textsl{fillRegisters}()$ erzeugt.
-\item Zum Schluss werden die einzelnen Befehle, die im Rumpf der Funktion stehen, übersetzt.      
+\item Zum Schluss werden die einzelnen Befehle, die im Rumpf der Funktion stehen, \"ubersetzt.      
 \end{enumerate}
 Die Methode $\textsl{saveRegisters}()$ erzeugt Code, mit dem die Register, die in der
 Methode benutzt werden, auf dem Stack gesichert werden.  Dazu benutzt Sie den
@@ -341,31 +341,31 @@ Pseudo-Assembler-Befehl
 \texttt{storec R$i$, SP + $o$},
 \\[0.2cm]
 mit dem das Register \texttt{R$i$} an die Adresse  $\texttt{SP} + o$ im Hauptspeicher
-geschrieben wird.  Dieser Pseudo-Befehl wird in die folgenden Assembler-Befehle übersetzt:
+geschrieben wird.  Dieser Pseudo-Befehl wird in die folgenden Assembler-Befehle \"ubersetzt:
 
 \noindent
 \hspace*{1.3cm} \texttt{const R31, $o$} \\
 \hspace*{1.3cm} \texttt{add \ \ R31, R30, R31} \\
 \hspace*{1.3cm} \texttt{store R$i$, R31} 
 \\[0.2cm]
-Anschließend speichern wir die Adresse der ersten freien Stelle auf dem Stack in der
+Anschlie{\ss}end speichern wir die Adresse der ersten freien Stelle auf dem Stack in der
 Symboltabelle unter dem Namen ``\symbol{36}free@'' + \textsl{name}, wobei \texttt{name}
-für den Namen der Prozedur steht.
+f\"ur den Namen der Prozedur steht.
 Genauso werden die Anzahl der Variablen, die wir auf dem Stack haben sowie die Anzahl der
-benutzten Register in der Symboltabelle abgespeichert.  Diese Werte werden später in der
-Klasse \texttt{ReturnStmnt} benötigt um die alten Werte der auf dem Stack gesicherten
+benutzten Register in der Symboltabelle abgespeichert.  Diese Werte werden sp\"ater in der
+Klasse \texttt{ReturnStmnt} ben\"otigt um die alten Werte der auf dem Stack gesicherten
 Register wieder herzustellen.
 
 
 Die Methode $\textsl{fillRegisters}()$ hat die Aufgabe, die Parameter, mit denen die
-Funktion aufgerufen worden ist, vom Stack in die dafür vorgesehenen Register zu laden.
+Funktion aufgerufen worden ist, vom Stack in die daf\"ur vorgesehenen Register zu laden.
 Dazu benutzt diese Methode den Pseudo-Assembler-Befehl
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{loadc R$i$, SP + $o$},
 \\[0.2cm]
 mit dem das Register \texttt{R$i$} von der Adresse  $\texttt{SP} + o$ im Hauptspeicher
-geladen wird.  Dieser Pseudo-Befehl wird in die folgenden Assembler-Befehle übersetzt:
+geladen wird.  Dieser Pseudo-Befehl wird in die folgenden Assembler-Befehle \"ubersetzt:
 \\[0.2cm]
 \noindent
 \hspace*{1.3cm} \texttt{const R31, $o$} \\
@@ -422,25 +422,25 @@ Pseudobefehl direkt umsetzen kann.
 
 Die in Abbildungen \ref{fig:Function.java-SRP-3} gezeigte Methode $\textsl{initTable}()$
 berechnet die Symboltabelle, in der hinterlegt ist, wo die einzelnen Variablen
-abgespeichert sind.  Dazu wird zunächst die Funktion $\textsl{maxErshov}()$ aufgerufen.
-Diese Funktion berechnet, wieviele Register maximal für Zwischenergebnisse benötigt
-werden.  Das erste Register, über das wir frei verfügen können, hat dann den Wert
+abgespeichert sind.  Dazu wird zun\"achst die Funktion $\textsl{maxErshov}()$ aufgerufen.
+Diese Funktion berechnet, wieviele Register maximal f\"ur Zwischenergebnisse ben\"otigt
+werden.  Das erste Register, \"uber das wir frei verf\"ugen k\"onnen, hat dann den Wert
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{maxErshov}() + 1$.
 \\[0.2cm]
-Als nächstes ordnen wir in den Zeilen 65 bis 74 den Übergabe-Parametern der Funktion
-Register zu.  Falls wir für einen Parameter kein freies Register mehr finden können,
-berücksichtigen wir in Zeile 71, dass die Parameter einer Funktion ja schon auf dem Stack
-unterhalb der Rücksprungadresse liegen und tragen die entsprechende Adresse in der
+Als n\"achstes ordnen wir in den Zeilen 65 bis 74 den \"Ubergabe-Parametern der Funktion
+Register zu.  Falls wir f\"ur einen Parameter kein freies Register mehr finden k\"onnen,
+ber\"ucksichtigen wir in Zeile 71, dass die Parameter einer Funktion ja schon auf dem Stack
+unterhalb der R\"ucksprungadresse liegen und tragen die entsprechende Adresse in der
 Symboltabelle ein.  Da auf Register wesentlich schneller zugegriffen werden kann als auf
 den Stack, der ja im Hauptspeicher liegt, ist das
-Ziel, möglichst alle Parameter in Registern zur Verfügung zu haben.  Wenn es aber nicht
-genügend  Register gibt, die noch frei sind, dann müssen wir uns eben damit begnügen, die
-überzähligen Parameter im Bedarfsfall vom Stack zu laden.
+Ziel, m\"oglichst alle Parameter in Registern zur Verf\"ugung zu haben.  Wenn es aber nicht
+gen\"ugend  Register gibt, die noch frei sind, dann m\"ussen wir uns eben damit begn\"ugen, die
+\"uberz\"ahligen Parameter im Bedarfsfall vom Stack zu laden.
 
 
-In den Zeilen 76 bis 85 suchen wir anschließend für die lokalen Variablen einen Platz.
+In den Zeilen 76 bis 85 suchen wir anschlie{\ss}end f\"ur die lokalen Variablen einen Platz.
 Falls noch Register frei sind, ordnen wir den Variablen Register zu, sonst kommen die lokalen Variablen
 auf den Stack.
 
@@ -482,8 +482,8 @@ auf den Stack.
 \label{fig:Function.java-SRP-4}
 \end{figure}
 
-Abbildung \ref{fig:Function.java-SRP-4} zeigt schließlich die Implementierung der Funktion
-$\textsl{maxErshov}()$, bei der einfach das Maximum über alle Befehle des Rumpfs der
+Abbildung \ref{fig:Function.java-SRP-4} zeigt schlie{\ss}lich die Implementierung der Funktion
+$\textsl{maxErshov}()$, bei der einfach das Maximum \"uber alle Befehle des Rumpfs der
 Funktion gebildet wird.
 
 \begin{figure}[!ht]
@@ -550,52 +550,52 @@ Funktion gebildet wird.
 \label{fig:Sum.java-SRP}
 \end{figure}
 
-Abbildung \ref{fig:Sum.java-SRP} zeigt exemplarisch, wie die Ershov-Zahlen für einzelne
-Ausdrücke berechnet werden und wie der Code für einen arithmetischen Ausdruck der Form
+Abbildung \ref{fig:Sum.java-SRP} zeigt exemplarisch, wie die Ershov-Zahlen f\"ur einzelne
+Ausdr\"ucke berechnet werden und wie der Code f\"ur einen arithmetischen Ausdruck der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{lhs} + \textsl{rhs}$
 \\[0.2cm]
 produziert
-wird.  Die Klasse \texttt{Sum} repräsentiert einen Ausdruck der Form
+wird.  Die Klasse \texttt{Sum} repr\"asentiert einen Ausdruck der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{mLhs} + \textsl{mRhs}$.
 \\[0.2cm]
 Von der abstrakten Klasse \textsl{Expr} erbt die Klasse \textsl{Sum} die beiden
 Member-Variablen \texttt{mErshov} und \texttt{mRegister}.  Die Variable \texttt{mErshov}
-gibt an, wieviele Register zur Übersetzung dieses Ausdrucks benötigt werden.  Die Variable
+gibt an, wieviele Register zur \"Ubersetzung dieses Ausdrucks ben\"otigt werden.  Die Variable
 \texttt{mRegister} gibt das Register an, in dem der Wert dieses Ausdrucks abgespeichert wird.
-Die Ershov-Zahl für diesen Ausdruck wird bereits im Konstruktor ermittelt, wobei die
+Die Ershov-Zahl f\"ur diesen Ausdruck wird bereits im Konstruktor ermittelt, wobei die
 Fallunterscheidung unmittelbar aus der im letzten Abschnitt gegebenen Diskussion folgt.
 
-Die Methode $\textsl{compile}()$ bekommt als erstes Argument eine natürliche Zahl
+Die Methode $\textsl{compile}()$ bekommt als erstes Argument eine nat\"urliche Zahl
 \textsl{base} und als zweites Argument die Symboltabelle.  Das Argument \textsl{base} gibt
-dabei den Index des ersten Registers an, das für Zwischen-Ergebnisse genutzt werden kann.
+dabei den Index des ersten Registers an, das f\"ur Zwischen-Ergebnisse genutzt werden kann.
 \begin{enumerate}
-\item Betrachten wir zunächst den Fall, dass die Zahl der Register, die für die Berechnung von
-      \texttt{mLhs} benötigt wird, kleiner ist, als die Zahl der für \texttt{mRhs} benötigten
-      Register.  In diesem Fall berechnen wir erst \texttt{mRhs}.  Anschließend berechnen
-      wir \texttt{mLhs}.  Da wir dafür weniger Register benötigen als für die Berechnung
+\item Betrachten wir zun\"achst den Fall, dass die Zahl der Register, die f\"ur die Berechnung von
+      \texttt{mLhs} ben\"otigt wird, kleiner ist, als die Zahl der f\"ur \texttt{mRhs} ben\"otigten
+      Register.  In diesem Fall berechnen wir erst \texttt{mRhs}.  Anschlie{\ss}end berechnen
+      wir \texttt{mLhs}.  Da wir daf\"ur weniger Register ben\"otigen als f\"ur die Berechnung
       von \texttt{mRhs} werden wir das Ergebnis, das wir bei der Berechnung von
-      \texttt{mRhs} im letzten Register gesichert haben, nicht überschreiben.
+      \texttt{mRhs} im letzten Register gesichert haben, nicht \"uberschreiben.
 
-      Wir speichern für jeden Ausdruck in der Member-Variablen \texttt{mRegister}, die in
-      der abstrakten Klasse \texttt{Expr} definiert ist und die über die Funktion $\textsl{getReg}()$
+      Wir speichern f\"ur jeden Ausdruck in der Member-Variablen \texttt{mRegister}, die in
+      der abstrakten Klasse \texttt{Expr} definiert ist und die \"uber die Funktion $\textsl{getReg}()$
       abgefragt werden kann, dasjenige Register, in dem das Ergebnis des Ausdrucks
-      abgespeichert wird.  Wir setzen diese Variable in Zeile 38 und können dann die Summe
+      abgespeichert wird.  Wir setzen diese Variable in Zeile 38 und k\"onnen dann die Summe
       durch den Befehl
       \\[0.2cm]
       \hspace*{1.3cm}
       \texttt{add mRegister, mLhs.getReg(), mRhs.getReg()}
       \\[0.2cm]
       berechnen.  Dieser Fall wird in den Zeilen 22 -- 26 abgehandelt.
-\item Der umgekehrte Fall, bei dem die Zahl der Register, die für die Berechnung von
-      \texttt{mRhs} benötigt wird, kleiner ist, als die Zahl der für \texttt{mLhs} benötigten
+\item Der umgekehrte Fall, bei dem die Zahl der Register, die f\"ur die Berechnung von
+      \texttt{mRhs} ben\"otigt wird, kleiner ist, als die Zahl der f\"ur \texttt{mLhs} ben\"otigten
       Register, kann analog behandelt werden und ist in den Zeilen
       27 -- 31 gezeigt.
-\item Abschließend betrachten wir den Fall, in dem die Zahl der Register, die für die Berechnung von
-      \texttt{mLhs} benötigt wird, genauso groß ist wie die Zahl der für \texttt{mRhs} benötigten
+\item Abschlie{\ss}end betrachten wir den Fall, in dem die Zahl der Register, die f\"ur die Berechnung von
+      \texttt{mLhs} ben\"otigt wird, genauso gro{\ss} ist wie die Zahl der f\"ur \texttt{mRhs} ben\"otigten
       Register.  In diesem Fall benutzen wir zur Berechnung von \texttt{mLhs} die Register
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -609,14 +609,14 @@ dabei den Index des ersten Registers an, das für Zwischen-Ergebnisse genutzt wer
       \hspace*{1.3cm}
       $\textsl{base} + 1 + \textsl{mLhs}.\textsl{getErshov}()$ 
       \\[0.2cm]
-      gespeicherte Ergebnis nicht überschrieben werden kann.  
+      gespeicherte Ergebnis nicht \"uberschrieben werden kann.  
       Dieser Fall ist der Grund, warum wir bei der Methode $\textsl{compile}()$ das
-      zusätzliche Argument \textsl{base} benötigen.  Der Fall ist in den Zeilen 33 bis 36
+      zus\"atzliche Argument \textsl{base} ben\"otigen.  Der Fall ist in den Zeilen 33 bis 36
       gezeigt.
 \item Der Fall, dass die Anzahl der Register nicht ausreichend ist, um die
-      Zwischen-Ergebnisse, die bei der Berechnung eines Ausdrucks auftreten können, zu
-      berechnen, wird in Zeile 42 behandelt.  Dieser Fall kann, wie in einer Übungsaufgabe
-      gezeigt wird, bei 29 frei verfügbaren Registern de facto nicht auftreten.
+      Zwischen-Ergebnisse, die bei der Berechnung eines Ausdrucks auftreten k\"onnen, zu
+      berechnen, wird in Zeile 42 behandelt.  Dieser Fall kann, wie in einer \"Ubungsaufgabe
+      gezeigt wird, bei 29 frei verf\"ugbaren Registern de facto nicht auftreten.
 \end{enumerate}
 
 \begin{figure}[!ht]
@@ -673,15 +673,15 @@ dabei den Index des ersten Registers an, das für Zwischen-Ergebnisse genutzt wer
 
 \noindent
 Die  in Abbildung \ref{fig:ReturnStmnt.java-SRP} gezeigte Klasse \texttt{ReturnStmnt}
-zeigt die Übersetzung eines Befehls der Form 
+zeigt die \"Ubersetzung eines Befehls der Form 
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{return \textsl{expr};} 
 \\[0.2cm]
-In der Methode $\textsl{compile}()$ wird zunächst der Ausdruck \textsl{expr} berechnet und
+In der Methode $\textsl{compile}()$ wird zun\"achst der Ausdruck \textsl{expr} berechnet und
 das Ergebnis dieser Rechnung wird in Zeile 15 auf den Stack gelegt.
-Anschließend werden mit dem von der Methode $\textsl{restoreRegisters}()$ erzeugten Code
-die Register wieder auf die Werte zurück gesetzt, die auf dem Stack gespeichert wurden.
+Anschlie{\ss}end werden mit dem von der Methode $\textsl{restoreRegisters}()$ erzeugten Code
+die Register wieder auf die Werte zur\"uck gesetzt, die auf dem Stack gespeichert wurden.
 
 
 \begin{figure}[!ht]
@@ -742,42 +742,42 @@ Zum Abschluss diskutieren wir die in Abbildung \ref{fig:FunctionCall.java-SRP} g
 \hspace*{1.3cm}
 $f(e_1, \cdots, e_n)$
 \\[0.2cm]
-repräsentiert.  Der Konstruktor initialisiert sowohl den Namen als auch die Argumente der
-Funktion und berechnet anschließend die Ershov-Zahl als Maximum der Ershov-Zahlen der
+repr\"asentiert.  Der Konstruktor initialisiert sowohl den Namen als auch die Argumente der
+Funktion und berechnet anschlie{\ss}end die Ershov-Zahl als Maximum der Ershov-Zahlen der
 Argumente.  Die Aufgabe der Methode \textsl{compile} ist es nun, Code zu erzeugen, der
 diese Argumente berechnet und auf dem Stack ablegt.  In der Symboltabelle haben wir unter
 der Pseudo-Variablen ``\symbol{36}free'' gespeichert, wo der erste freie Platz auf dem
 Stack ist. Dort legen wir in der Schleife in Zeile 20 -- 23 die Argumente ab.
-Anschließend erhöhen wir in Zeile 26 den Stack-Pointer, so dass er nun auf das letzte auf
+Anschlie{\ss}end erh\"ohen wir in Zeile 26 den Stack-Pointer, so dass er nun auf das letzte auf
 dem Stack abgelegte Argument zeigt und rufen die Funktion mit einem \texttt{call}-Befehl auf.
-In Zeile 29 laden wir das Ergebnis vom Stack und speichern es in dem dafür vorgesehenen
-Register.  Danach wird der Stack-Pointer wieder auf seinen ursprünglichen Wert zurück gesetzt.
+In Zeile 29 laden wir das Ergebnis vom Stack und speichern es in dem daf\"ur vorgesehenen
+Register.  Danach wird der Stack-Pointer wieder auf seinen urspr\"unglichen Wert zur\"uck gesetzt.
 
 \section{Schlussbetrachtung}
 Der im letzten Abschnitt dargestellte Compiler geht sehr sorglos mit Registern um.
 Insbesondere das Sichern und Wiederherstellen der Register auf dem Stack, das von diesem
-Compiler durchgeführt würde, ist für die Praxis viel zu aufwendig.  Um einen
+Compiler durchgef\"uhrt w\"urde, ist f\"ur die Praxis viel zu aufwendig.  Um einen
 halbwegs brauchbaren Code zu erzeugen, sind wenigstens die folgenden Schritte
 erforderlich:
 \begin{enumerate}
-\item Zunächst muss überprüft werden, welche Variablen an welcher Stelle des Programms
+\item Zun\"achst muss \"uberpr\"uft werden, welche Variablen an welcher Stelle des Programms
       \emph{lebendig} sind.  Dabei wird eine Variable an einer Stelle des Programms 
       dann als \emph{lebendig} bezeichnet, wenn der Wert, den diese Variable an der Stelle
-      hat, später noch für eine Rechnung benötigt wird.
+      hat, sp\"ater noch f\"ur eine Rechnung ben\"otigt wird.
 
       Der Grund, warum eine Berechnung der lebendigen Variablen Sinn macht, ist der, dass
       ein Register, das von einer Variablen belegt wird, die an dieser Stelle des
       Programms nicht mehr lebendig ist, von einer anderen Variablen genutzt werden kann.
-\item Anschließend geschieht nun die Register-Allokation, bei der nun auch verschiedenen
+\item Anschlie{\ss}end geschieht nun die Register-Allokation, bei der nun auch verschiedenen
       Variablen dasselbe Register zugeordnet werden kann.   Wird zwei verschiedenen
-      Variablen $x$ und $y$ dasselbe Register zugewiesen, so muss lediglich gewährleistet 
+      Variablen $x$ und $y$ dasselbe Register zugewiesen, so muss lediglich gew\"ahrleistet 
       werden, dass es keinen Punkt im Programm gibt, bei dem gleichzeitig sowohl $x$ als
       auch $y$ lebendig sind.
 \item Bei dem Sichern und Wiederherstellen der Register auf dem Stack muss ausgehend von der Analyse
       der Lebendigkeit der Variablen garantiert werden, dass nur solche Register gesichert
-      werden, deren Werte tatsächlich später noch benötigt werden. 
+      werden, deren Werte tats\"achlich sp\"ater noch ben\"otigt werden. 
 \end{enumerate}
-Wir werden uns im nächsten Kapitel näher mit der Frage der Lebendigkeit von Variablen beschäftigen.
+Wir werden uns im n\"achsten Kapitel n\"aher mit der Frage der Lebendigkeit von Variablen besch\"aftigen.
 
 
 %%% Local Variables: 

--- a/Lecture-Notes/regulaere-sprachen.tex
+++ b/Lecture-Notes/regulaere-sprachen.tex
@@ -28,18 +28,18 @@ Using the pumping lemma we will be able to show that the language
 \\[0.2cm]
 is not regular.
 
-\section{Abschluss-Eigenschaften regulärer Sprachen}
-In diesem Abschnitt zeigen wir, dass reguläre Sprachen unter den Boole'schen Operationen
+\section{Abschluss-Eigenschaften regul\"arer Sprachen}
+In diesem Abschnitt zeigen wir, dass regul\"are Sprachen unter den Boole'schen Operationen
 \emph{Vereinigung}, \emph{Durchschnitt} und \emph{Komplement} abgeschlossen sind.  Wir beginnen mit
 der Vereinigung.  
 
 \begin{Satz}
-  Sind $L_1$ und $L_2$ reguläre Sprachen, so ist auch die Vereinigung $L_1 \cup L_2$ 
-  eine reguläre Sprache.
+  Sind $L_1$ und $L_2$ regul\"are Sprachen, so ist auch die Vereinigung $L_1 \cup L_2$ 
+  eine regul\"are Sprache.
 \end{Satz}
 
 \proof
-Da $L_1$ und $L_2$ reguläre Sprachen sind, gibt es reguläre Ausdrücke $r_1$ und $r_2$, so dass
+Da $L_1$ und $L_2$ regul\"are Sprachen sind, gibt es regul\"are Ausdr\"ucke $r_1$ und $r_2$, so dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $L_1 = L(r_1)$ \quad und \quad $L_2 = L(r_2)$
@@ -49,35 +49,35 @@ gilt.  Wir definieren $r := r_1 + r_2$.  Offenbar gilt
 \hspace*{1.3cm}
 $L(r) = L(r_1 + r_2) = L(r_1) \cup L(r_2) = L_1 \cup L_2$.
 \\[0.2cm]
-Damit ist klar, dass auch $L_1 \cup L_2$ eine reguläre Sprache ist. \qed
+Damit ist klar, dass auch $L_1 \cup L_2$ eine regul\"are Sprache ist. \qed
 
 \begin{Satz} \label{satz:schnitt}
-  Sind $L_1$ und $L_2$ reguläre Sprachen, so ist auch der Durchschnitt $L_1 \cap L_2$ 
-  eine reguläre Sprache.
+  Sind $L_1$ und $L_2$ regul\"are Sprachen, so ist auch der Durchschnitt $L_1 \cap L_2$ 
+  eine regul\"are Sprache.
 \end{Satz}
 
-\proof Während der letzte Satz unmittelbar aus der Definition der regulären Ausdrücke
-gefolgert werden kann, müssen wir nun etwas weiter ausholen.  Im vorletzten Kapitel haben wir
-gesehen, dass es zu jedem regulären Ausdruck $r$ einen äquivalenten deterministischen
+\proof W\"ahrend der letzte Satz unmittelbar aus der Definition der regul\"aren Ausdr\"ucke
+gefolgert werden kann, m\"ussen wir nun etwas weiter ausholen.  Im vorletzten Kapitel haben wir
+gesehen, dass es zu jedem regul\"aren Ausdruck $r$ einen \"aquivalenten deterministischen
 endlichen Automaten $A$ gibt, der die durch $r$ spezifizierte Sprache akzeptiert und wir
-können außerdem annehmen, dass dieser Automat vollständig ist.  Es seien $r_1$ und $r_2$
-reguläre Ausdrücke, die die Sprachen $L_1$ und $L_2$ spezifizieren:
+k\"onnen au{\ss}erdem annehmen, dass dieser Automat vollst\"andig ist.  Es seien $r_1$ und $r_2$
+regul\"are Ausdr\"ucke, die die Sprachen $L_1$ und $L_2$ spezifizieren:
 \\[0.2cm]
 \hspace*{1.3cm}
 $L_1 = L(r_1)$ \quad und \quad $L_2 = L(r_2)$.
 \\[0.2cm]
-Dann konstruieren wir zunächst zwei vollständige deterministische endliche Automaten $A_1$
+Dann konstruieren wir zun\"achst zwei vollst\"andige deterministische endliche Automaten $A_1$
 und $A_2$, die diese Sprachen akzeptieren, es gilt also
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(A_1) = L_1$ \quad und \quad $L(A_2) = L_2$.
 \\[0.2cm]
-Wir werden für die Sprache $L_1 \cap L_2$ einen Automaten $A$ bauen, der diese Sprache
-akzeptiert.  Da es zu jedem Automaten auch einen regulären Ausdruck gibt, 
+Wir werden f\"ur die Sprache $L_1 \cap L_2$ einen Automaten $A$ bauen, der diese Sprache
+akzeptiert.  Da es zu jedem Automaten auch einen regul\"aren Ausdruck gibt, 
 der die Sprache beschreibt, die von dem Automaten akzeptiert wird, 
-haben wir damit dann gezeigt, dass die Sprache $L_1 \cap L_2$ regulär ist.
-Als Baumaterial für den Automaten $A$, der die Sprache $L_1 \cap L_2$ akzeptiert, 
-verwenden wir natürlich die Automaten $A_1$ und $A_2$.  Wir nehmen an, dass
+haben wir damit dann gezeigt, dass die Sprache $L_1 \cap L_2$ regul\"ar ist.
+Als Baumaterial f\"ur den Automaten $A$, der die Sprache $L_1 \cap L_2$ akzeptiert, 
+verwenden wir nat\"urlich die Automaten $A_1$ und $A_2$.  Wir nehmen an, dass
 \\[0.2cm]
 \hspace*{1.3cm}
 $A_1 = \langle Q_1, \Sigma, \delta_1, q_1, F_1 \rangle$ \quad und \quad
@@ -88,7 +88,7 @@ gilt und definieren $A$ als ein verallgemeinertes kartesisches Produkt der Autom
 \hspace*{1.3cm}
 $A := \langle Q_1 \times Q_2, \Sigma, \delta, \pair(q_1,q_2), F_1 \times F_2 \rangle$,
 \\[0.2cm]
-wobei die Zustands-Übergangs-Funktion 
+wobei die Zustands-\"Ubergangs-Funktion 
 \\[0.2cm]
 \hspace*{1.3cm}
  $\delta : (Q_1 \times Q_2) \times \Sigma \rightarrow Q_1 \times Q_2$ 
@@ -100,18 +100,18 @@ $\delta\bigl( \pair(p_1, p_2), c \bigr) := \bigl\langle\delta_1(p_1,c), \delta_2
 \\[0.2cm]
 definiert wird.  Der so definierte endliche Automat $A$ simuliert gleichzeitig die 
 beiden Automaten $A_1$ und $A_2$ indem er parallel berechnet, in
-welchem Zustand die Automaten $A_1$ und $A_2$ jeweils sind.  Damit das möglich ist, bestehen die Zustände
+welchem Zustand die Automaten $A_1$ und $A_2$ jeweils sind.  Damit das m\"oglich ist, bestehen die Zust\"ande
 von $A$ aus Paaren $\pair(p_1,p_2)$, so dass $p_1$ ein Zustand von $A_1$ und $p_2$ ein
 Zustand von $A_2$ ist und die Funktion $\delta$ berechnet den Nachfolgezustand zu
-$\pair(p_1,p_2)$, indem gleichzeitig die Nachfolgezustände von $p_1$ und $p_2$ berechnet werden.
+$\pair(p_1,p_2)$, indem gleichzeitig die Nachfolgezust\"ande von $p_1$ und $p_2$ berechnet werden.
 Ein String wird genau dann akzeptiert, wenn sowohl der Automat $A_1$ als auch der Automat $A_2$ einen
-akzeptierenden Zustand erreicht haben.  Daher wird die Menge der akzeptierenden Zustände 
+akzeptierenden Zustand erreicht haben.  Daher wird die Menge der akzeptierenden Zust\"ande 
 wie folgt definiert:
 \\[0.2cm]
 \hspace*{1.3cm}
 $F := \bigl\{ \pair(p_1,p_2) \in Q_1 \times Q_2 \mid p_1 \in F_1 \wedge p_2 \in F_2 \bigr\} = F_1 \times F_2$.
 \\[0.2cm]
-Damit gilt für alle $s \in \Sigma^*$:
+Damit gilt f\"ur alle $s \in \Sigma^*$:
 \\[0.2cm]
 \hspace*{1.3cm}
 $
@@ -134,40 +134,40 @@ Also haben wir nachgewiesen, dass
 gilt und das war zu zeigen. \qed
 
 \remark
-Prinzipiell wäre es möglich, für reguläre Ausdrücke eine Funktion 
+Prinzipiell w\"are es m\"oglich, f\"ur regul\"are Ausdr\"ucke eine Funktion 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\wedge: \textsl{RegExp} \times \textsl{RegExp} \rightarrow \textsl{RegExp}$
 \\[0.2cm]
-zu definieren, so dass für den Ausdruck $r_1 \wedge r_2$ die Beziehung
+zu definieren, so dass f\"ur den Ausdruck $r_1 \wedge r_2$ die Beziehung
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(r_1 \wedge r_2) = L(r_1) \cap L(r_2)$
 \\[0.2cm]
-gilt:  Zunächst berechnen wir zu $r_1$ und $r_2$ äquivalente nicht-deterministische
-endliche Automaten, überführen diese Automaten dann in einen vollständigen
+gilt:  Zun\"achst berechnen wir zu $r_1$ und $r_2$ \"aquivalente nicht-deterministische
+endliche Automaten, \"uberf\"uhren diese Automaten dann in einen vollst\"andigen
 deterministischen Automaten, bilden wie oben gezeigt das kartesische Produkt dieser
-Automaten und gewinnen schließlich aus diesem Automaten einen regulären 
-Ausdruck zurück.  Der so gewonnene reguläre Ausdruck wäre allerdings so groß,
-dass diese Funktion in der Praxis nicht implementiert wird, denn bei der Überführung
+Automaten und gewinnen schlie{\ss}lich aus diesem Automaten einen regul\"aren 
+Ausdruck zur\"uck.  Der so gewonnene regul\"are Ausdruck w\"are allerdings so gro{\ss},
+dass diese Funktion in der Praxis nicht implementiert wird, denn bei der \"Uberf\"uhrung
 eines nicht-deterministischen in einen deterministischen Automaten kann der Automat
-stark anwachsen und der reguläre Ausdruck, der sich aus einem Automaten ergibt, kann schon
-bei verhältnismäßig kleinen Automaten sehr unübersichtlich werden.
+stark anwachsen und der regul\"are Ausdruck, der sich aus einem Automaten ergibt, kann schon
+bei verh\"altnism\"a{\ss}ig kleinen Automaten sehr un\"ubersichtlich werden.
 
 \begin{Satz}
-  Ist $L$ eine reguläre Sprache über dem Alphabet $\Sigma$, so ist auch das Komplement
-  von $L$, die Sprache $\Sigma^* \backslash L$ eine reguläre Sprache.
+  Ist $L$ eine regul\"are Sprache \"uber dem Alphabet $\Sigma$, so ist auch das Komplement
+  von $L$, die Sprache $\Sigma^* \backslash L$ eine regul\"are Sprache.
 \end{Satz}
 
-\proof Wir gehen ähnlich vor wie beim Beweis des letzten Satzes und nehmen an, dass ein
-vollständiger deterministischer endlicher Automat $A$ gegeben ist, der die Sprache $L$
+\proof Wir gehen \"ahnlich vor wie beim Beweis des letzten Satzes und nehmen an, dass ein
+vollst\"andiger deterministischer endlicher Automat $A$ gegeben ist, der die Sprache $L$
 akzeptiert:
 \\[0.2cm]
 \hspace*{1.3cm} $L = L(A)$.
 \\[0.2cm]
 Wir konstruieren einen Automaten $\hat{A}$, der ein Wort $w$ genau dann akzeptiert, wenn
 $A$ dieses Wort nicht akzeptiert.  Dazu ist es lediglich erforderlich das Komplement der
-Menge der akzeptierenden Zustände von $A$ zu bilden.  Sei also
+Menge der akzeptierenden Zust\"ande von $A$ zu bilden.  Sei also
 \\[0.2cm]
 \hspace*{1.3cm} $A = \langle Q, \Sigma, \delta, q_0, F \rangle$.
 \\[0.2cm]
@@ -188,8 +188,8 @@ $
 und daraus folgt die Behauptung. \qed
 
 \begin{Korollar} \label{kor:mengendif}
-  Sind $L_1$ und $L_2$ reguläre Sprachen, so ist auch die Mengen-Differenz $L_1 \backslash L_2$ 
-  eine reguläre Sprache.
+  Sind $L_1$ und $L_2$ regul\"are Sprachen, so ist auch die Mengen-Differenz $L_1 \backslash L_2$ 
+  eine regul\"are Sprache.
 \end{Korollar}
 
 \proof
@@ -200,12 +200,12 @@ $L_1 \backslash L_2 = L_1 \cap (\Sigma^* \backslash L_2)$,
 \\[0.2cm]
 denn ein Wort $w$ ist genau dann in $L_1 \backslash L_2$, wenn $w$ einerseits in  $L_1$
 und andererseits im Komplement von $L_2$ liegt.  Nach dem letzten Satz wissen wir, dass mit
-$L_2$ auch das Komplement $\Sigma^* \backslash L_2$ regulär ist.  Da der Durchschnitt
-zweier regulärer Sprachen wieder regulär ist, ist damit auch $L_1 \backslash L_2$ regulär.
+$L_2$ auch das Komplement $\Sigma^* \backslash L_2$ regul\"ar ist.  Da der Durchschnitt
+zweier regul\"arer Sprachen wieder regul\"ar ist, ist damit auch $L_1 \backslash L_2$ regul\"ar.
 \qed
 \vspace*{0.3cm}
 
-Insgesamt haben wir jetzt gezeigt, dass reguläre Sprachen unter den Boole'schen
+Insgesamt haben wir jetzt gezeigt, dass regul\"are Sprachen unter den Boole'schen
 Mengen-Operationen abgeschlossen sind.
 
 \exerciseEng
@@ -224,50 +224,50 @@ Next, assume that the language $L \subseteq \Sigma^*$ is regular.  Prove that th
 language, too. \eox
 
 \section{Erkennung leerer Sprachen \label{section:leer}}
-In diesem Abschnitt untersuchen wir für einen gegeben deterministischen endlichen Automaten
+In diesem Abschnitt untersuchen wir f\"ur einen gegeben deterministischen endlichen Automaten
 \\[0.2cm]
 \hspace*{1.3cm}
 $A = \langle Q, \Sigma, \delta, q_0, F \rangle$
 \\[0.2cm]
 die Frage, ob die von $A$ erkannte Sprache leer ist, ob also $L(A) = \{\}$ gilt.  Dazu fassen wir den
 endlichen Automaten als einen Graphen auf: Die
-Knoten dieses Graphen sind die Zustände von $A$ und zwischen zwei Zuständen $q_1$ und
+Knoten dieses Graphen sind die Zust\"ande von $A$ und zwischen zwei Zust\"anden $q_1$ und
 $q_2$ gibt es genau dann eine Kante, die $q_1$ mit $q_2$ verbindet, wenn es einen
 Buchstaben $c \in \Sigma$ gibt, so dass $\delta(q_1, c) = q_2$ gilt.  Die Sprache $L(A)$
 ist genau dann leer, wenn es in diesem Graphen keinen Pfad gibt, der von dem Start-Zustand
 $q_0$ ausgeht und in einem akzeptierenden Zustand endet, wenn also die akzeptierenden
-Zustände von dem Start-Zustand aus nicht erreichbar sind.
+Zust\"ande von dem Start-Zustand aus nicht erreichbar sind.
 
 Daher berechnen wir zur Beantwortung der Frage, ob $L(A)$ leer ist,
-die Menge $R$ der von dem Start-Zustand $q_0$ erreichbaren Zustände.  Diese Berechnung
+die Menge $R$ der von dem Start-Zustand $q_0$ erreichbaren Zust\"ande.  Diese Berechnung
 kann am einfachsten iterativ erfolgen:
 \begin{enumerate}
 \item $q_0 \in R$.
 \item $p_1 \in R \wedge \delta(p_1,c) = p_2 \;\rightarrow\; p_2 \in R$.
 
-      Dieser Schritt wird solange wiederholt, bis wir der Menge $R$ keine neuen Zustände
-      mehr hinzufügen können.
+      Dieser Schritt wird solange wiederholt, bis wir der Menge $R$ keine neuen Zust\"ande
+      mehr hinzuf\"ugen k\"onnen.
 \end{enumerate}
-Die Sprache $L(A)$ ist genau dann leer, wenn keiner der akzeptierenden Zustände erreichbar
+Die Sprache $L(A)$ ist genau dann leer, wenn keiner der akzeptierenden Zust\"ande erreichbar
 ist, mit anderen Worten haben wir
 \\[0.2cm]
 \hspace*{1.3cm}
 $L(A) = \{\} \;\Leftrightarrow\; R \cap F = \{\}$.
 \\[0.2cm]
 Damit haben wir einen Algorithmus zur Beantwortung der Frage, ob $L(A) = \{\}$ ist:
-Wir bilden die Menge alle vom Start-Zustand $q_0$ erreichbaren Zustände und überprüfen
-dann, ob diese Menge einen akzeptierenden Zustand enthält.
+Wir bilden die Menge alle vom Start-Zustand $q_0$ erreichbaren Zust\"ande und \"uberpr\"ufen
+dann, ob diese Menge einen akzeptierenden Zustand enth\"alt.
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Bemerkung}:  Ist die reguläre Sprache $L$ nicht durch einen endlichen Automaten $A$,
-sondern durch einen regulären Ausdruck $r$ gegeben, so lässt sich durch einen einfachen
-rekursiven Algorithmus, der dem Aufbau des regulären Ausdrucks folgt, entscheiden, ob
+\textbf{Bemerkung}:  Ist die regul\"are Sprache $L$ nicht durch einen endlichen Automaten $A$,
+sondern durch einen regul\"aren Ausdruck $r$ gegeben, so l\"asst sich durch einen einfachen
+rekursiven Algorithmus, der dem Aufbau des regul\"aren Ausdrucks folgt, entscheiden, ob
 $L(r)$ leer ist.
 \begin{enumerate}
 \item $L(\emptyset) = \{\}$.
 \item $L(\varepsilon) \not= \{\}$.
-\item $L(c) \not= \{\}$ \quad für alle $c \in \Sigma$.
+\item $L(c) \not= \{\}$ \quad f\"ur alle $c \in \Sigma$.
 \item $L(r_1 \cdot r_2) = \{\} \;\Leftrightarrow\; L(r_1) = \{\} \vee L(r_2) = \{\}$.
 \item $L(r_1 + r_2) = \{\} \;\Leftrightarrow\; L(r_1) = \{\} \wedge L(r_2) = \{\}$.
 \item $L(r^*) \not= \{\}$.
@@ -701,30 +701,30 @@ Prove that the language  $L_{\mathrm{square}}$ is not a regular language.
 
 
 \solution
-Wir führen den Beweis indirekt und nehmen an, dass $L_{\mathrm{square}}$ regulär
-wäre.  Nach dem Pumping-Lemma gibt es dann eine positive natürliche Zahl $n$ (dies war die Anzahl
-der Zustände des deterministischen Automaten, der die Sprache erkennt), so dass sich jeder String
-$s \in L_{\mathrm{square}}$ mit $|s| \geq n$ in drei Teilstrings $u$, $v$ und $w$ aufspalten lässt, so dass gilt:
+Wir f\"uhren den Beweis indirekt und nehmen an, dass $L_{\mathrm{square}}$ regul\"ar
+w\"are.  Nach dem Pumping-Lemma gibt es dann eine positive nat\"urliche Zahl $n$ (dies war die Anzahl
+der Zust\"ande des deterministischen Automaten, der die Sprache erkennt), so dass sich jeder String
+$s \in L_{\mathrm{square}}$ mit $|s| \geq n$ in drei Teilstrings $u$, $v$ und $w$ aufspalten l\"asst, so dass gilt:
 \begin{enumerate}
 \item $s = uvw$,
 \item $|uv| \leq n$,
 \item $v \not= \varepsilon$,
 \item $\forall h \in \mathbb{N}_0: uv^hw \in L_{\mathrm{square}}$. 
 \end{enumerate} 
-Wir betrachten nun den String $s = a^{n^2}$.  Für die Länge dieses Strings gilt offenbar
+Wir betrachten nun den String $s = a^{n^2}$.  F\"ur die L\"ange dieses Strings gilt offenbar
 \[ |s| = \big| a^{n^2} \big| = n^2 \geq n. \]
 Also gibt es eine Aufspaltung von $s$ der Form $s = uvw$ mit den oben angegebenen Eigenschaften.
-Da $a$ der einzige Buchstabe ist, der in $s$ vorkommt, können in $u$, $v$ und $w$ auch keine anderen
-Buchstaben vorkommen und es muss natürliche Zahlen $x$, $y$ und $z$ geben, so dass 
+Da $a$ der einzige Buchstabe ist, der in $s$ vorkommt, k\"onnen in $u$, $v$ und $w$ auch keine anderen
+Buchstaben vorkommen und es muss nat\"urliche Zahlen $x$, $y$ und $z$ geben, so dass 
 \[ u = a^x,\; v = a^y\; \mbox{und}\; w = a^z \]
-gilt.  Wir untersuchen, welche Konzequenzen sich daraus für die Zahlen $x$, $y$ und $z$ ergeben.
+gilt.  Wir untersuchen, welche Konzequenzen sich daraus f\"ur die Zahlen $x$, $y$ und $z$ ergeben.
 \begin{enumerate}
 \item Die Zerlegung $s = uvw$ schreibt sich als $a^{n^2} = a^xa^ya^z$ und daraus folgt
       \begin{equation}
         \label{eq:e1}
          n^2 = x + y + z.     
       \end{equation}
-\item Die Ungleichung $|uv| \leq n$ ist jetzt äquivalent zu $x +y \leq n$, woraus 
+\item Die Ungleichung $|uv| \leq n$ ist jetzt \"aquivalent zu $x +y \leq n$, woraus 
       \begin{equation}
         \label{eq:e2}
         y \leq n
@@ -741,9 +741,9 @@ gilt.  Wir untersuchen, welche Konzequenzen sich daraus für die Zahlen $x$, $y$ 
         \forall h \in \mathbb{N}_0: a^xa^{y\cdot h}a^z \in L_{\mathrm{square}}. 
       \end{equation}
 \end{enumerate}
-Die letzte Gleichung muss insbesondere auch für den Wert $h=2$ gelten:
+Die letzte Gleichung muss insbesondere auch f\"ur den Wert $h=2$ gelten:
 \[ a^xa^{y\cdot 2}a^z \in L_{\mathrm{square}}.  \]
-Nach Definition der Sprache $L_{\mathrm{square}}$ gibt es dann eine natürliche Zahl
+Nach Definition der Sprache $L_{\mathrm{square}}$ gibt es dann eine nat\"urliche Zahl
 $k$, so dass gilt
 \begin{equation}
   \label{eq:e5}
@@ -774,8 +774,8 @@ Damit haben wir insgesamt  $k^2 < (n+1)^2$ gezeigt und das impliziert
 \end{equation}
 Zusammen mit Ungleichung (\ref{eq:e6}) liefert Ungleichung (\ref{eq:e7}) nun die Ungleichungs-Kette
 \[ n < k < n + 1. \]
-Da andererseits $k$ eine natürliche Zahl sein muss und $n$ ebenfalls eine natürliche Zahl ist,
-haben wir jetzt einen Widerspruch, denn zwischen $n$ und $n+1$ gibt es keine natürliche Zahl.
+Da andererseits $k$ eine nat\"urliche Zahl sein muss und $n$ ebenfalls eine nat\"urliche Zahl ist,
+haben wir jetzt einen Widerspruch, denn zwischen $n$ und $n+1$ gibt es keine nat\"urliche Zahl.
 \qed
 \pagebreak
 
@@ -807,9 +807,9 @@ is not regular.  \eox
 
 \noindent
 \textbf{Beweis}:
-Wir führen den Beweis indirekt und nehmen an, $L$ wäre regulär.  Nach
-dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es für alle Strings $s \in L$, 
-deren Länge größer-gleich $n$ ist, eine Zerlegung
+Wir f\"uhren den Beweis indirekt und nehmen an, $L$ w\"are regul\"ar.  Nach
+dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es f\"ur alle Strings $s \in L$, 
+deren L\"ange gr\"o{\ss}er-gleich $n$ ist, eine Zerlegung
 \\[0.2cm]
 \hspace*{1.3cm}
 $s = uvw$
@@ -820,34 +820,34 @@ mit den folgenden drei Eigenschaften gibt:
 \item $|uv| \leq n$ \quad und
 \item $\forall h \in \mathbb{N}_0: u v^h w \in L$.
 \end{enumerate}
-Wir wählen nun eine Primzahl $p$, die größer-gleich  $n + 2$ ist und setzen $s = \mathtt{a}^p$.
-Dann gilt $|s| = p \geq n$ und die Voraussetzung des Pumping-Lemmas ist erfüllt.
+Wir w\"ahlen nun eine Primzahl $p$, die gr\"o{\ss}er-gleich  $n + 2$ ist und setzen $s = \mathtt{a}^p$.
+Dann gilt $|s| = p \geq n$ und die Voraussetzung des Pumping-Lemmas ist erf\"ullt.
 Wir finden also eine Zerlegung von $\mathtt{a}^p$ der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\mathtt{a}^p = uvw$ 
 \\[0.2cm]
 mit den oben angegebenen Eigenschaften.
-Aufgrund der Gleichung $s = uvw$ können die Teilstrings $u$, $v$ und $w$ nur aus dem
-Buchstaben ``\texttt{a}'' bestehen.  Also gibt es natürliche Zahlen $x$, $y$, und
+Aufgrund der Gleichung $s = uvw$ k\"onnen die Teilstrings $u$, $v$ und $w$ nur aus dem
+Buchstaben ``\texttt{a}'' bestehen.  Also gibt es nat\"urliche Zahlen $x$, $y$, und
 $z$ so dass gilt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $u = \mathtt{a}^x$, \quad $v = \mathtt{a}^y$ \quad und \quad $w = \mathtt{a}^z$.
 \\[0.2cm]
-Für  $x$, $y$ und $z$ gilt dann Folgendes:
+F\"ur  $x$, $y$ und $z$ gilt dann Folgendes:
 \begin{enumerate}
 \item $x + y + z = p$,
 \item $y \not= 0$,
 \item $x + y \leq n$,
 \item $\forall h \in \mathbb{N}_0: x + h \cdot y + z \in \mathbb{P}$.
 \end{enumerate}
-Setzen wir in der letzten Gleichung für $h$ den Wert $(x + z)$ ein, so erhalten wir
+Setzen wir in der letzten Gleichung f\"ur $h$ den Wert $(x + z)$ ein, so erhalten wir
 \\[0.2cm]
 \hspace*{1.3cm}
 $x + (x + z)\cdot y + z \in P$.
 \\[0.2cm]
-Wegen $x + (x + z)\cdot y + z = (x + z) \cdot (1 + y)$ hätten wir dann
+Wegen $x + (x + z)\cdot y + z = (x + z) \cdot (1 + y)$ h\"atten wir dann
 \\[0.2cm]
 \hspace*{1.3cm}
 $(x + z) \cdot (1 + y) \in \mathbb{P}$.
@@ -856,31 +856,31 @@ Das kann aber nicht sein, denn wegen $y > 0$ ist der Faktor $1 + y$ von 1
 verschieden und wegen $x + y \leq n$ und $x + y + z = p$ und $p \geq n + 2$ wissen wir, dass
 $z \geq 2$ ist, so dass auch der Faktor $(x + z)$ von 1 verschieden ist.  Damit kann das Produkt
 $(x + z) \cdot (1 + y)$ aber keine Primzahl mehr sein und wir haben einen Widerspruch zu der
-Annahme, dass $L$ regulär ist. \qed
+Annahme, dass $L$ regul\"ar ist. \qed
 
 
 \exercise
-Die Sprache $L_{\mathrm{power}}$ beinhaltet alle Wörter der Form $\mathtt{a}^n$ für die $n$ eine
+Die Sprache $L_{\mathrm{power}}$ beinhaltet alle W\"orter der Form $\mathtt{a}^n$ f\"ur die $n$ eine
 Zweier-Potenz ist, es gilt also
 \\[0.2cm]
 \hspace*{1.3cm}
 $L_{\mathrm{power}} = \bigl\{ \mathtt{a}^{2^k} \mid k \in \mathbb{N}_0 \bigr\}$
 \\[0.2cm]
-Zeigen Sie mit Hilfe des Pumping-Lemmas, dass die Sprache $L_{\mathrm{power}}$ keine reguläre Sprache ist.
+Zeigen Sie mit Hilfe des Pumping-Lemmas, dass die Sprache $L_{\mathrm{power}}$ keine regul\"are Sprache ist.
 \eox
 
 \exercise
-Für zwei natürliche Zahlen $k$ und $l$ bezeichne der Ausdruck $\mathtt{ggt}(k, l)$ den größten
+F\"ur zwei nat\"urliche Zahlen $k$ und $l$ bezeichne der Ausdruck $\mathtt{ggt}(k, l)$ den gr\"o{\ss}ten
 gemeinsamen Teiler von $k$ und $l$.  Wir definieren die Sprache $L_{\mathrm{ggt}}$ als
 \\[0.2cm]
 \hspace*{1.3cm}
 $L_{\mathrm{ggt}} := \bigl\{ \mathtt{a}^k\mathtt{b}^l \mid k \in \mathbb{N} \wedge l \in \mathbb{N} \wedge \mathtt{ggt}(k, l) = 1 \bigr\}$.
 \\[0.2cm]
-Zeigen Sie, dass die Sprache $L_{\mathrm{ggt}}$ keine reguläre Sprache ist.
+Zeigen Sie, dass die Sprache $L_{\mathrm{ggt}}$ keine regul\"are Sprache ist.
 \vspace{0.2cm}
 
 \noindent
-\textbf{Hinweis}:  Nutzen Sie aus, dass reguläre Sprachen unter Komplement-Bildung abgeschlossen sind.
+\textbf{Hinweis}:  Nutzen Sie aus, dass regul\"are Sprachen unter Komplement-Bildung abgeschlossen sind.
 \eox
 
 

--- a/Lecture-Notes/sed.tex
+++ b/Lecture-Notes/sed.tex
@@ -1,5 +1,5 @@
 \section{sed}
-Das Werkzeug \texttt{sed} ist ein \emph{Stream-Editor}, der auf regulären Ausdrücken
+Das Werkzeug \texttt{sed} ist ein \emph{Stream-Editor}, der auf regul\"aren Ausdr\"ucken
 basiert.  Ein \emph{Stream-Editor} ist ein \emph{Filter}, also ein Programm, das von der
 Standard-Eingabe liest und auf die Standard-Ausgabe schreibt.  Das Programm kann
 wie folgt aufgerufen werden:
@@ -13,36 +13,36 @@ Hierbei bezeichnet \textsl{cmd} ein \texttt{sed}-Komando.  Wir werden nur ein ei
 \hspace*{1.3cm}
 \texttt{s/}\textsl{Regexp}/\textsl{Replacement}\texttt{/g}
 \\[0.2cm]
-Hierbei ist \textsl{Regexp} ein regulärer Ausdruck und \textsl{Replacement} ist ein
+Hierbei ist \textsl{Regexp} ein regul\"arer Ausdruck und \textsl{Replacement} ist ein
 Substitutions-Ausdruck.  Der Aufruf
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{sed s/}\textsl{Regexp}/\textsl{Replacement}\texttt{/g}
 \\[0.2cm]
-ersetzt sucht in der Eingabe nach einem Auftreten des regulären Ausdrucks \textsl{Regexp}
+ersetzt sucht in der Eingabe nach einem Auftreten des regul\"aren Ausdrucks \textsl{Regexp}
 und ersetzt diese durch \textsl{Replacement}.  Beispielsweise ersetzt das Kommando 
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{sed s/Stephan/Stefan/g}
 \\[0.2cm]
 alle Auftreten von \texttt{Stephan} durch \texttt{Stefan}.  Dieses Kommando
-könnte wie folgt in eine \emph{Unix-Pipe} eingebunden werden:
+k\"onnte wie folgt in eine \emph{Unix-Pipe} eingebunden werden:
 \\[0.2cm]
 \hspace*{1.3cm}
 \texttt{cat $f_1$ | sed s/Stephan/Stefan/g > $f_2$} 
 \\[0.2cm]
-Diese Pipe würde die Datei $f_1$ lesen, in dem gelesenen Text Datei jedes Auftreten von
-``\texttt{Stephan}'' durch ``\texttt{Stefan}'' ersetzen und den so veränderten Text in die
+Diese Pipe w\"urde die Datei $f_1$ lesen, in dem gelesenen Text Datei jedes Auftreten von
+``\texttt{Stephan}'' durch ``\texttt{Stefan}'' ersetzen und den so ver\"anderten Text in die
 Datei $f_2$ schreiben.
 
-\subsection{Reguläre Ausdrücke in \texttt{sed}}
-Die Syntax der in \texttt{sed} verwendeten regulären Ausdrücke weicht von der
-im letzten Kapitel eingeführten Syntax stark ab.  Den regulären Ausdrücken in \texttt{sed}
+\subsection{Regul\"are Ausdr\"ucke in \texttt{sed}}
+Die Syntax der in \texttt{sed} verwendeten regul\"aren Ausdr\"ucke weicht von der
+im letzten Kapitel eingef\"uhrten Syntax stark ab.  Den regul\"aren Ausdr\"ucken in \texttt{sed}
 liegt das \textsc{Ascii}-Alphabet zu Grunde.  Die Buchstaben des \textsc{Ascii}-Alphabets
 werden in zwei Gruppen eingeteilt:
 \begin{enumerate}
 \item Operator-Symbole,
-\item alle übrigen Zeichen,
+\item alle \"ubrigen Zeichen,
 \end{enumerate}
 Die folgenden Zeichen sind folgenden Operator-Symbole verwendet: 
 \\[0.2cm]
@@ -50,43 +50,43 @@ Die folgenden Zeichen sind folgenden Operator-Symbole verwendet:
    ``\texttt{*}'', ``\texttt{.}'', ``\texttt{\symbol{92}}'', ``\texttt{\symbol{94}}'', 
    ``\texttt{\symbol{36}}'', \texttt{[}, \texttt{]}
 \\[0.2cm]
-Reguläre Ausdrücke in \texttt{sed} werden nun wie folgt definiert.
+Regul\"are Ausdr\"ucke in \texttt{sed} werden nun wie folgt definiert.
 \begin{enumerate}
 \item Jeder Buchstabe $c$, das von den oben aufgelisteten Operator-Symbolen verschieden ist,
-      ist ein reguläre Ausdruck.
-\item Ist $o$ ein Operator-Symbol, so ist ``$\texttt{\symbol{92}}o$'' ein regulärer
-      Ausdruck, der für das Operator-Symbol $o$ steht.
-\item Das Zeichen ``\texttt{.}'' ist ein regulärer Ausdruck, der für ein beliebiges
-      Zeichen steht, die zugehörige Sprache besteht also aus allen Wörtern der Länge Eins.
-\item Sind $r_1$ und $r_2$ reguläre Ausdrücke, so ist auch die Konkatenation $r_1r_2$
-      ein regulärer Ausdruck.  Im letzten Kapitel hatten wir  diesen Ausdruck $r_1 \cdot r_2$
+      ist ein regul\"are Ausdruck.
+\item Ist $o$ ein Operator-Symbol, so ist ``$\texttt{\symbol{92}}o$'' ein regul\"arer
+      Ausdruck, der f\"ur das Operator-Symbol $o$ steht.
+\item Das Zeichen ``\texttt{.}'' ist ein regul\"arer Ausdruck, der f\"ur ein beliebiges
+      Zeichen steht, die zugeh\"orige Sprache besteht also aus allen W\"ortern der L\"ange Eins.
+\item Sind $r_1$ und $r_2$ regul\"are Ausdr\"ucke, so ist auch die Konkatenation $r_1r_2$
+      ein regul\"arer Ausdruck.  Im letzten Kapitel hatten wir  diesen Ausdruck $r_1 \cdot r_2$
       geschrieben.
-\item Sind $r_1$ und $r_2$ reguläre Ausdrücke, so ist  $r_1\,\mathtt{\symbol{92}|}\,r_2$
-      ein regulärer Ausdruck.  Im letzten Kapitel hatten wir statt dessen $r_1 + r_2$
+\item Sind $r_1$ und $r_2$ regul\"are Ausdr\"ucke, so ist  $r_1\,\mathtt{\symbol{92}|}\,r_2$
+      ein regul\"arer Ausdruck.  Im letzten Kapitel hatten wir statt dessen $r_1 + r_2$
       geschrieben.
-\item Ist $r$ ein regulärer Ausdruck, so ist auch $r\mathtt{*}$ ein regulärer Ausdruck.
+\item Ist $r$ ein regul\"arer Ausdruck, so ist auch $r\mathtt{*}$ ein regul\"arer Ausdruck.
       Wir hatten diesen Ausdruck als $r^*$ geschrieben.
-\item Ist $r$ ein regulärer Ausdruck, so ist auch
+\item Ist $r$ ein regul\"arer Ausdruck, so ist auch
       $\mathtt{\symbol{92}(}r\mathtt{\symbol{92})}$
-      ein regulärer Ausdruck.  Wir hatten statt dessen $(r)$ geschrieben, aber weil die
+      ein regul\"arer Ausdruck.  Wir hatten statt dessen $(r)$ geschrieben, aber weil die
       beiden Klammer-Symbole ``\texttt{(}'' und ``\texttt{)}'' in \texttt{sed} keine
-      Operator-Symbole sind, müssen sie durch das Voranstellen eines Backslashs geschützt 
+      Operator-Symbole sind, m\"ussen sie durch das Voranstellen eines Backslashs gesch\"utzt 
       werden.
-\item Ist $r$ ein regulärer Ausdruck, so ist auch $r\mathtt{\symbol{92}+}$ ein regulärer
-      Ausdruck.   Dieser Ausdruck ist nur eine Abkürzung für den Ausdruck
+\item Ist $r$ ein regul\"arer Ausdruck, so ist auch $r\mathtt{\symbol{92}+}$ ein regul\"arer
+      Ausdruck.   Dieser Ausdruck ist nur eine Abk\"urzung f\"ur den Ausdruck
       \\[0.2cm]
       \hspace*{1.3cm}
       $rr\mathtt{*}$.
       \\[0.2cm]
       Anschaulich steht $r\mathtt{\symbol{92}+}$ dass der durch $r$ spezifizierte
       Ausdruck mindestens einmal auftreten muss.
-\item Ist $r$ ein regulärer Ausdruck, so ist auch $r\mathtt{\symbol{92}?}$ ein regulärer
+\item Ist $r$ ein regul\"arer Ausdruck, so ist auch $r\mathtt{\symbol{92}?}$ ein regul\"arer
       Ausdruck.  Der Ausdruck spezifiziert,
        dass der durch $r$ spezifizierte
       Ausdruck einmal oder keinmal auftreten muss.
 \item Sind $c_1, \cdots, c_n$ Buchstaben, so ist
-      $\mathtt{[}c_1,\cdots, c_n\mathtt{]}$ ein regulärer Ausdruck, der als Abkürzung
-      für den Ausdruck $c_1 \mathtt{\symbol{92}|} \cdots \mathtt{\symbol{92}|} c_n$
+      $\mathtt{[}c_1,\cdots, c_n\mathtt{]}$ ein regul\"arer Ausdruck, der als Abk\"urzung
+      f\"ur den Ausdruck $c_1 \mathtt{\symbol{92}|} \cdots \mathtt{\symbol{92}|} c_n$
       verwendet werden kann.  Beispielsweise spezifiziert der Ausdruck
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -94,7 +94,7 @@ Reguläre Ausdrücke in \texttt{sed} werden nun wie folgt definiert.
       \\[0.2cm]
       genau die Vokale.
 \item Sind $c_1$ und $c_n$ zwei Buchstaben, so ist
-      $\mathtt{[}c_1\mathtt{-}c_n\mathtt{]}$ ein regulärer Ausdruck, der 
+      $\mathtt{[}c_1\mathtt{-}c_n\mathtt{]}$ ein regul\"arer Ausdruck, der 
       die Menge aller Zeichen zwischen $c_1$ und $c_n$ beschreibt.  Beispielsweise
       spezifiziert der Ausdruck 
       \\[0.2cm]
@@ -103,30 +103,30 @@ Reguläre Ausdrücke in \texttt{sed} werden nun wie folgt definiert.
       \\[0.2cm]
       die Menge aller kleinen Buchstaben.
 \item Sind $c_1, \cdots, c_n$ Buchstaben, so ist
-      $\mathtt{[\symbol{94}}c_1,\cdots, c_n\mathtt{]}$ ein regulärer Ausdruck, 
-      der für alle Buchstaben steht, die von $c_1, \cdots, c_n$ verschieden sind.
+      $\mathtt{[\symbol{94}}c_1,\cdots, c_n\mathtt{]}$ ein regul\"arer Ausdruck, 
+      der f\"ur alle Buchstaben steht, die von $c_1, \cdots, c_n$ verschieden sind.
 \end{enumerate}
-Wir geben einige Beispiele für reguläre Ausdrücke:
+Wir geben einige Beispiele f\"ur regul\"are Ausdr\"ucke:
 \begin{enumerate}
-\item Der reguläre Ausdruck \texttt{Hugo} spezifiziert das Wort ``\texttt{Hugo}''.
-\item Der reguläre Ausdruck \texttt{Hugo*} spezifiziert die Wörter 
+\item Der regul\"are Ausdruck \texttt{Hugo} spezifiziert das Wort ``\texttt{Hugo}''.
+\item Der regul\"are Ausdruck \texttt{Hugo*} spezifiziert die W\"orter 
       ``\texttt{Hug}'',
       ``\texttt{Hugo}'',
       ``\texttt{Hugoo}'',
       ``\texttt{Hugooo}'', $\cdots$.
-      Beachten Sie bei diesem Beispiel, dass der Operator ``\texttt{*}'' stärker bindet
+      Beachten Sie bei diesem Beispiel, dass der Operator ``\texttt{*}'' st\"arker bindet
       als der (unsichtbare) Konkatenations-Operator.
-\item Der reguläre Ausdruck \texttt{a*b} spezifiziert alle Wörter,
+\item Der regul\"are Ausdruck \texttt{a*b} spezifiziert alle W\"orter,
       die mit beliebig vielen \texttt{a}'s beginnen, denen dann noch ein einzelnes
       \texttt{b} folgt.
-\item Der reguläre Ausdruck 
-      \texttt{\symbol{92}(\symbol{92}[a-z]\symbol{92}|[A-Z]\symbol{92})\symbol{92}[a-z]} beschreibt Wörter,
-      die mit einem großen oder kleinen Buchstaben des lateinischen Alphabets beginnen
-      und anschließend nur aus kleinen Buchstaben dieses Alphabets bestehen.  Dieser
-      reguläre Ausdruck kann auch einfacher als \texttt{[a-zA-Z][a-z]*} geschrieben werden.
-\item Der reguläre Ausdruck \texttt{[a-zA-Z][a-zA-Z0-9\_]*} beschreibt die Syntax von
+\item Der regul\"are Ausdruck 
+      \texttt{\symbol{92}(\symbol{92}[a-z]\symbol{92}|[A-Z]\symbol{92})\symbol{92}[a-z]} beschreibt W\"orter,
+      die mit einem gro{\ss}en oder kleinen Buchstaben des lateinischen Alphabets beginnen
+      und anschlie{\ss}end nur aus kleinen Buchstaben dieses Alphabets bestehen.  Dieser
+      regul\"are Ausdruck kann auch einfacher als \texttt{[a-zA-Z][a-z]*} geschrieben werden.
+\item Der regul\"are Ausdruck \texttt{[a-zA-Z][a-zA-Z0-9\_]*} beschreibt die Syntax von
       Variablen-Namen in der Sprache \texttt{C}:  In \texttt{C} muss eine Variable
-      mit einem lateinischen Buchstaben beginnen, danach können lateinische Buchstaben,
+      mit einem lateinischen Buchstaben beginnen, danach k\"onnen lateinische Buchstaben,
       Ziffern, oder das Zeichen ``\texttt{\_}'' folgen.
 \end{enumerate}
 
@@ -136,16 +136,16 @@ Wir hatten anfangs gesagt, dass wir Aufrufe von \texttt{sed} der Form
 \hspace*{1.3cm}
 \texttt{sed s/}\textsl{Regexp}/\textsl{Replacement}\texttt{/g}
 \\[0.2cm]
-diskutieren wollen.  Im letzten Abschnitt hatten wir diskutiert, was wir für den Ausdruck
-\textsl{Regexp} einsetzen können, nun wenden wir uns dem Ausdruck \textsl{Replacement} zu.
+diskutieren wollen.  Im letzten Abschnitt hatten wir diskutiert, was wir f\"ur den Ausdruck
+\textsl{Regexp} einsetzen k\"onnen, nun wenden wir uns dem Ausdruck \textsl{Replacement} zu.
 Der Ausdruck \textsl{Replacement} spezifiziert den Text, durch den der Text, der dem
-regulären Ausdruck \textsl{Regexp} entspricht ersetzt werden kann.  Dabei kann innerhalb
-von dem Ausdruck \textsl{Replacement} auf geklammerte Teile zurückgegriffen werden.
+regul\"aren Ausdruck \textsl{Regexp} entspricht ersetzt werden kann.  Dabei kann innerhalb
+von dem Ausdruck \textsl{Replacement} auf geklammerte Teile zur\"uckgegriffen werden.
 \texttt{\symbol{92}1} bezieht sich auf den ersten in Klammern eingefassten  Teilausdruck,
 \texttt{\symbol{92}2} auf den zweiten,
 \texttt{\symbol{92}3} auf den dritten, etc.
 
-Für eine ausführlichere Diskussion von \texttt{sed} verweisen wir auf das Buch
+F\"ur eine ausf\"uhrlichere Diskussion von \texttt{sed} verweisen wir auf das Buch
 von Dougherty und Robbins \cite{dougherty:1997}, sowie auf die Manual-Page und die Seiten
 im Unix-Info-System.
 

--- a/Lecture-Notes/shift-reduce-parser.tex
+++ b/Lecture-Notes/shift-reduce-parser.tex
@@ -1,21 +1,21 @@
 \chapter{Bottom-Up-Parser}
-Bei der Konstruktion eines Parsers gibt es generell zwei Möglichkeiten:  Wir können
+Bei der Konstruktion eines Parsers gibt es generell zwei M\"oglichkeiten:  Wir k\"onnen
 \emph{Top-Down} oder \emph{Bottom-Up} vorgehen.  Den Top-Down-Ansatz haben wir bereits
-ausführlich diskutiert.  In diesem Kapitel erläutern wir nun den Bottom-Up-Ansatz.
-Dazu stellen wir im nächsten Abschnitt das allgemeine Konzept vor, das einem
+ausf\"uhrlich diskutiert.  In diesem Kapitel erl\"autern wir nun den Bottom-Up-Ansatz.
+Dazu stellen wir im n\"achsten Abschnitt das allgemeine Konzept vor, das einem
 \textsl{Bottom-Up-Parser} zu Grunde liegt.  
-Im darauf folgenden Abschnitt zeigen wir, wie Bottom-Up-Parser implementiert werden können
-und stellen als eine Implementierungsmöglichkeit die \emph{Shift-Reduce-Parser} vor.
+Im darauf folgenden Abschnitt zeigen wir, wie Bottom-Up-Parser implementiert werden k\"onnen
+und stellen als eine Implementierungsm\"oglichkeit die \emph{Shift-Reduce-Parser} vor.
 Ein Shift-Reduce-Parser arbeitet mit Hilfe einer Tabelle, in der
 hinterlegt ist, wie der Parser in einem bestimmten Zustand die Eingaben verarbeiten muss.
-Die Theorie, wie eine solche Tabelle sinnvoll mit Informationen gefüllt werden kann,
-entwickeln wir dann in dem folgenden Abschnitt: Zunächst diskutieren wir die
+Die Theorie, wie eine solche Tabelle sinnvoll mit Informationen gef\"ullt werden kann,
+entwickeln wir dann in dem folgenden Abschnitt: Zun\"achst diskutieren wir die
 \emph{SLR-Parser} (\emph{simple LR-Parser}).  Dies ist die einfachste Klasse von Shift-Reduce-Parsern.
-Das Konzept der SLR-Parser ist leider für die Praxis nicht mächtig genug.  Daher verfeinern wir
+Das Konzept der SLR-Parser ist leider f\"ur die Praxis nicht m\"achtig genug.  Daher verfeinern wir
 dieses Konzept und erhalten so die Klasse der
-\emph{kanonischen LR-Parser}.  Da die Tabellen für LR-Parser in der Praxis
-häufig groß werden, vereinfacht man diese Tabellen etwas und erhält dann das Konzept der
-\emph{LALR-Parser}, das von der Mächtigkeit zwischen dem Konzept der \emph{SLR-Parser} und dem
+\emph{kanonischen LR-Parser}.  Da die Tabellen f\"ur LR-Parser in der Praxis
+h\"aufig gro{\ss} werden, vereinfacht man diese Tabellen etwas und erh\"alt dann das Konzept der
+\emph{LALR-Parser}, das von der M\"achtigkeit zwischen dem Konzept der \emph{SLR-Parser} und dem
 Konzept der \emph{LR-Parser} liegt.  In dem folgenden Kapitel werden wir dann den Parser-Generator
 \textsl{JavaCup} diskutieren, der ein LALR-Parser ist.
 
@@ -39,7 +39,7 @@ Regeln
 gegeben ist,  zu parsen.  Dazu suchen wir in diesem String
 Teilstrings, die den rechten Seiten von Grammatikregeln entsprechen, wobei wir den String
 von links nach rechts durchsuchen.  Auf diese Art versuchen wir,
-einen Parse-Baum rückwärts von unten aufzubauen:
+einen Parse-Baum r\"uckw\"arts von unten aufzubauen:
 \\[0.2cm]
 \hspace*{0.3cm} 
 $
@@ -65,14 +65,14 @@ Im ersten Schritt haben wir beispielsweise die Grammatik-Regel $F \rightarrow \s
 benutzt, um den String ``\texttt{1}'' durch $F$ zu ersetzen und dabei dann den String 
 ``F\texttt{ + 2 * 3}'' erhalten.  Im zweiten Schritt haben wir die Regel
 $P \rightarrow F$ benutzt, um $F$ durch $P$ zu
-ersetzen.  Auf diese Art und Weise haben wir am Ende den ursprünglichen String 
-``\texttt{1 + 2 * 3}'' auf E zurück geführt.  Wir können an dieser Stelle zwei
+ersetzen.  Auf diese Art und Weise haben wir am Ende den urspr\"unglichen String 
+``\texttt{1 + 2 * 3}'' auf E zur\"uck gef\"uhrt.  Wir k\"onnen an dieser Stelle zwei
 Beobachtungen machen:
 \begin{enumerate}
 \item Wir ersetzen bei unserem Vorgehen immer den am weitesten links stehenden Teilstring,
       der ersetzt werden kann, wenn wir den anfangs gegebenen String auf das Start-Symbol
-      der Grammatik zurück führen wollen.
-\item Schreiben wir die Ableitung, die wir rückwärts konstruiert haben, noch einmal
+      der Grammatik zur\"uck f\"uhren wollen.
+\item Schreiben wir die Ableitung, die wir r\"uckw\"arts konstruiert haben, noch einmal
       in der richtigen Reihenfolge hin, so erhalten wir:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -96,14 +96,14 @@ $
        Im Gegensatz dazu ist es bei den Ableitungen, die ein \emph{Top-Down-Parser}
        erzeugt, genau umgekehrt:  Dort wird immer die am weitesten links stehende
        syntaktische Variable ersetzt.  Die mit einem solchen Parser erzeugten Ableitungen
-       heißen daher \emph{Links-Ableitungen}.
+       hei{\ss}en daher \emph{Links-Ableitungen}.
 \end{enumerate}
 Die obigen beiden Beobachtungen sind der Grund, weshalb die Parser, die wir in diesem
-Kapitel diskutieren, als \emph{LR-Parser} bezeichnet werden.  Das \emph{L} steht für
+Kapitel diskutieren, als \emph{LR-Parser} bezeichnet werden.  Das \emph{L} steht f\"ur
 \emph{\underline{l}eft to right} und beschreibt die Vorgehensweise, dass der String immer
-von links nach rechts durchsucht wird, während das \emph{R} für 
+von links nach rechts durchsucht wird, w\"ahrend das \emph{R} f\"ur 
 \emph{\underline{r}everse rightmost derivation} steht
-und ausdrückt, dass solche Parser eine Rechts-Ableitung rückwärts konstruieren.
+und ausdr\"uckt, dass solche Parser eine Rechts-Ableitung r\"uckw\"arts konstruieren.
 \vspace*{0.2cm}
 
 \noindent
@@ -114,40 +114,40 @@ Bei der Implementierung eines LR-Parsers stellen sich zwei Fragen:
 \end{enumerate}
 Die Beantwortung dieser Fragen ist im Allgemeinen nicht trivial.  Zwar gehen wir die Strings immer
 von links nach rechts durch, aber damit ist noch nicht unbeding klar, welchen Teilstring wir
-ersetzen, denn die potentiell zu ersetzenden Teilstrings können sich durchaus überlappen.
+ersetzen, denn die potentiell zu ersetzenden Teilstrings k\"onnen sich durchaus \"uberlappen.
 Betrachten wir beispielsweise das Zwischenergebnis
 \\[0.2cm]
 \hspace*{1.3cm}
 $E \texttt{ + } P \texttt{ * 3}$,
 \\[0.2cm]
-das wir oben im fünften Schritt erhalten haben.
-Hier könnten wir den Teilstring ``P'' mit Hilfe der Regel
+das wir oben im f\"unften Schritt erhalten haben.
+Hier k\"onnten wir den Teilstring ``P'' mit Hilfe der Regel
 \\[0.2cm]
 \hspace*{1.3cm}
 $E \rightarrow P$
 \\[0.2cm]
-durch ``E'' ersetzen.  Dann würden wir den String
+durch ``E'' ersetzen.  Dann w\"urden wir den String
 \\[0.2cm]
 \hspace*{1.3cm}
 $E \texttt{ + } E \texttt{ * 3}$
 \\[0.2cm]
-erhalten.  Die einzigen Reduktionen, die wir jetzt noch durchführen können, führen über die
+erhalten.  Die einzigen Reduktionen, die wir jetzt noch durchf\"uhren k\"onnen, f\"uhren \"uber die
 Zwischenergebnisse $E \texttt{ + } E \texttt{ * }  F$ und $E \texttt{ + } E \texttt{ * } P$
 zu dem String
 \\[0.2cm]
 \hspace*{1.3cm}
 $E \texttt{ + } E \texttt{ * }  E$,
 \\[0.2cm]
-der sich dann  aber mit der oben angegebenen Grammatik nicht mehr reduzieren lässt.  
+der sich dann  aber mit der oben angegebenen Grammatik nicht mehr reduzieren l\"asst.  
 Die Antwort auf die obigen Fragen, welchen Teilstring wir ersetzen und welche Regel wir
 verwenden, setzt einiges an Theorie voraus, die wir
 in den folgenden Abschnitten entwickeln werden.
 
 
 \section{Shift-Reduce-Parser}
-Wollen wir einen Bottom-Up-Parser implementieren, so müssen wir uns zunächst die Frage stellen,
+Wollen wir einen Bottom-Up-Parser implementieren, so m\"ussen wir uns zun\"achst die Frage stellen,
 welche Datenstrukturen wir bei der Implementierung verwenden wollen.
-Wenn wir uns dabei für einen Stack entscheiden, dann sprechen wir von einem
+Wenn wir uns dabei f\"ur einen Stack entscheiden, dann sprechen wir von einem
 \emph{Shift-Reduce-Parser}.  Ist $G = \langle V, T, R, S \rangle$ eine kontextfreie Grammatik, so
 wird ein Shift-Reduce-Parser $P$ durch ein 4-Tupel
 \\[0.2cm]
@@ -156,16 +156,16 @@ $P = \langle Q, q_0, \textsl{action}, \textsl{goto} \rangle$
 \\[0.2cm]
 beschrieben.  Dabei gilt:
 \begin{enumerate}
-\item $Q$ ist die Menge der \emph{Zustände} des Shift-Reduce-Parsers.  
+\item $Q$ ist die Menge der \emph{Zust\"ande} des Shift-Reduce-Parsers.  
 
-      Zunächst werden wir die einzelnen Zustände rein abstrakt sehen und ihre Natur nicht näher
-      analysieren.  Später, wenn wir 
+      Zun\"achst werden wir die einzelnen Zust\"ande rein abstrakt sehen und ihre Natur nicht n\"aher
+      analysieren.  Sp\"ater, wenn wir 
       die Theorie der SLR-Parser diskutieren, werden wir erkennen, dass ein Zustand
       die Information speichert, mit welcher Grammatik-Regel der Parser gerade zu parsen versucht
       und welcher Teil der rechten Seite der Regel bereits erkannt worden ist.
 \item $q_0 \in Q$ ist der Start-Zustand.
 \item $\textsl{action}$ ist eine Funktion, die als Argumente einen Zustand $q \in Q$
-      und ein Terminal $t \in T$ erhält.  Das Ergebnis ist ein Element der Menge
+      und ein Terminal $t \in T$ erh\"alt.  Das Ergebnis ist ein Element der Menge
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{Action} :=
@@ -176,7 +176,7 @@ beschrieben.  Dabei gilt:
       \\[0.2cm]
       wobei \texttt{shift}, \texttt{reduce}, \texttt{accept} und \texttt{error} hier einfach als
       Strings interpretiert werden, mit denen die verschiedenen Arten von Ergebnissen der Funktion
-      $\textsl{action}()$ unterschieden werden können.  
+      $\textsl{action}()$ unterschieden werden k\"onnen.  
       Zusammenfassend haben wir also:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -189,7 +189,7 @@ beschrieben.  Dabei gilt:
 \end{enumerate}
 Ein Shift-Reduce-Parser arbeitet nun mit den folgenden Daten-Strukturen.
 \begin{enumerate}
-\item Einem Stack \textsl{states}, auf dem Zustände aus der Menge $Q$ abgelegt werden:
+\item Einem Stack \textsl{states}, auf dem Zust\"ande aus der Menge $Q$ abgelegt werden:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{states} \in \textsl{Stack}\langle Q \rangle$.
@@ -199,8 +199,8 @@ Ein Shift-Reduce-Parser arbeitet nun mit den folgenden Daten-Strukturen.
       \hspace*{1.3cm}
       $\textsl{symbols} \in \textsl{Stack}\langle T \cup V \rangle$.
 \end{enumerate}
-Zur Vereinfachung der folgenden Überlegungen nehmen wir an, dass die Menge $T$ der Terminale das
-spezielle Symbol ``\textsc{Eof}'' enthält und dass dieses Symbol das Ende des zu parsenden
+Zur Vereinfachung der folgenden \"Uberlegungen nehmen wir an, dass die Menge $T$ der Terminale das
+spezielle Symbol ``\textsc{Eof}'' enth\"alt und dass dieses Symbol das Ende des zu parsenden
 Strings spezifiziert aber sonst in dem String nicht auftritt.  
 
 \begin{figure}[!ht]

--- a/Lecture-Notes/type-checker.tex
+++ b/Lecture-Notes/type-checker.tex
@@ -59,17 +59,17 @@ language and then we develop a type checker for this language.
 
 \section{Eine Beispielsprache}
 Wir stellen jetzt die Sprache \textsc{Ttl} (\emph{typed term language} vor.  Dabei handelt es sich
-um eine sehr einfache Beispielsprache, die es dem Benutzer ermöglicht
+um eine sehr einfache Beispielsprache, die es dem Benutzer erm\"oglicht
 \begin{itemize}
 \item Typen zu definieren,
 \item Funktionen zu deklarieren und
 \item Terme anzugeben,
 \end{itemize}
-für die dann die Typ-Korrektheit nachgewiesen wird.
+f\"ur die dann die Typ-Korrektheit nachgewiesen wird.
 Die Sprache \textsc{Ttl} ist sehr einfach gehalten,
-damit wir uns auf die wesentlichen Ideen der Typ-Überprüfung konzentrieren können.
-Daher können wir in \textsc{Ttl} auch keine wirklichen Programme schreiben,
-sondern einzig und allein überprüfen, ob Ausdrücke wohlgetypt sind.
+damit wir uns auf die wesentlichen Ideen der Typ-\"Uberpr\"ufung konzentrieren k\"onnen.
+Daher k\"onnen wir in \textsc{Ttl} auch keine wirklichen Programme schreiben,
+sondern einzig und allein \"uberpr\"ufen, ob Ausdr\"ucke wohlgetypt sind.
 
 \begin{figure}[!ht]
 \centering
@@ -97,11 +97,11 @@ sondern einzig und allein überprüfen, ob Ausdrücke wohlgetypt sind.
 \label{fig:types.ttl}
 \end{figure}
 
-Abbildung \ref{fig:types.ttl} zeigt ein einfaches Beispiel-Programm.  Die Schlüsselwörter habe ich
+Abbildung \ref{fig:types.ttl} zeigt ein einfaches Beispiel-Programm.  Die Schl\"usselw\"orter habe ich
 unterstrichen.  Wir diskutieren dieses Programm jetzt im Detail.
 \begin{enumerate}
 \item In Zeile 1 definieren wir den \emph{generischen} Typ $\texttt{list}(X)$.  Das $X$ ist hier der
-      Typ-Parameter, der später durch einen konkreten Typ wie z.B. \texttt{int},
+      Typ-Parameter, der sp\"ater durch einen konkreten Typ wie z.B. \texttt{int},
       \texttt{string} oder $\mathtt{list}(\mathtt{string})$ ersetzt werden kann.
 
       Semantisch ist die Zeile als induktive Definition zu lesen, durch die eine Menge von Termen
@@ -121,12 +121,12 @@ unterstrichen.  Wir diskutieren dieses Programm jetzt im Detail.
       diesen Typ.
 \item In den Zeilen 4 -- 6 legen wir fest, dass die Variablen $x$, $y$ und $z$ jeweils den Typ
       \texttt{int} haben.
-\item In Zeile 8 und 9 werden schließlich die beiden Terme
+\item In Zeile 8 und 9 werden schlie{\ss}lich die beiden Terme
       \[ \mathtt{concat(nil, nil)} \quad \mbox{und} \quad
          \mathtt{concat(cons(x, nil), cons(y, cons(z, nil)))}
       \] 
       angegeben und es wird behauptet, dass diese den Typ $\texttt{list}(\texttt{int})$ haben.
-      Die Aufgabe der Typ-Überprüfung besteht darin, diese Aussage zu verifizieren.
+      Die Aufgabe der Typ-\"Uberpr\"ufung besteht darin, diese Aussage zu verifizieren.
 \end{enumerate}
 
 
@@ -169,7 +169,7 @@ unterstrichen.  Wir diskutieren dieses Programm jetzt im Detail.
     FCT     : ('a'..'z')('a'..'z'|'A'..'Z'|'_'|'0'..'9')*;
 \end{Verbatim}
 \vspace*{-0.3cm}
-  \caption{Eine EBNF-Grammatik für die getypte Beispielsprache}
+  \caption{Eine EBNF-Grammatik f\"ur die getypte Beispielsprache}
 \label{fig:typeChecker-grammar}
 \end{figure}
 
@@ -178,16 +178,16 @@ unterstrichen.  Wir diskutieren dieses Programm jetzt im Detail.
 \noindent
 Die genaue Syntax der Sprache \textsc{Ttl} wird durch die in Abbildung \ref{fig:typeChecker-grammar}
 gezeigte Grammatik definiert.  Diese Grammatik verwendet neben den Zeichen-Reihen, die in doppelten
-Anführungs-Zeichen gesetzt sind, die folgenden Terminale:
+Anf\"uhrungs-Zeichen gesetzt sind, die folgenden Terminale:
 \begin{enumerate}
 \item \textsc{Function} bezeichnet entweder einen Typ-Konstruktor wie \texttt{list}, eine Variable
       wie \texttt{x} oder \texttt{y} oder einen Funktionsnamen wie \texttt{concat}.  Syntaktisch
       werden Typ-Konstruktoren, Variablen und Funktionsnamen dadurch erkannt, dass sie mit
       einem Kleinbuchstaben beginnen. 
 \item \textsc{Parameter} bezeichnet einen Typ-Parameter wie z.B.~das $X$ in $\texttt{list}(X)$.
-      Diese beginnen immer mit einem Großbuchstaben.
+      Diese beginnen immer mit einem Gro{\ss}buchstaben.
 \end{enumerate}
-Bevor wir einen Algorithmus zur Typ-Überprüfung vorstellen können ist es erforderlich,
+Bevor wir einen Algorithmus zur Typ-\"Uberpr\"ufung vorstellen k\"onnen ist es erforderlich,
 einige grundlegende Begriffe wie 
 den Begriff der Substitution und die Anwendung von Substitutionen auf Typen zu diskutieren.
 
@@ -209,31 +209,31 @@ an.  Damit spezifizieren wir:
 \item Das $i$-te Argument hat den Typ $\sigma_i$.  
 \item Das von der Funktion berechnete Ergebnis hat den Typ $\varrho$.
 \end{enumerate}
-Als nächstes definieren wir, was wir unter einem Typ verstehen wollen.
-Anschaulich sind das Ausdrücke wie 
+Als n\"achstes definieren wir, was wir unter einem Typ verstehen wollen.
+Anschaulich sind das Ausdr\"ucke wie 
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{map}(K,V)$, \quad $\textsl{double}$, \quad oder \quad $\textsl{list}(\textsl{int})$.
 \\[0.2cm]
 Formal werden Typen aus Typ-Parametern und Typ-Konstruktoren aufgebaut.
 In dem obigen Beispiel sind \textsl{map}, \textsl{double}, \textsl{list} und \textsl{int}
-Typ-Konstruktoren, während $K$ und $V$ Typ-Parameter sind.
+Typ-Konstruktoren, w\"ahrend $K$ und $V$ Typ-Parameter sind.
 Wir nehmen an, dass einerseits eine Menge $\mathbb{P}$ von Typ-Parametern und
 andererseits eine Menge von Typ-Konstruktoren $\mathbb{K}$ gegeben sind.  In dem letzten Beispiel
-könnten wir
+k\"onnten wir
 \\[0.2cm]
 \hspace*{1.3cm}
 $\mathbb{K} = \bigl\{ \textsl{map}, \textsl{list}, \textsl{int}, \textsl{double}\bigr\}$
 \quad und \quad
 $\mathbb{P} = \bigl\{ K, V \bigr\}$
 \\[0.2cm]
-setzen.  Zusätzlich muss noch eine Funktion
+setzen.  Zus\"atzlich muss noch eine Funktion
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{arity}: \mathbb{K} \rightarrow \mathbb{N}$
 \\[0.2cm]
-gegeben sein, die für jeden Typ-Konstruktor festlegt, wieviel Argumente er erwartet.
-In dem obigen Beispiel hätten wir
+gegeben sein, die f\"ur jeden Typ-Konstruktor festlegt, wieviel Argumente er erwartet.
+In dem obigen Beispiel h\"atten wir
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{arity}(\textsl{map}) = 2$, \quad
@@ -659,18 +659,18 @@ is a solution of the type equation given above.
 
 %\input{ep}
 
-\section{Implementierung eines Typ-Checkers für \textsc{TTL}}
-Zur Illustration der dargestellten Theorie implementieren wir einen Typ-Checker für \textsc{TTL}.
+\section{Implementierung eines Typ-Checkers f\"ur \textsc{TTL}}
+Zur Illustration der dargestellten Theorie implementieren wir einen Typ-Checker f\"ur \textsc{TTL}.
 Die Grammatik hatten wir ja bereits in Abbildung \ref{fig:typeChecker-grammar} auf Seite
-\pageref{fig:typeChecker-grammar} präsentiert.  Die Abbildungen 
+\pageref{fig:typeChecker-grammar} pr\"asentiert.  Die Abbildungen 
 \ref{fig:typeChecker.cup-1}, \ref{fig:typeChecker.cup-2} und \ref{fig:typeChecker.cup-3} 
-auf den folgenden Seiten zeigen die \textsl{JavaCup}-Spezifikation eines Parsers für diese Grammatik.
-Der zugehörige Scanner ist in Abbildungen  \ref{fig:typeChecker.jflex} auf Seite
+auf den folgenden Seiten zeigen die \textsl{JavaCup}-Spezifikation eines Parsers f\"ur diese Grammatik.
+Der zugeh\"orige Scanner ist in Abbildungen  \ref{fig:typeChecker.jflex} auf Seite
 \pageref{fig:typeChecker.jflex} gezeigt.  Der Scanner unterscheidet in den Zeilen 34 und 35 zwischen
-Namen, die mit einem großen Buchstaben beginnen und solchen Namen, die mit einem kleinen Buchstaben
+Namen, die mit einem gro{\ss}en Buchstaben beginnen und solchen Namen, die mit einem kleinen Buchstaben
 beginnen.  Erstere bezeichnen Typ-Parameter, letztere bezeichnen sowohl Funktionen als auch Typ-Konstruktoren.
 Der von \textsl{JavaCup} generierte Parser baut einen abstrakten
-Syntax-Baum auf.  Die zugehörigen Klassen wurden mit Hilfe des im vorhergehenden Abschnitts diskutierten
+Syntax-Baum auf.  Die zugeh\"origen Klassen wurden mit Hilfe des im vorhergehenden Abschnitts diskutierten
 Klassen-Generators 
 \textsc{EP} aus der in Abbildung \ref{fig:typeExpr.ep} gezeigten Spezifikation erzeugt.
 
@@ -873,7 +873,7 @@ Klassen-Generators
         MartelliMontanari(List<Equation> equations, Substitution theta);
 \end{Verbatim}
 \vspace*{-0.3cm}
-\caption{Definition der benötigten \textsl{Java}-Klassen mit Hilfe von \textsc{EP}.}
+\caption{Definition der ben\"otigten \textsl{Java}-Klassen mit Hilfe von \textsc{EP}.}
 \label{fig:typeExpr.ep}
 \end{figure}
 
@@ -985,12 +985,12 @@ Klassen-Generators
 \label{fig:MartelliMontanari:solve.java}
 \end{figure}
 
-Die Klasse \texttt{MartelliMontanari} enthält die in Abbildung \ref{fig:MartelliMontanari:solve.java}
-gezeigte Methode $\textsl{solve}()$, mit der sich ein syntaktisches Gleichungs-System lösen lässt.
+Die Klasse \texttt{MartelliMontanari} enth\"alt die in Abbildung \ref{fig:MartelliMontanari:solve.java}
+gezeigte Methode $\textsl{solve}()$, mit der sich ein syntaktisches Gleichungs-System l\"osen l\"asst.
 Wir diskutieren diese Methode jetzt im Detail.
 \begin{enumerate}
-\item Am Anfang wählen wir in  Zeilen 3 willkürlich die erste syntaktische Gleichung aus der Menge
-      \texttt{mEquations} der zu lösenden syntaktischen Gleichungen aus.  
+\item Am Anfang w\"ahlen wir in  Zeilen 3 willk\"urlich die erste syntaktische Gleichung aus der Menge
+      \texttt{mEquations} der zu l\"osenden syntaktischen Gleichungen aus.  
       
       Das weitere Vorgehen richtet sich dann nach der Art der Gleichung.
 \item In den Zeilen 6 -- 14 behandeln wir den Fall, dass auf der linken Seite der syntaktischen Gleichung
@@ -1001,13 +1001,13 @@ Wir diskutieren diese Methode jetzt im Detail.
       $\Big\langle E \cup \big\{ X \doteq \tau \big\}, \vartheta \Big\rangle \quad\leadsto\quad 
        \Big\langle E[X \mapsto \tau], \vartheta\big[ X \mapsto \tau \big] \Big\rangle$. 
       \\[0.2cm]
-      Der Typ-Parameter, der in der obigen Formel mit \texttt{X} bezeichnet wird, trägt im Programm 
+      Der Typ-Parameter, der in der obigen Formel mit \texttt{X} bezeichnet wird, tr\"agt im Programm 
       den Namen \texttt{var} und der Typ $\tau$ wird im Programm mit \texttt{rhs} bezeichnet.
 \item In Zeile 15 betrachten wir den Fall, dass auf der linken Seite der syntaktischen Gleichung
-      ein zusammengesetzter Typ steht.  Wenn die Typ-Gleichung lösbar sein soll, muss dann auch auf der
-      rechten Seite ein zusammengesetzter Typ stehen.  Dies wird in  Zeile 16 überprüft.
+      ein zusammengesetzter Typ steht.  Wenn die Typ-Gleichung l\"osbar sein soll, muss dann auch auf der
+      rechten Seite ein zusammengesetzter Typ stehen.  Dies wird in  Zeile 16 \"uberpr\"uft.
 
-      Der restliche Code beschäftigt sich nun mit dem Fall, dass auf beiden Seiten der syntaktischen
+      Der restliche Code besch\"aftigt sich nun mit dem Fall, dass auf beiden Seiten der syntaktischen
       Gleichung ein zusammengesetzter Typ steht.
 \item Die Zeilen 22 -- 25 behandeln den Fall, dass die Typ-Konstruktoren auf beiden Seiten verschieden sind,
       es wird also der Fall
@@ -1018,8 +1018,8 @@ Wir diskutieren diese Methode jetzt im Detail.
        \;\leadsto\; \Omega$. 
       \\[0.2cm]
       behandelt.  Die Methode liefert in diesem Fall statt einer Substitution den Wert \texttt{null}
-      zurück.
-\item Die Zeilen 27 -- 32 behandeln schließlich den Fall, in dem wir das Gleichungs-System nach der Regel
+      zur\"uck.
+\item Die Zeilen 27 -- 32 behandeln schlie{\ss}lich den Fall, in dem wir das Gleichungs-System nach der Regel
       \\[0.2cm]
       \hspace*{1.3cm}
       $\Big\langle E \cup \big\{ f(\sigma_1,\cdots,\sigma_n) \doteq f(\tau_1,\cdots,\tau_n) \big\}, 
@@ -1080,7 +1080,7 @@ eine Signatur
 \hspace*{1.3cm}
 $f: \sigma_1 \times \cdots \times \sigma_n \rightarrow \varrho$
 \\[0.2cm]
-hat und es darüber hinaus eine Parameter-Substitution $\vartheta$ gibt, so dass
+hat und es dar\"uber hinaus eine Parameter-Substitution $\vartheta$ gibt, so dass
 $\tau = \varrho\vartheta$ gilt und weiterhin die Terme $s_i$ vom Typ $\sigma_i\vartheta$ sind:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -1088,14 +1088,14 @@ $f(s_1,\cdots,s_n):\tau \;\Leftrightarrow\;
  \exists \vartheta\in\textsc{Subst}: \varrho\vartheta = \tau \wedge 
  s_1:\sigma_1\vartheta \wedge \cdots \wedge s_n:\sigma_n\vartheta$.
 \begin{enumerate}
-\item Um die obige Definition von $t:\tau$ umzusetzen, suchen wir für einen Term der Form
-      $f(s_1,\cdots,s_n)$ zunächst in Zeile 2 nach der Signatur des Funktions-Zeichens $f$.
+\item Um die obige Definition von $t:\tau$ umzusetzen, suchen wir f\"ur einen Term der Form
+      $f(s_1,\cdots,s_n)$ zun\"achst in Zeile 2 nach der Signatur des Funktions-Zeichens $f$.
       Diese Signaturen sind in der Symboltabelle \texttt{map} hinterlegt.
-      Findet sich für das Funktions-Zeichen keine Signatur, so liegt offenbar ein Fehler vor, 
+      Findet sich f\"ur das Funktions-Zeichen keine Signatur, so liegt offenbar ein Fehler vor, 
       der in Zeile 4 ausgegeben wird.
 \item Ansonsten speichern wir in Zeile 8 die Argument-Typen $\sigma_1, \cdots, \sigma_n$ in der Variablen
-      \texttt{argTypes}.  Die Signatur von $f$ muss natürlich genau so viele Argument-Typen
-      haben, wie das Funktions-Zeichen $f$ Argumente hat.  Dies wird in Zeile  9 überprüft.
+      \texttt{argTypes}.  Die Signatur von $f$ muss nat\"urlich genau so viele Argument-Typen
+      haben, wie das Funktions-Zeichen $f$ Argumente hat.  Dies wird in Zeile  9 \"uberpr\"uft.
 \item Falls bis hierhin keine Probleme aufgetreten sind, erzeugen wir nun die Typ-Gleichungen nach der Formel
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -1103,7 +1103,7 @@ $f(s_1,\cdots,s_n):\tau \;\Leftrightarrow\;
       \textsl{typeEqs}\bigl( f(t_1,\cdots,t_n), \tau \bigr) := 
       \{ \varrho = \tau \} \cup \bigcup\limits_{i=1}^n \textsl{typeEqs}(t_i, \sigma_i)$.
       \\[0.2cm]
-      Dazu erstellen wir in Zeile 17 zuächst die Typ-Gleichungen
+      Dazu erstellen wir in Zeile 17 zu\"achst die Typ-Gleichungen
       \\[0.2cm]      
       \hspace*{1.3cm}
       $\varrho \doteq \tau$
@@ -1112,10 +1112,10 @@ $f(s_1,\cdots,s_n):\tau \;\Leftrightarrow\;
       den Forderungen 
       \\[0.2cm]
       \hspace*{1.3cm}
-      $s_i:\sigma_i \quad \mbox{für} \; i=1,\cdots,n$
+      $s_i:\sigma_i \quad \mbox{f\"ur} \; i=1,\cdots,n$
       \\[0.2cm]
       ergeben.  Als Ergebnis erhalten wir eine Menge von Typ-Gleichungen, die genau
-      dann lösbar sind, wenn der Term $f(s_1,\cdots,s_n)$ den Typ $\tau$ hat.
+      dann l\"osbar sind, wenn der Term $f(s_1,\cdots,s_n)$ den Typ $\tau$ hat.
 \end{enumerate}
 
 \begin{figure}[!ht]
@@ -1181,13 +1181,13 @@ zeigt den Konstruktor dieser Klasse.  Dieser Konstruktor bekommt als Argumente
 \item eine Liste von Typ-Definitionen \texttt{typeDefs},
 \item eine Liste von Signaturen \texttt{signatures} und
 \item eine Liste von getypten Termen \texttt{typedTerms}, deren Typ-Korrektheit
-      überprüft werden soll.
+      \"uberpr\"uft werden soll.
 \end{itemize}
 Die wesentliche Aufgabe des Konstruktors besteht darin,  die Member-Variable
 \texttt{mSignatureMap} zu initialisieren.  Hierbei handelt es sich um eine Symboltabelle,
-in der zu jedem Funktions-Namen die zugehörige Signatur abgelegt ist.
-Dazu werden zunächst in der Schleife in Zeile 9 -- 11 alle
-Signaturen aus der als Argument übergebenen Liste \texttt{signatures} in dieser Liste eingetragen.
+in der zu jedem Funktions-Namen die zugeh\"orige Signatur abgelegt ist.
+Dazu werden zun\"achst in der Schleife in Zeile 9 -- 11 alle
+Signaturen aus der als Argument \"ubergebenen Liste \texttt{signatures} in dieser Liste eingetragen.
 Dies alleine ist allerdings nicht ausreichend, denn durch die Typ-Definitionen werden implizit noch
 weitere Funktions-Zeichen deklariert.  Beispielsweise werden durch die Typ-Definition
 \\[0.2cm]
@@ -1202,12 +1202,12 @@ haben die folgenden Signaturen:
 \end{enumerate}
 Die Aufgabe des Konstruktors der Klasse \texttt{Program} besteht also darin, aus den in dem Argument
 \texttt{typeDefs} enthaltenen Typ-Definitionen die Signaturen der implizit deklarierten
-Funktionszeichen zu generieren.  Dazu iteriert die Schleife in Zeile 12 zunächst über alle
+Funktionszeichen zu generieren.  Dazu iteriert die Schleife in Zeile 12 zun\"achst \"uber alle
 Typ-Definitionen.   Es gibt zwei Arten von Typ-Definitionen:  Typ-Definitionen, bei denen der
-erzeugte Typ noch von einem oder mehreren Parametern abhängt, wie dies z.B.~bei der Typ-Definition
+erzeugte Typ noch von einem oder mehreren Parametern abh\"angt, wie dies z.B.~bei der Typ-Definition
 von \texttt{List(T)} der Fall ist, oder solche Typ-Definitionen, bei denen der erzeugte Typ keine
 Parameter hat.  Letztere Typ-Definitionen werden durch die Klasse \texttt{SimpleTypeDef}
-dargestellt, erstere durch die Klasse \texttt{CompositeType}.  Diese beiden Fälle werden durch die
+dargestellt, erstere durch die Klasse \texttt{CompositeType}.  Diese beiden F\"alle werden durch die
 \texttt{if}-Abfrage in Zeile 13 unterschieden.
 \begin{enumerate}
 \item Falls die untersuchte Typ-Definition \texttt{td} eine einfache Typ-Definition der Form
@@ -1222,21 +1222,21 @@ dargestellt, erstere durch die Klasse \texttt{CompositeType}.  Diese beiden Fäll
       wird dann in der Symboltabelle \texttt{mSignatureMap} abgelegt.
 \item Falls es sich bei der untersuchten Typ-Definition um die Definition eines parametrisierten
       Typs handelt, muss darauf geachtet werden, dass der Ergebnis-Typ der Signatur der Funktionen
-      $f_i$ auch von diesen Parametern abhängt.  Zu diesem Zweck wird in Zeile 24 zunächst eine neue
+      $f_i$ auch von diesen Parametern abh\"angt.  Zu diesem Zweck wird in Zeile 24 zun\"achst eine neue
       Parameter-Liste \texttt{paramList} angelegt, in die dann in der Schleife in Zeile 25 --- 27
       die Parameter des Typs hineinkopiert werden.  Der Rest dieses Falls ist analog zum ersten Fall.
 \end{enumerate}
-Neben dem Konstruktor enthält die Klasse \texttt{Program} noch die Methode \texttt{typeCheck()},
-welche die Typüberprüfung ausführt.  Die Implementierung dieser Methode ist in der Abbildung
+Neben dem Konstruktor enth\"alt die Klasse \texttt{Program} noch die Methode \texttt{typeCheck()},
+welche die Typ\"uberpr\"ufung ausf\"uhrt.  Die Implementierung dieser Methode ist in der Abbildung
 \ref{fig:Program.typeCheck} gezeigt.  Diese Methode iteriert in der Schleife, die in Zeile 2
-beginnt, über alle getypten Terme $t: \tau$, die dem Konstruktor der Klasse \texttt{Program}
-übergeben wurden.   Dazu wird in Zeile 6 zu jedem Term $t$ und Typ $\tau$ die Menge der
+beginnt, \"uber alle getypten Terme $t: \tau$, die dem Konstruktor der Klasse \texttt{Program}
+\"ubergeben wurden.   Dazu wird in Zeile 6 zu jedem Term $t$ und Typ $\tau$ die Menge der
 Typ-Gleichungen $\textsl{typeEqs}(t,\tau)$ berechnet.  Dazu wird der Methode \texttt{typeEqs()}, die
 die Funktion $\textsl{typeEqs}()$ implementiert, noch die vom Konstruktor berechnete Symboltabelle
-übergeben.  In dieser Symboltabelle sind die Signaturen der verschiedenen Funktions-Zeichen
-abgespeichert.   Die berechneten Typ-Gleichungen werden anschließend mit Hilfe der Methode
-\texttt{solve()}  der Klasse \texttt{MartelliMontanari} gelöst.  Falls die Typ-Gleichungen
-gelöst werden konnten, hat der Term $t$ tatsächlich den Typ $\tau$.  Andernfalls wird eine
+\"ubergeben.  In dieser Symboltabelle sind die Signaturen der verschiedenen Funktions-Zeichen
+abgespeichert.   Die berechneten Typ-Gleichungen werden anschlie{\ss}end mit Hilfe der Methode
+\texttt{solve()}  der Klasse \texttt{MartelliMontanari} gel\"ost.  Falls die Typ-Gleichungen
+gel\"ost werden konnten, hat der Term $t$ tats\"achlich den Typ $\tau$.  Andernfalls wird eine
 Fehlermeldung ausgegeben.
 
 
@@ -1283,26 +1283,26 @@ gleichzeitig den Typ \texttt{Object}, es gilt also
 $\texttt{String} \subseteq \texttt{Object}$.
 \\[0.2cm]
 Allgemein gilt: Ist $e$ ein Ausdruck, der den Typ $A$ hat und ist $A$ weiter eine Klasse, die von der
-Klasse $B$ abgeleitet ist, so kann der Ausdruck $e$ überall dort verwendet werden, wo ein Ausdruck vom Typ
-$B$ benötigt wird.  Damit kann der Ausdruck $e$ sowohl als ein $A$, als auch als ein $B$ verwendet werden:
+Klasse $B$ abgeleitet ist, so kann der Ausdruck $e$ \"uberall dort verwendet werden, wo ein Ausdruck vom Typ
+$B$ ben\"otigt wird.  Damit kann der Ausdruck $e$ sowohl als ein $A$, als auch als ein $B$ verwendet werden:
 $e$ kann also \emph{polymorph} verwendet werden.  Im Gegensatz zu dem \emph{parametrischen Polymorphismus},
 den wir bisher betrachtet haben, sprechen wir hier von \emph{Inklusions-Polymorphismus}.  Die Behandlung von
 Inklusions-Polymorphismus ist besonders dann interessant, wenn dieser zusammen mit parametrischen
 Polymorphismus auftritt.  Wir zeigen exemplarisch ein Beispiel in Abbildung \ref{fig:TypeSurprise.java}.
 \begin{enumerate}
-\item In Zeile 4 wird hier zunächst ein Feld \texttt{x} von Strings angelegt.
+\item In Zeile 4 wird hier zun\"achst ein Feld \texttt{x} von Strings angelegt.
 \item In Zeile 5 definieren wir ein Feld \texttt{y} von Objekten und initialisieren dieses Feld mit
       dem bereits erzeugten Feld \texttt{x}.  Da jeder String zugleich auch ein Objekt ist,
-      ist dies möglich.
+      ist dies m\"oglich.
 \item In Zeile 6 weisen wir dem zweiten Element des Feldes \texttt{y} die Zahl 2 zu.
       Da \texttt{y} ein Feld von Objekten ist und eine Zahl ebenfalls als Objekt angesehen werden kann,
       sollte auch dies kein Problem sein.
 \end{enumerate}
-In der Tat lässt sich das Programm fehlerfrei übersetzen.  Bei der Ausführung wird aber eine Ausnahme
-ausgelöst.  Der Grund ist, dass mit der Zuweisung in Zeile 5 die Variable \texttt{y} eine Referenz auf das
+In der Tat l\"asst sich das Programm fehlerfrei \"ubersetzen.  Bei der Ausf\"uhrung wird aber eine Ausnahme
+ausgel\"ost.  Der Grund ist, dass mit der Zuweisung in Zeile 5 die Variable \texttt{y} eine Referenz auf das
 Feld von Strings ist, das in Zeile 4 angelegt worden ist.  Wenn wir nun versuchen, in dieses Feld eine Zahl
-einzufügen, dann gibt es eine \texttt{ArrayStoreException}.  Dieses Beispiel zeigt, dass die Sprache
-\textsl{Java} nicht statisch auf Typ-Sicherheit geprüft werden kann.  Es zeigt auch, dass die Behandlung der
+einzuf\"ugen, dann gibt es eine \texttt{ArrayStoreException}.  Dieses Beispiel zeigt, dass die Sprache
+\textsl{Java} nicht statisch auf Typ-Sicherheit gepr\"uft werden kann.  Es zeigt auch, dass die Behandlung der
 Kombiation von Inklusions-Polymorphismus und parametrischen Polymorphismus deutlich komplexer ist, als die
 Behandlung von parametrischem Polymorphismus alleine.
 
@@ -1332,7 +1332,7 @@ Behandlung von parametrischem Polymorphismus alleine.
 \label{fig:TypeSurprise.java}
 \end{figure}
 In dem Papier ``\emph{Type Inference for Java 5}''  von Mazurak und Zdancewic wird das Typ-System
-der Sprache \textsl{Java} näher untersucht.  Die Autoren kommen zu dem Schluss, dass die Frage, ob
+der Sprache \textsl{Java} n\"aher untersucht.  Die Autoren kommen zu dem Schluss, dass die Frage, ob
 ein gegebenes \textsl{Java}-Programm korrekt getypt ist, unentscheidbar ist.  Es ist daher auch
 nicht verwunderlich,  dass sich der \textsl{Java}-Compiler bei manchen Programmen mit einem
 Stack-Overflow verabschiedet, der seine Ursache im Typ-Checker des Compilers hat.
@@ -1351,7 +1351,7 @@ instead.
 \vspace*{0.3cm}
 \noindent
 Dies zeigt, dass die Kombination von parametrischem Polymorphismus und Inklusions-Polymor\-phismus zu
-sehr komplexen Problemen führen kann, die wir aber aus Zeitgründen nicht tiefer betrachten können.
+sehr komplexen Problemen f\"uhren kann, die wir aber aus Zeitgr\"unden nicht tiefer betrachten k\"onnen.
 
 
 

--- a/Probe-Klausur/Herbst/loesung.tex
+++ b/Probe-Klausur/Herbst/loesung.tex
@@ -23,12 +23,12 @@
 
 
 \noindent
-{\large Lösungen zu den Aufgaben zur Vorlesung  ``{\sl Formale Sprachen}''}
+{\large L\"osungen zu den Aufgaben zur Vorlesung  ``{\sl Formale Sprachen}''}
 \vspace{0.5cm}
 
 \noindent
 \exercise
-Eine mögliche Lösung sehen Sie nachstehend:
+Eine m\"ogliche L\"osung sehen Sie nachstehend:
 \begin{Verbatim}[ frame         = lines, 
                   framesep      = 0.3cm, 
                   labelposition = bottomline,
@@ -60,24 +60,24 @@ Eine mögliche Lösung sehen Sie nachstehend:
 
 \exercise
 \begin{enumerate}
-\item Eine mögliche Lösung ist unten gezeigt. Beachten Sie, dass bei dieser Lösung
+\item Eine m\"ogliche L\"osung ist unten gezeigt. Beachten Sie, dass bei dieser L\"osung
       der Wert $\delta(q_2,a)$ undefiniert ist.
 
       \epsfig{file=Abbildungen/graph-a.eps, scale=0.6}
  
       \textbf{Bemerkung}: Der Zustand $q_2$ ist der einzige Zustand, der nicht-akzeptierend ist. 
       Wir gelangen sowohl von $q_1$ als auch von $q_3$ in diesen Zustand,
-      wenn wir ein ``\texttt{a}'' lesen.  Lesen wir anschließend ein ``\texttt{b}'',
+      wenn wir ein ``\texttt{a}'' lesen.  Lesen wir anschlie{\ss}end ein ``\texttt{b}'',
       so gelangen wir wie vorgeschrieben in den akzeptierenden Zustand $q_3$ in dem wir
-      dann noch beliebig viele ``\texttt{b}''s einlesen können.   Falls wir im Zustand
+      dann noch beliebig viele ``\texttt{b}''s einlesen k\"onnen.   Falls wir im Zustand
       $q_2$ ein ``\texttt{a}'' lesen, so stirbt der Automat, aber das ist auch richtig so,
       denn auf jedes ``\texttt{a}'' soll ja ein ``\texttt{b}'' folgen.
-\item Die Sprache wird von dem regulären Ausdruck $(b+ab)^*$ beschrieben.
-\item Die unten stehende Abbildung zeigt eine Lösung.  Die unbeschrifteten Kanten sind
-      $\varepsilon$-Übergänge.
+\item Die Sprache wird von dem regul\"aren Ausdruck $(b+ab)^*$ beschrieben.
+\item Die unten stehende Abbildung zeigt eine L\"osung.  Die unbeschrifteten Kanten sind
+      $\varepsilon$-\"Uberg\"ange.
 
       \epsfig{file=Abbildungen/graph-c.eps, scale=0.6}
-\item Wir definieren die Zustände wir folgt:
+\item Wir definieren die Zust\"ande wir folgt:
       \begin{enumerate}
       \item $S_0 = \{ q_0, q_1, q_2, q_4, q_8 \}$,
       \item $S_1 = \Delta(S_0, a) = \{ q_5 \}$,
@@ -91,14 +91,14 @@ Eine mögliche Lösung sehen Sie nachstehend:
       \item $\Delta(S_4, a) = \{ q_5 \} = S_1$,
       \item $\Delta(S_4, b) = \{ q_3, q_7, q_1, q_2, q_4, q_8 \} = S_2$.
       \end{enumerate}
-      Der Startzustand ist $S_0$, die Zustände $S_0$, $S_2$ und $S_4$ sind akzeptierend.
+      Der Startzustand ist $S_0$, die Zust\"ande $S_0$, $S_2$ und $S_4$ sind akzeptierend.
       Die folgende Abbildung zeigt den deterministischen Automaten.
 
       \epsfig{file=Abbildungen/graph-d.eps, scale=0.6}
 \item Wir gehen wir im Skript beschrieben vor und erstellen eine Tabelle.
       \begin{enumerate}
-      \item Im ersten Schritt erkennen wir, dass die akzeptierenden Zustände $S_0$,
-            $S_2$ und $S_4$ von den nicht-akzeptierenden Zuständen $S_1$ und $S_3$ unterscheidbar sind.
+      \item Im ersten Schritt erkennen wir, dass die akzeptierenden Zust\"ande $S_0$,
+            $S_2$ und $S_4$ von den nicht-akzeptierenden Zust\"anden $S_1$ und $S_3$ unterscheidbar sind.
             Damit hat der erste Entwurf unserer  Tabelle die folgende Gestalt:
             \begin{center}        
             \begin{tabular}[t]{|l||l|l|l|l|l|}
@@ -118,14 +118,14 @@ Eine mögliche Lösung sehen Sie nachstehend:
             \hline
             \end{tabular}
             \end{center}
-      \item Als nächstes erkennen wir, dass die Zustände $S_1$ und $S_3$ unterscheidbar sind,
+      \item Als n\"achstes erkennen wir, dass die Zust\"ande $S_1$ und $S_3$ unterscheidbar sind,
             denn es gilt 
             \\[0.2cm]
             \hspace*{1.3cm}
             $\delta(S_1,b) = S_4$, \quad $\delta(S_3,b) = S_3$ \quad und \quad $S_4 \not\sim S_3$.
             \\[0.2cm]
-            Auf der anderen Seite sehen wir, dass die Zustände $S_0$ und $S_2$ nicht
-            unterscheidbar sein können, denn es gilt
+            Auf der anderen Seite sehen wir, dass die Zust\"ande $S_0$ und $S_2$ nicht
+            unterscheidbar sein k\"onnen, denn es gilt
             \\[0.2cm]
             \hspace*{1.3cm}
             $\delta(S_0,a) = S_1 = \delta(S_2,a)$ \quad und 
@@ -139,7 +139,7 @@ Eine mögliche Lösung sehen Sie nachstehend:
             $\delta(S_0,b) = S_2 = \delta(S_4,b)$.
             \\[0.2cm]
             Aus $S_0 \sim S_2$ und $S_0 \sim S_4$ folgt sofort $S_2 \sim S_4$,
-            Damit haben wir jetzt alle möglichen Äquivalenzen untersucht und unsere
+            Damit haben wir jetzt alle m\"oglichen \"Aquivalenzen untersucht und unsere
             Tabelle hat die folgende Form:
             \begin{center}        
             \begin{tabular}[t]{|l||l|l|l|l|l|}
@@ -160,15 +160,15 @@ Eine mögliche Lösung sehen Sie nachstehend:
             \end{tabular}
             \end{center}
       \end{enumerate}
-      Die Zustände $S_0$, $S_2$ und $S_4$ sind also paarweise äquivalent.
-      Die nachstehende Abbildung zeigt die Lösung.  
+      Die Zust\"ande $S_0$, $S_2$ und $S_4$ sind also paarweise \"aquivalent.
+      Die nachstehende Abbildung zeigt die L\"osung.  
 
       \epsfig{file=Abbildungen/graph-e.eps, scale=0.6}
 \end{enumerate}
 
 \exercise
-Wir führen den Beweis indirekt und nehmen an, dass $L_P$ eine reguläre Sprache wäre.
-Nach dem Pumping-Lemma gibt es dann eine natürliche Zahl $n$, so dass gilt:
+Wir f\"uhren den Beweis indirekt und nehmen an, dass $L_P$ eine regul\"are Sprache w\"are.
+Nach dem Pumping-Lemma gibt es dann eine nat\"urliche Zahl $n$, so dass gilt:
 \\[0.2cm]
 \hspace*{0.5cm}
   $\forall s \in L_P : \bigl(|s| \geq n \rightarrow \exists u,v,w\in \Sigma^* :
@@ -176,7 +176,7 @@ Nach dem Pumping-Lemma gibt es dann eine natürliche Zahl $n$, so dass gilt:
    (\forall h \in \mathbb{N}: uv^h w \in L_P)\bigr)
 $.
 \\[0.2cm]
-In Worten heißt dass: Für alle $s \in L_P$, für die $|s| \geq n$ gilt, gibt es eine Zerlegung
+In Worten hei{\ss}t dass: F\"ur alle $s \in L_P$, f\"ur die $|s| \geq n$ gilt, gibt es eine Zerlegung
 \\[0.2cm]
 \hspace*{1.3cm}
 $s = uvw$,
@@ -193,7 +193,7 @@ Also gibt es nach dem Pumping-Lemma eine Zerlegung von $s$ der Form
 $a^nb^{2 \cdot n} a^n = uvw$
 \\[0.2cm]
 mit den Eigenschaften $v \not= \varepsilon$ und $|uv| \leq n$.  Aus $|uv| \leq n$ folgt, dass der
-String $uv$ ganz in dem String $a^n$ enthalten ist.  Damit müssen die Strings $u$, $v$ und $w$
+String $uv$ ganz in dem String $a^n$ enthalten ist.  Damit m\"ussen die Strings $u$, $v$ und $w$
 folgende Form haben:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -229,18 +229,18 @@ und damit ist $uw$ keine Palindrom.
       \hspace*{1.3cm} $S \rightarrow   \mathtt{a}S\mathtt{c} \mid T$, \\[0.2cm]
       \hspace*{1.3cm} $T \rightarrow \mathtt{b}T\mathtt{c} \mid \varepsilon$. 
       \\[0.2cm]
-      Die möglichen Ableitungen von $T$ haben die Form
+      Die m\"oglichen Ableitungen von $T$ haben die Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $T \Rightarrow \mathtt{b}T\mathtt{c} \Rightarrow \mathtt{b}^2T\mathtt{c}^2
       \Rightarrow \cdots \Rightarrow \mathtt{b}^lT\mathtt{c}^l \Rightarrow \mathtt{b}^l\mathtt{c}^l$,
       \\[0.2cm]
-      Dies zeigt, dass für die durch $T$ beschriebene Sprache folgendes gilt:
+      Dies zeigt, dass f\"ur die durch $T$ beschriebene Sprache folgendes gilt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $L(T) = \{ \mathtt{b}^l \mathtt{c}^l \mid l \in \mathbb{N} \}$.
       \\[0.2cm]
-      Die möglichen Ableitungen von $S$ haben die Form
+      Die m\"oglichen Ableitungen von $S$ haben die Form
       \\[0.2cm]
       \hspace*{1.3cm}
       $S \Rightarrow \mathtt{a}S\mathtt{c} \Rightarrow \mathtt{a}^2S\mathtt{c}^2
@@ -250,20 +250,20 @@ und damit ist $uw$ keine Palindrom.
       \Rightarrow^* 
       \mathtt{a}^k \mathtt{b}^l \mathtt{c}^l\mathtt{c}^k$.
       \\[0.2cm]
-      Dies zeigt, dass für die durch $S$ beschriebene Sprache folgendes gilt:
+      Dies zeigt, dass f\"ur die durch $S$ beschriebene Sprache folgendes gilt:
       \\[0.2cm]
       \hspace*{1.3cm}
       $L(S) = \{ \mathtt{a}^k \mathtt{b}^l \mathtt{c}^{l+k}\mid l \in \mathbb{N} \}$.
-\item Wir können die Sprache $L_2$ auf die Sprache $L_1$ zurück führen, denn wenn
-      $h \geq k+ l$ ist, heißt dies nichts anderes als dass es ein $j \in \mathbb{N}$
+\item Wir k\"onnen die Sprache $L_2$ auf die Sprache $L_1$ zur\"uck f\"uhren, denn wenn
+      $h \geq k+ l$ ist, hei{\ss}t dies nichts anderes als dass es ein $j \in \mathbb{N}$
       gibt, so dass $h = k + l + j$ gilt.  Damit haben wir
       \\[0.2cm]
       \hspace*{1.3cm}
       $L_2 = \{ \mathtt{a}^k \mathtt{b}^l \mathtt{c}^{l+k}\mathtt{c}^j\mid l \in
       \mathbb{N} \wedge j \in \mathbb{N} \}$.
       \\[0.2cm]
-      Dies zeigt, dass die Wörter aus $L_2$ aus Wörtern von $L_1$ bestehen, an die noch
-      der Buchstabe ``\texttt{c}'' beliebig oft herangehängt wird. Dies führt zu folgender
+      Dies zeigt, dass die W\"orter aus $L_2$ aus W\"ortern von $L_1$ bestehen, an die noch
+      der Buchstabe ``\texttt{c}'' beliebig oft herangeh\"angt wird. Dies f\"uhrt zu folgender
       Grammatik:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -286,8 +286,8 @@ Im Skript hatten wir gesehen, dass  Regeln der Form
 \hspace*{1.3cm} 
 $A \rightarrow A \beta_1 \mid \cdots \mid A \beta_k  \mid \gamma_1 \mid \cdots \mid \gamma_l$
 \\[0.2cm]
-durch Einführen einer neuen Variablen $L$ in die folgenden nicht-links-rekursiven Regeln
-überführt werden können:
+durch Einf\"uhren einer neuen Variablen $L$ in die folgenden nicht-links-rekursiven Regeln
+\"uberf\"uhrt werden k\"onnen:
 \\[0.2cm]
 \hspace*{1.3cm}
 $
@@ -297,7 +297,7 @@ L & \rightarrow & \beta_1 \;L \;\mid\; \beta_2 \;L \;\mid\; \cdots \;\mid\; \bet
 \end{array}
 $
 \\[0.2cm]
-Wir führen also drei neue syntaktische Variablen $L_S$, $L_A$ und $L_B$ ein
+Wir f\"uhren also drei neue syntaktische Variablen $L_S$, $L_A$ und $L_B$ ein
 und erhalten dann die folgenden Regeln:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -315,7 +315,7 @@ $
 \exercise
 \begin{enumerate}
 \item Die Grammatik $G = \langle \{E\}, \{N\}, R, E \rangle$ , bei der die Regeln $R$ wie folgt
-      gegeben sind, leistet das Gewünschte:
+      gegeben sind, leistet das Gew\"unschte:
       \\[0.2cm]
       \hspace*{1.3cm}
       \begin{array}[t]{lcl}
@@ -328,7 +328,7 @@ $
       \\[0.2cm]
       
 
-\item Ein \textsc{Antlr}-Programm könnte wie folgt aussehen:
+\item Ein \textsc{Antlr}-Programm k\"onnte wie folgt aussehen:
 \begin{Verbatim}[ frame         = lines, 
                   framesep      = 0.3cm, 
                   labelposition = bottomline,
@@ -368,16 +368,16 @@ $
       \hspace*{1.3cm}
       $L_2 = L_1 \cap (\Sigma^* \backslash L)$.
       \\[0.2cm]
-      Die Sprache $L_1$ ist offenbar regulär, denn sie wird durch den regulären Ausdruck
+      Die Sprache $L_1$ ist offenbar regul\"ar, denn sie wird durch den regul\"aren Ausdruck
       $a^* b^*$ beschrieben.  Die Sprache $L_2$ ist identisch mit der Sprache
       \\[0.2cm]
       \hspace*{1.3cm}
       $\{ a^k b^k \mid k \in \mathbb{N} \}$ 
       \\[0.2cm]
-      und von dieser Sprache haben wir bereits im Skript gezeigt, dass sie nicht regulär ist.
-      Wäre nun $L$ regulär, so wäre auch das Komplement von $L$, die Sprache
-      $\Sigma^* \backslash L$ regulär. Da der Schnitt zweier regulärer Sprache ebenfalls
-      regulär ist, wäre dann auch $L_2$ regulär, im Widerspruch zu dem in der Vorlesung gezeigten
+      und von dieser Sprache haben wir bereits im Skript gezeigt, dass sie nicht regul\"ar ist.
+      W\"are nun $L$ regul\"ar, so w\"are auch das Komplement von $L$, die Sprache
+      $\Sigma^* \backslash L$ regul\"ar. Da der Schnitt zweier regul\"arer Sprache ebenfalls
+      regul\"ar ist, w\"are dann auch $L_2$ regul\"ar, im Widerspruch zu dem in der Vorlesung gezeigten
       Ergebnis.
 \item Wir geben eine Grammatik an, die diese Sprache erzeugt:
       \\[0.2cm]
@@ -401,9 +401,9 @@ $
 
 \exercise
 %\begin{enumerate}
-Wir führen den Beweis indirekt und nehmen an, $L_{\mathbb{P}}$ wäre regulär.  Nach
-dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es für alle Strings $s \in L_{\mathbb{P}}$, 
-deren Länge größer-gleich $n$ ist, eine Zerlegung
+Wir f\"uhren den Beweis indirekt und nehmen an, $L_{\mathbb{P}}$ w\"are regul\"ar.  Nach
+dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es f\"ur alle Strings $s \in L_{\mathbb{P}}$, 
+deren L\"ange gr\"o{\ss}er-gleich $n$ ist, eine Zerlegung
 \\[0.2cm]
 \hspace*{1.3cm}
 $s = uvw$
@@ -414,34 +414,34 @@ mit den folgenden drei Eigenschaften gibt:
 \item $|uv| \leq n$ \quad und
 \item $\forall h \in \mathbb{N}: u v^h w \in L_{\mathbb{P}}$.
 \end{enumerate}
-Wir wählen nun eine Primzahl $p$, die größer-gleich  $n + 2$ ist und setzen $s = \mathtt{a}^p$.
-Dann gilt $|s| = p \geq n$ und die Voraussetzung des Pumping-Lemmas ist erfüllt.
+Wir w\"ahlen nun eine Primzahl $p$, die gr\"o{\ss}er-gleich  $n + 2$ ist und setzen $s = \mathtt{a}^p$.
+Dann gilt $|s| = p \geq n$ und die Voraussetzung des Pumping-Lemmas ist erf\"ullt.
 Wir finden also eine Zerlegung von $\mathtt{a}^p$ der Form
 \\[0.2cm]
 \hspace*{1.3cm}
 $\mathtt{a}^p = uvw$ 
 \\[0.2cm]
 mit den oben angegebenen Eigenschaften.
-Aufgrund der Gleichung $s = uvw$ können die Teilstrings $u$, $v$ und $w$ nur aus dem
-Buchstaben ``\texttt{a}'' bestehen.  Also gibt es natürliche Zahlen $x$, $y$, und
+Aufgrund der Gleichung $s = uvw$ k\"onnen die Teilstrings $u$, $v$ und $w$ nur aus dem
+Buchstaben ``\texttt{a}'' bestehen.  Also gibt es nat\"urliche Zahlen $x$, $y$, und
 $z$ so dass gilt:
 \\[0.2cm]
 \hspace*{1.3cm}
 $u = \mathtt{a}^x$, \quad $v = \mathtt{a}^y$ \quad und \quad $w = \mathtt{a}^z$.
 \\[0.2cm]
-Für  $x$, $y$ und $z$ gilt dann Folgendes:
+F\"ur  $x$, $y$ und $z$ gilt dann Folgendes:
 \begin{enumerate}
 \item $x + y + z = p$,
 \item $y \not= 0$,
 \item $x + y \leq n$,
 \item $\forall h \in \mathbb{N}: x + h \cdot y + z \in \mathbb{P}$.
 \end{enumerate}
-Setzen wir in der letzten Gleichung für $h$ den Wert $(x + z)$ ein, so erhalten wir
+Setzen wir in der letzten Gleichung f\"ur $h$ den Wert $(x + z)$ ein, so erhalten wir
 \\[0.2cm]
 \hspace*{1.3cm}
 $x + (x + z)\cdot y + z \in P$.
 \\[0.2cm]
-Wegen $x + (x + z)\cdot y + z = (x + z) \cdot (1 + y)$ hätten wir dann
+Wegen $x + (x + z)\cdot y + z = (x + z) \cdot (1 + y)$ h\"atten wir dann
 \\[0.2cm]
 \hspace*{1.3cm}
 $(x + z) \cdot (1 + y) \in \mathbb{P}$.
@@ -450,10 +450,10 @@ Das kann aber nicht sein, denn wegen $y > 0$ ist der Faktor $1 + y$ von 1
 verschieden und wegen $x + y \leq n$ und $x + y + z = p$ und $p \geq n + 2$ wissen wir, dass
 $z \geq 2$ ist, so dass auch der Faktor $(x + z)$ von 1 verschieden ist.  Damit kann das Produkt
 $(x + z) \cdot (1 + y)$ aber keine Primzahl mehr sein und wir haben einen Widerspruch zu der
-Annahme, dass $L_{\mathbb{P}}$ regulär ist.
-%\item Wir führen den Beweis indirekt und nehmen an, $L_{\mathbb{P}}$ wäre kontextfrei.  Nach
-%      dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es für alle Strings $s \in L_{\mathbb{P}}$, 
-%      deren Länge größer als $n$ ist, eine Zerlegung
+Annahme, dass $L_{\mathbb{P}}$ regul\"ar ist.
+%\item Wir f\"uhren den Beweis indirekt und nehmen an, $L_{\mathbb{P}}$ w\"are kontextfrei.  Nach
+%      dem Pumping-Lemma gibt es dann eine Zahl $n$, so dass es f\"ur alle Strings $s \in L_{\mathbb{P}}$, 
+%      deren L\"ange gr\"o{\ss}er als $n$ ist, eine Zerlegung
 %      \\[0.2cm]
 %      \hspace*{1.3cm}
 %      $s = uvwxy$
@@ -464,30 +464,30 @@ Annahme, dass $L_{\mathbb{P}}$ regulär ist.
 %      \item $vx \not= \varepsilon$, 
 %      \item $\forall h \in \mathbb{N}: u v^h w x^h y \in L_{\mathbb{P}}$.
 %      \end{enumerate}
-%      Wir wählen nun eine Primzahl $p$, die größer als $n+1$ ist und setzen $s = \mathtt{a}^p$.
-%      Dann gilt $|s| = p > n$ und die Voraussetzung des Pumping-Lemmas ist erfüllt.
+%      Wir w\"ahlen nun eine Primzahl $p$, die gr\"o{\ss}er als $n+1$ ist und setzen $s = \mathtt{a}^p$.
+%      Dann gilt $|s| = p > n$ und die Voraussetzung des Pumping-Lemmas ist erf\"ullt.
 %      Wir finden also eine Zerlegung von $\mathtt{a}^p$ der Form
 %      \\[0.2cm]
 %      \hspace*{1.3cm}
 %      $\mathtt{a}^p = uvwxy$ 
 %      \\[0.2cm]
 %      mit den oben angegebenen Eigenschaften.
-%      Aufgrund der Gleichung $s = uvwxy$ können die Teilstrings $u$, $v$, $w$, $x$ und $y$ nur aus dem
-%      Buchstaben ``\texttt{a}'' bestehen.  Also gibt es natürliche Zahlen $c$, $d$, $e$, $f$ und
+%      Aufgrund der Gleichung $s = uvwxy$ k\"onnen die Teilstrings $u$, $v$, $w$, $x$ und $y$ nur aus dem
+%      Buchstaben ``\texttt{a}'' bestehen.  Also gibt es nat\"urliche Zahlen $c$, $d$, $e$, $f$ und
 %      $g$ so dass gilt:
 %      \\[0.2cm]
 %      \hspace*{1.3cm}
 %      $u = \mathtt{a}^c$, \quad $v = \mathtt{a}^d$, \quad $w = \mathtt{a}^e$, \quad 
 %      $x = \mathtt{a}^f$ \quad und \quad $y = \mathtt{a}^g$.
 %      \\[0.2cm]
-%      Für die Zahlen $c$, $d$, $e$, $f$ und $g$ gilt dann Folgendes:
+%      F\"ur die Zahlen $c$, $d$, $e$, $f$ und $g$ gilt dann Folgendes:
 %      \begin{enumerate}
 %      \item $c + d + e + f + g = p$,
 %      \item $d + f \not= 0$,
 %      \item $d + e + f \leq n$,
 %      \item $\forall h \in \mathbb{N}: c + h \cdot d + e + h \cdot f + g \in \mathbb{P}$.
 %      \end{enumerate}
-%      Setzen wir in der letzten Gleichung für $h$ den Wert $(c + e + g)$ ein, so erhalten wir
+%      Setzen wir in der letzten Gleichung f\"ur $h$ den Wert $(c + e + g)$ ein, so erhalten wir
 %      \\[0.2cm]
 %      \hspace*{1.3cm}
 %      $c + (c + e + g) \cdot d + e + (c + e + g) \cdot f + g \in P$.
@@ -497,7 +497,7 @@ Annahme, dass $L_{\mathbb{P}}$ regulär ist.
 %      \hspace*{1.3cm}
 %      $c + (c + e + g) \cdot d + e + (c + e + g) \cdot f + g = (c + e + g) \cdot (1 + d + f)$ 
 %      \\[0.2cm]
-%      hätten wir dann
+%      h\"atten wir dann
 %      \\[0.2cm]
 %      \hspace*{1.3cm}
 %      $(c + e + g) \cdot (1 + d + f) \in \mathbb{P}$.
@@ -517,13 +517,13 @@ Die Grammatik
  $G = \langle \{ E_1, E_2, \cdots, E_n \}, 
   \{ \textsc{Number}, \textsc{Var}, \mathtt{\#}_1, \cdots, \mathtt{\#}_n \}, R, E_1 \rangle$, 
 \\[0.2cm]
-deren Regeln wie folgt gegeben sind, leistet das Gewünschte:
+deren Regeln wie folgt gegeben sind, leistet das Gew\"unschte:
 \\[0.2cm]
 \hspace*{1.3cm}
 $
 \begin{array}[t]{lcll}
 E_k &\rightarrow& E_k \;\mathtt{\#}_k\; E_{k+1}  &  \\[0.2cm]
-    &\mid       & E_{k+1}                    & \mbox{für alle $k \in \{1, \cdots, k-1\}$} \\[0.3cm]
+    &\mid       & E_{k+1}                    & \mbox{f\"ur alle $k \in \{1, \cdots, k-1\}$} \\[0.3cm]
 E_n &\rightarrow& \textsc{Var}  \\
     &\mid       & \textsc{Number} 
 \end{array}

--- a/Probe-Klausur/Herbst/probe-klausur.tex
+++ b/Probe-Klausur/Herbst/probe-klausur.tex
@@ -35,31 +35,31 @@ Ein Kassenzettel bestehe aus Zeilen, die in etwa wie folgt aussehen:
 Die Preise sind also teilweise in Euro, teilweise
 in Schweizer Franken angegeben.  
 Entwickeln Sie ein \textsl{JFlex}-Programm, dass einen Kassenzettel einliest und 
-anschließend den Gesamtpreis in Euro ausgibt.  
+anschlie{\ss}end den Gesamtpreis in Euro ausgibt.  
 Nehmen Sie dabei an, dass ein Euro einen Wert von 1,20 Franken hat.
 
 \exercise
 \begin{enumerate}
 \item Geben Sie einen deterministischen endlichen Automaten $F$ an, so dass $L(F)$ aus genau den
-      Wörtern der Sprache $\{a,b\}^*$ besteht,  bei denen auf jedes \qote{a} mindestens ein \qote{b} folgt.
-\item Geben Sie einen regulären Ausdruck an, der diese Sprache beschreibt.
-\item Berechnen Sie, ausgehend von dem unter (b) angegebenen regulären Ausdruck,
+      W\"ortern der Sprache $\{a,b\}^*$ besteht,  bei denen auf jedes \qote{a} mindestens ein \qote{b} folgt.
+\item Geben Sie einen regul\"aren Ausdruck an, der diese Sprache beschreibt.
+\item Berechnen Sie, ausgehend von dem unter (b) angegebenen regul\"aren Ausdruck,
       einen nicht-deterministischen endlichen Automaten, der dieselbe Sprache erkennt.
 
       Benutzen Sie dabei das in der Vorlesung diskutierte Verfahren.
-\item Überführen Sie den unter (c) angegebenen Automaten in einen
+\item \"Uberf\"uhren Sie den unter (c) angegebenen Automaten in einen
       deterministischen endlichen Automaten.
 
       Benutzen Sie dabei das in der Vorlesung diskutierte Verfahren.
-\item Minimieren Sie die Anzahl der Zustände des in (d) berechneten Automaten.
+\item Minimieren Sie die Anzahl der Zust\"ande des in (d) berechneten Automaten.
 
       Benutzen Sie dabei das in der Vorlesung diskutierte Verfahren.
 \end{enumerate}
 
 \exercise
-Die Sprache $L_{P}$ beinhaltet alle Wörter aus der Sprache $\{ \texttt{a}, \texttt{b} \}^*$,
-die Palindrome sind.  Definieren wir für einen String $w = c_1 c_2 \cdots c_{n-1} c_n$ den
-String $w_r$ (gelesen: \emph{w rückwärts}) durch
+Die Sprache $L_{P}$ beinhaltet alle W\"orter aus der Sprache $\{ \texttt{a}, \texttt{b} \}^*$,
+die Palindrome sind.  Definieren wir f\"ur einen String $w = c_1 c_2 \cdots c_{n-1} c_n$ den
+String $w_r$ (gelesen: \emph{w r\"uckw\"arts}) durch
 \\[0.2cm]
 \hspace*{1.3cm}
 $w^r := c_n c_{n-1} \cdots c_2 c_1$,
@@ -71,9 +71,9 @@ $L_{P} := \bigl\{ w \in \{ \texttt{a}, \texttt{b} \}^* \mid w = w^r \bigr\}$
 \\[0.2cm]
 definiert werden.
 \begin{enumerate}
-\item Zeigen Sie mit Hilfe des Pumping-Lemmas für reguläre Sprachen, dass die Sprache $L_{P}$
-      der Palindrome keine reguläre Sprache ist.
-\item Überprüfen Sie, ob die Sprache $L_P$ eine kontextfreie Sprache ist und beweisen Sie
+\item Zeigen Sie mit Hilfe des Pumping-Lemmas f\"ur regul\"are Sprachen, dass die Sprache $L_{P}$
+      der Palindrome keine regul\"are Sprache ist.
+\item \"Uberpr\"ufen Sie, ob die Sprache $L_P$ eine kontextfreie Sprache ist und beweisen Sie
       Ihre Behauptung.
 \end{enumerate}
 \pagebreak 
@@ -85,38 +85,38 @@ Es sei $\Sigma = \{ \texttt{a}, \texttt{b}, \mathtt{c} \}$.  \begin{enumerate}
       \hspace*{1.3cm}
       $L_1 :=  \{ \texttt{a}^k \texttt{b}^l \texttt{c}^{l + k} \in \Sigma^* \mid  k,l \in \mathbb{N} \}$
       \\[0.2cm] 
-      definiert. Überprüfen Sie, ob die Sprache $L_1$ regulär ist und beweisen Sie Ihre Behauptung.
-\item Überprüfen Sie, ob die oben definierte Sprache $L_1$ kontextfrei ist und beweisen Sie Ihre Behauptung.
+      definiert. \"Uberpr\"ufen Sie, ob die Sprache $L_1$ regul\"ar ist und beweisen Sie Ihre Behauptung.
+\item \"Uberpr\"ufen Sie, ob die oben definierte Sprache $L_1$ kontextfrei ist und beweisen Sie Ihre Behauptung.
 \item Die Sprache $L_2$ werde durch die Gleichung
       \\[0.2cm]
       \hspace*{1.3cm}
       $L_2 :=  \{ \texttt{a}^k \texttt{b}^l \texttt{c}^{l \cdot k} \in \Sigma^* \mid  k,l \in \mathbb{N} \}$
       \\[0.2cm] 
-      definiert. Überprüfen Sie, ob die Sprache $L_2$ regulär ist und beweisen Sie Ihre Behauptung.
-\item Überprüfen Sie, ob die oben definierte Sprache $L_2$ kontextfrei ist und beweisen Sie Ihre Behauptung.
+      definiert. \"Uberpr\"ufen Sie, ob die Sprache $L_2$ regul\"ar ist und beweisen Sie Ihre Behauptung.
+\item \"Uberpr\"ufen Sie, ob die oben definierte Sprache $L_2$ kontextfrei ist und beweisen Sie Ihre Behauptung.
 \end{enumerate}
 
 
 \exercise
-Präfix-Ausdrücke sind Ausdrücke, in denen die arithmetischen Operatoren \qote{+}, \qote{-},
-\qote{*} und \qote{/} als zweistellige Präfix-Operatoren benutzt werden.  Außer den
-genannten Operatoren sollen die Ausdrücke nur natürliche Zahlen enthalten.  Die Operatoren stehen
-immer vor ihren Argumenten, die natürlich selber komplexe Präfix-Ausdrücke sein können.
+Pr\"afix-Ausdr\"ucke sind Ausdr\"ucke, in denen die arithmetischen Operatoren \qote{+}, \qote{-},
+\qote{*} und \qote{/} als zweistellige Pr\"afix-Operatoren benutzt werden.  Au{\ss}er den
+genannten Operatoren sollen die Ausdr\"ucke nur nat\"urliche Zahlen enthalten.  Die Operatoren stehen
+immer vor ihren Argumenten, die nat\"urlich selber komplexe Pr\"afix-Ausdr\"ucke sein k\"onnen.
 Beispielsweise ist
 \\[0.2cm]
 \hspace*{1.3cm}
 $+ + 2 * 3\; 4 - 1\; 2$
 \\[0.2cm]
-ein Präfix-Ausdruck, der den selben Wert hat wie der Term
+ein Pr\"afix-Ausdruck, der den selben Wert hat wie der Term
 \\[0.2cm]
 \hspace*{1.3cm}
 $\bigl(2 + (3 * 4)) + (1 - 2)$.
 \begin{enumerate}
-\item Geben Sie eine \textbf{Ebnf}-Grammatik für Präfix-Ausdrücke an.
+\item Geben Sie eine \textbf{Ebnf}-Grammatik f\"ur Pr\"afix-Ausdr\"ucke an.
 \item Geben Sie eine \textsc{Antlr}-Grammatik an, mit deren Hilfe Sie einen
-      Präfix-Ausdruck auswerten können.  
+      Pr\"afix-Ausdruck auswerten k\"onnen.  
 \item Geben Sie eine \textsc{JavaCup}-Grammatik an, mit deren Hilfe Sie einen
-      Präfix-Ausdruck auswerten können.  Zusätzlich sollen Sie mit Hilfe von \textsl{JFlex} einen
+      Pr\"afix-Ausdruck auswerten k\"onnen.  Zus\"atzlich sollen Sie mit Hilfe von \textsl{JFlex} einen
       Scanner entwickeln, der die in der \textsc{JavaCup}-Grammatik verwendeten Nicht-Terminale
       erzeugt.
 \end{enumerate}
@@ -125,7 +125,7 @@ $\bigl(2 + (3 * 4)) + (1 - 2)$.
 Betrachten Sie die folgende Sprache:
 \[ L = \{ a^k b^l \mid k,l \in \mathbb{N} \wedge k \not= l \} \]
 \begin{enumerate}
-\item Zeigen Sie, dass diese Sprache nicht regulär ist.
+\item Zeigen Sie, dass diese Sprache nicht regul\"ar ist.
 
       \textbf{Hinweis}: Benutzen Sie das Theorem von Nerode.
 \item Zeigen Sie, dass diese Sprache kontextfrei ist.
@@ -148,25 +148,25 @@ $
 \\[0.2cm]
 Bearbeiten Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Überprüfen Sie, ob diese Grammatik eine LL(1)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob diese Grammatik eine LL(1)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob diese Grammatik eine LR-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob diese Grammatik eine LR-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
 \end{enumerate}
 
 
 %\exercise
-%In einer hypothetischen Programmiersprache bestehen die Ausdrücke aus natürlichen Zahlen,
-%Variablen und binären Infix-Operatoren der Form ``\texttt{\#}$_k$'' mit 
-%$k \in \{1, \cdots, n \}$.  Die Zahl $n$ ist hier eine beliebige vorgegebene natürliche Zahl.
-%Die Zahl $k$ gibt die Präzedenz des Operators ``\texttt{\#}$_k$''
-%an:  Je größer $k$ ist, um so stärker bindet der Operator.  Außerdem wollen wir
+%In einer hypothetischen Programmiersprache bestehen die Ausdr\"ucke aus nat\"urlichen Zahlen,
+%Variablen und bin\"aren Infix-Operatoren der Form ``\texttt{\#}$_k$'' mit 
+%$k \in \{1, \cdots, n \}$.  Die Zahl $n$ ist hier eine beliebige vorgegebene nat\"urliche Zahl.
+%Die Zahl $k$ gibt die Pr\"azedenz des Operators ``\texttt{\#}$_k$''
+%an:  Je gr\"o{\ss}er $k$ ist, um so st\"arker bindet der Operator.  Au{\ss}erdem wollen wir
 %voraussetzen, dass die Operatoren  ``\texttt{\#}$_k$'' alle links-assoziativ sind.
 %\vspace{0.2cm}
 
 %\noindent
-%Geben Sie eine Grammatik an, mit der sich die Struktur von Ausdrücken der oben
-%beschriebenen Art eindeutig beschreiben lässt.
+%Geben Sie eine Grammatik an, mit der sich die Struktur von Ausdr\"ucken der oben
+%beschriebenen Art eindeutig beschreiben l\"asst.
 
 
 \exercise
@@ -175,14 +175,14 @@ habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \mathtt{+} \mid S\, S\, \mathtt{-} \mid \mathtt{a}. \]
 \begin{enumerate}
 \item Berechnen Sie die Mengen $\textsl{First}(S)$ und $\textsl{Follow}(S)$.
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik und
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik und
       stellen Sie das Ergebnis in einer Tabelle dar.
 \item Untersuchen Sie, ob diese Grammatik mehrdeutig ist.
 \end{enumerate}
 
 \exercise
-Nehmen Sie an, dass die im Skript eingeführte Sprache \textsl{Integer}-\texttt{C} um eine 
+Nehmen Sie an, dass die im Skript eingef\"uhrte Sprache \textsl{Integer}-\texttt{C} um eine 
 \texttt{do-while}-Schleife erweitert werden soll, deren Syntax durch die folgende Grammatik-Regel gegeben ist:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -190,9 +190,9 @@ $\textsl{statement} \rightarrow \quoted{do}\; \textsl{statement}\; \quoted{while
  \quoted{(} \;\textsl{boolExpr} \;\quoted{)}$.
 \\[0.2cm]
 Die Semantik dieses Konstruktes soll mit der Semantik des entsprechenden Konstruktes in
-der Sprache \texttt{C} übereinstimmen.
+der Sprache \texttt{C} \"ubereinstimmen.
 Geben Sie eine Gleichung an, die beschreibt, wie eine \texttt{do-while}-Schleife in
-\textsl{Java-Assembler} übersetzt werden kann.
+\textsl{Java-Assembler} \"ubersetzt werden kann.
 
 \end{document}
 

--- a/Probe-Klausur/Sommer/aufgabe-2009.tex
+++ b/Probe-Klausur/Sommer/aufgabe-2009.tex
@@ -25,7 +25,7 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 \newcommand{\quoted}[1]{\;\mbox{``\texttt{#1}''}\;}
 
 
@@ -33,12 +33,12 @@
 
 
 \noindent
-{\large  Aufgaben zur Klausurvorbereitung für die Vorlesung ``{\sl Compilerbau}''}
+{\large  Aufgaben zur Klausurvorbereitung f\"ur die Vorlesung ``{\sl Compilerbau}''}
 \vspace{0.5cm}
 
 \noindent
-\textbf{Hinweis}: Bei der Klausur müssen alle Aufgabenbläter mit abgegeben werden, sonst
-ist die Klausur ungültig!
+\textbf{Hinweis}: Bei der Klausur m\"ussen alle Aufgabenbl\"ater mit abgegeben werden, sonst
+ist die Klausur ung\"ultig!
 \vspace{0.5cm}
 
 
@@ -48,9 +48,9 @@ habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \mathtt{+} \mid S\, S\, \mathtt{-} \mid \mathtt{a}. \]
 \begin{enumerate}
 \item Berechnen Sie die Mengen $\textsl{First}(S)$ und $\textsl{Follow}(S)$.
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
-\item Berechnen Sie die Menge der LR-Zustände für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
+\item Berechnen Sie die Menge der LR-Zust\"ande f\"ur diese Grammatik.
 \end{enumerate}
 
 \exercise
@@ -69,36 +69,36 @@ $
 \\[0.2cm]
 Bearbeiten Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Überprüfen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
 \end{enumerate}
 
 
 \exercise
 Wir definieren \emph{geschachtelte Listen} rekursiv als solche Listen, 
-deren Elemente natürliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
+deren Elemente nat\"urliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
 geschachtelten Listen sollen durch Kommata getrennt werden und die Listen selber sollen
 durch die eckigen Klammern ``\texttt{[}'' und ``\texttt{]}'' begrenzt sein.
-Beispiele für geschachtelte Listen sind also:
+Beispiele f\"ur geschachtelte Listen sind also:
 \begin{enumerate}
 \item \texttt{[ 1, [ 1, [], [ 2, 3]], 7]}
 \item \texttt{[ [], [ [], [], [ 4], 5], []]}
 \end{enumerate}
-Lösen Sie die folgenden Teilaufgaben:
+L\"osen Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Geben Sie eine Grammatik für geschachtelte Listen an.
+\item Geben Sie eine Grammatik f\"ur geschachtelte Listen an.
 \item Geben Sie die EP-Spezifikation von Klassen an, mit deren Hilfe sich
-      geschachtelte Listen repräsentieren lassen.
+      geschachtelte Listen repr\"asentieren lassen.
 \item Geben Sie einen \textsl{JavaCup}-Parser an, der eine geschachtelte Liste einliest
       und einen abstrakten Syntax-Baum der Liste berechnet.
 
-      \textbf{Hinweis:} In der Klausur können Sie später davon ausgehen, dass ein geeigneter
+      \textbf{Hinweis:} In der Klausur k\"onnen Sie sp\"ater davon ausgehen, dass ein geeigneter
       \textsl{JFlex}-Scanner bereits gegeben ist, aber bei dieser Aufgabe sollen Sie den
-      Scanner ebenfalls erstellen, damit Sie Ihre Lösung auch testen können.
+      Scanner ebenfalls erstellen, damit Sie Ihre L\"osung auch testen k\"onnen.
 \end{enumerate}
 
 
@@ -119,11 +119,11 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{typeEqs}\bigl(\texttt{addLast(cons(x, nil), z): list(int)}\bigr)$.
-\item Lösen Sie die in Teil (a) berechneten Typ-Gleichungen.
+\item L\"osen Sie die in Teil (a) berechneten Typ-Gleichungen.
 \end{enumerate}
 
 \exercise
-Nehmen Sie an, dass die im Skript eingeführte Sprache \textsl{Integer}-\texttt{C} um eine 
+Nehmen Sie an, dass die im Skript eingef\"uhrte Sprache \textsl{Integer}-\texttt{C} um eine 
 \texttt{do-while}-Schleife erweitert werden soll, deren Syntax durch die folgende Grammatik-Regel gegeben ist:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -131,13 +131,13 @@ $\textsl{statement} \rightarrow \quoted{do} \textsl{statement} \quoted{while}
  \quoted{(} \textsl{boolExpr} \quoted{)}$.
 \\[0.2cm]
 Die Semantik dieses Konstruktes soll mit der Semantik des entsprechenden Konstruktes in
-der Sprache \texttt{C} übereinstimmen.
+der Sprache \texttt{C} \"ubereinstimmen.
 \begin{enumerate}
 \item Geben Sie eine Gleichung an, die beschreibt, wie eine \texttt{do-while}-Schleife in
-      \textsl{Java-Byte-Code} übersetzt werden kann.
+      \textsl{Java-Byte-Code} \"ubersetzt werden kann.
 \item Geben Sie die Methode $\textsl{compile}()$ an, die das entsprechende
-      Konstrukt übersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
-      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse für \textsc{Ep}
+      Konstrukt \"ubersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
+      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse f\"ur \textsc{Ep}
       wie folgt spezifiziert ist:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -153,7 +153,7 @@ Zeigen Sie, dass die wie folgt definierte Menge $M$
 \hspace*{1.3cm}
 $M := \{ x \in \mathbb{R} \mid 0 \leq x \leq 1 \}$
 \\[0.2cm] 
-nicht abzählbar ist.
+nicht abz\"ahlbar ist.
 
 \noindent
 \textbf{Hinweis}: Nehmen Sie an, dass Sie eine Funktion
@@ -161,12 +161,12 @@ nicht abzählbar ist.
 \hspace*{1.3cm}
 $f: \mathbb{N} \rightarrow M$
 \\[0.2cm]
-gibt, so dass es für jedes $x \in M$ eine Zahl $n \in \mathbb{N}$ gibt, für die
-$x = f(n)$ ist.  Führen Sie diese Annahme zum Widerspruch, indem Sie eine Zahl 
-$\gamma \in M$ konstruieren, für die 
+gibt, so dass es f\"ur jedes $x \in M$ eine Zahl $n \in \mathbb{N}$ gibt, f\"ur die
+$x = f(n)$ ist.  F\"uhren Sie diese Annahme zum Widerspruch, indem Sie eine Zahl 
+$\gamma \in M$ konstruieren, f\"ur die 
 \\[0.2cm]
 \hspace*{1.3cm}
-$f(n) \not= \gamma$ \quad für alle $n \in \mathbb{N}$
+$f(n) \not= \gamma$ \quad f\"ur alle $n \in \mathbb{N}$
 \\[0.2cm]
 gilt.  Zur Konstruktion von $\gamma$ ist es sinnvoll die Hilfsfunktion
 \\[0.2cm]
@@ -183,13 +183,13 @@ $\textsl{digit}(0.125, 2) = 2$, \quad
 $\textsl{digit}(0.125, 3) = 5$, \quad und 
 \\[0.2cm]
 \hspace*{1.3cm}
-$\textsl{digit}(0.125, k) = 0$, \quad für alle $k > 3$.
+$\textsl{digit}(0.125, k) = 0$, \quad f\"ur alle $k > 3$.
 \pagebreak
 
 \noindent
 \framebox{\epsfig{file=danger.eps,scale=0.05}}
 \exercise
-Aus wieviel Zeichen muss der kleinste Ausdruck $e$ mindestens bestehen, für den
+Aus wieviel Zeichen muss der kleinste Ausdruck $e$ mindestens bestehen, f\"ur den
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{ershov}(e) = 30$

--- a/Probe-Klausur/Sommer/aufgabe-2010.tex
+++ b/Probe-Klausur/Sommer/aufgabe-2010.tex
@@ -26,19 +26,19 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 
 
 \begin{document}
 
 
 \noindent
-{\large  Aufgaben zur Klausurvorbereitung für die Vorlesung ``{\sl Compilerbau}''}
+{\large  Aufgaben zur Klausurvorbereitung f\"ur die Vorlesung ``{\sl Compilerbau}''}
 \vspace{0.5cm}
 
 \noindent
-\textbf{Hinweis}: Bei der Klausur müssen alle Aufgabenbläter mit abgegeben werden, sonst
-ist die Klausur ungültig!
+\textbf{Hinweis}: Bei der Klausur m\"ussen alle Aufgabenbl\"ater mit abgegeben werden, sonst
+ist die Klausur ung\"ultig!
 \vspace{0.5cm}
 
 \exercise
@@ -53,9 +53,9 @@ habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \mathtt{+} \mid S\, S\, \mathtt{-} \mid \mathtt{a}. \]
 \begin{enumerate}
 \item Berechnen Sie die Mengen $\textsl{First}(S)$ und $\textsl{Follow}(S)$.
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
-\item Berechnen Sie die Menge der LR-Zustände für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
+\item Berechnen Sie die Menge der LR-Zust\"ande f\"ur diese Grammatik.
 \item Untersuchen Sie, ob diese Grammatik mehrdeutig ist.
 \end{enumerate}
 
@@ -75,30 +75,30 @@ $
 \\[0.2cm]
 Bearbeiten Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Überprüfen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
 \end{enumerate}
 \pagebreak
 
 \exercise
 Wir definieren \emph{geschachtelte Listen} rekursiv als solche Listen, 
-deren Elemente natürliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
+deren Elemente nat\"urliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
 geschachtelten Listen sollen durch Kommata getrennt werden und die Listen selber sollen
 durch die eckigen Klammern ``\texttt{[}'' und ``\texttt{]}'' begrenzt sein.
-Beispiele für geschachtelte Listen sind also:
+Beispiele f\"ur geschachtelte Listen sind also:
 \begin{enumerate}
 \item \texttt{[ 1, [ 1, [], [ 2, 3]], 7]}
 \item \texttt{[ [], [ [], [], [ 4], 5], []]}
 \end{enumerate}
-Lösen Sie die folgenden Teilaufgaben:
+L\"osen Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Geben Sie eine Grammatik für geschachtelte Listen an.
+\item Geben Sie eine Grammatik f\"ur geschachtelte Listen an.
 \item Definieren Sie geeignete Klassen, mit deren Hilfe Sie geschachtelte Listen 
-      repräsentieren können.
+      repr\"asentieren k\"onnen.
 \item Geben Sie einen \textsc{Antlr}-Parser an, der eine geschachtelte Liste einliest
       und einen abstrakten Syntax-Baum der Liste berechnet.
 \item Geben Sie einen \textsl{JavaCup}-Parser an, der eine geschachtelte Liste einliest
@@ -123,11 +123,11 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{typeEqs}\bigl(\texttt{addLast(cons(x, nil), z): list(int)}\bigr)$.
-\item Lösen Sie die in Teil (a) berechneten Typ-Gleichungen.
+\item L\"osen Sie die in Teil (a) berechneten Typ-Gleichungen.
 \end{enumerate}
 
 \exercise
-Nehmen Sie an, dass die im Skript eingeführte Sprache \textsl{Integer}-\texttt{C} um eine 
+Nehmen Sie an, dass die im Skript eingef\"uhrte Sprache \textsl{Integer}-\texttt{C} um eine 
 \texttt{do-while}-Schleife erweitert werden soll, deren Syntax durch die folgende Grammatik-Regel gegeben ist:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -135,13 +135,13 @@ $\textsl{statement} \rightarrow \quoted{do} \textsl{statement} \quoted{while}
  \quoted{(} \textsl{boolExpr} \quoted{)}$.
 \\[0.2cm]
 Die Semantik dieses Konstruktes soll mit der Semantik des entsprechenden Konstruktes in
-der Sprache \texttt{C} übereinstimmen.
+der Sprache \texttt{C} \"ubereinstimmen.
 \begin{enumerate}
 \item Geben Sie eine Gleichung an, die beschreibt, wie eine \texttt{do-while}-Schleife in
-      \textsl{Java-Byte-Code} übersetzt werden kann.
+      \textsl{Java-Byte-Code} \"ubersetzt werden kann.
 \item Geben Sie die Methode $\textsl{compile}()$ an, die das entsprechende
-      Konstrukt übersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
-      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse für \textsc{Ep}
+      Konstrukt \"ubersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
+      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse f\"ur \textsc{Ep}
       wie folgt spezifiziert ist:
       \\[0.2cm]
       \hspace*{1.3cm}

--- a/Probe-Klausur/Sommer/aufgabe-2011.tex
+++ b/Probe-Klausur/Sommer/aufgabe-2011.tex
@@ -26,19 +26,19 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 
 
 \begin{document}
 
 
 \noindent
-{\large  Aufgaben zur Klausurvorbereitung für die Vorlesung ``{\sl Compilerbau}''}
+{\large  Aufgaben zur Klausurvorbereitung f\"ur die Vorlesung ``{\sl Compilerbau}''}
 \vspace{0.5cm}
 
 \noindent
-\textbf{Hinweis}: Bei der Klausur müssen alle Aufgabenbläter mit abgegeben werden, sonst
-ist die Klausur ungültig!
+\textbf{Hinweis}: Bei der Klausur m\"ussen alle Aufgabenbl\"ater mit abgegeben werden, sonst
+ist die Klausur ung\"ultig!
 \vspace{0.5cm}
 
 \exercise
@@ -53,9 +53,9 @@ habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \mathtt{+} \mid S\, S\, \mathtt{-} \mid \mathtt{a}. \]
 \begin{enumerate}
 \item Berechnen Sie die Mengen $\textsl{First}(S)$ und $\textsl{Follow}(S)$.
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
-\item Berechnen Sie die Menge der LR-Zustände für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
+\item Berechnen Sie die Menge der LR-Zust\"ande f\"ur diese Grammatik.
 \item Untersuchen Sie, ob diese Grammatik mehrdeutig ist.
 \end{enumerate}
 
@@ -75,30 +75,30 @@ $
 \\[0.2cm]
 Bearbeiten Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Überprüfen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
 \end{enumerate}
 \pagebreak
 
 \exercise
 Wir definieren \emph{geschachtelte Listen} rekursiv als solche Listen, 
-deren Elemente natürliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
+deren Elemente nat\"urliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
 geschachtelten Listen sollen durch Kommata getrennt werden und die Listen selber sollen
 durch die eckigen Klammern ``\texttt{[}'' und ``\texttt{]}'' begrenzt sein.
-Beispiele für geschachtelte Listen sind also:
+Beispiele f\"ur geschachtelte Listen sind also:
 \begin{enumerate}
 \item \texttt{[ 1, [ 1, [], [ 2, 3]], 7]}
 \item \texttt{[ [], [ [], [], [ 4], 5], []]}
 \end{enumerate}
-Lösen Sie die folgenden Teilaufgaben:
+L\"osen Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Geben Sie eine Grammatik für geschachtelte Listen an.
+\item Geben Sie eine Grammatik f\"ur geschachtelte Listen an.
 \item Definieren Sie geeignete Klassen, mit deren Hilfe Sie geschachtelte Listen 
-      repräsentieren können.
+      repr\"asentieren k\"onnen.
 \item Geben Sie einen \textsl{JavaCup}-Parser an, der eine geschachtelte Liste einliest
       und einen abstrakten Syntax-Baum der Liste berechnet.
 \end{enumerate}
@@ -121,11 +121,11 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{typeEqs}\bigl(\texttt{addLast(cons(x, nil), z): list(int)}\bigr)$.
-\item Lösen Sie die in Teil (a) berechneten Typ-Gleichungen.
+\item L\"osen Sie die in Teil (a) berechneten Typ-Gleichungen.
 \end{enumerate}
 
 \exercise
-Nehmen Sie an, dass die im Skript eingeführte Sprache \textsl{Integer}-\texttt{C} um eine 
+Nehmen Sie an, dass die im Skript eingef\"uhrte Sprache \textsl{Integer}-\texttt{C} um eine 
 \texttt{do-while}-Schleife erweitert werden soll, deren Syntax durch die folgende Grammatik-Regel gegeben ist:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -133,13 +133,13 @@ $\textsl{statement} \rightarrow \quoted{do}\; \textsl{statement}\; \quoted{while
  \quoted{(} \;\textsl{boolExpr} \;\quoted{)}$.
 \\[0.2cm]
 Die Semantik dieses Konstruktes soll mit der Semantik des entsprechenden Konstruktes in
-der Sprache \texttt{C} übereinstimmen.
+der Sprache \texttt{C} \"ubereinstimmen.
 \begin{enumerate}
 \item Geben Sie eine Gleichung an, die beschreibt, wie eine \texttt{do-while}-Schleife in
-      \textsl{Java-Byte-Code} übersetzt werden kann.
+      \textsl{Java-Byte-Code} \"ubersetzt werden kann.
 \item Geben Sie die Methode $\textsl{compile}()$ an, die das entsprechende
-      Konstrukt übersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
-      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse für \textsc{Ep}
+      Konstrukt \"ubersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
+      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse f\"ur \textsc{Ep}
       wie folgt spezifiziert ist:
       \\[0.2cm]
       \hspace*{1.3cm}

--- a/Probe-Klausur/Sommer/aufgabe-2012.tex
+++ b/Probe-Klausur/Sommer/aufgabe-2012.tex
@@ -26,19 +26,19 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 
 
 \begin{document}
 
 
 \noindent
-{\large  Aufgaben zur Klausurvorbereitung für die Vorlesung ``{\sl Compilerbau}''}
+{\large  Aufgaben zur Klausurvorbereitung f\"ur die Vorlesung ``{\sl Compilerbau}''}
 \vspace{0.5cm}
 
 \noindent
-\textbf{Hinweis}: Bei der Klausur müssen alle Aufgabenbläter mit abgegeben werden, sonst
-ist die Klausur ungültig!
+\textbf{Hinweis}: Bei der Klausur m\"ussen alle Aufgabenbl\"ater mit abgegeben werden, sonst
+ist die Klausur ung\"ultig!
 \vspace{0.5cm}
 
 \exercise
@@ -53,9 +53,9 @@ habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \mathtt{+} \mid S\, S\, \mathtt{-} \mid \mathtt{a}. \]
 \begin{enumerate}
 \item Berechnen Sie die Mengen $\textsl{First}(S)$ und $\textsl{Follow}(S)$.
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
-\item Berechnen Sie die Menge der LR-Zustände für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
+\item Berechnen Sie die Menge der LR-Zust\"ande f\"ur diese Grammatik.
 \item Untersuchen Sie, ob diese Grammatik mehrdeutig ist.
 \end{enumerate}
 
@@ -75,37 +75,37 @@ $
 \\[0.2cm]
 Bearbeiten Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Überprüfen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
 \end{enumerate}
 \pagebreak
 
 \exercise
 Wir definieren \emph{geschachtelte Listen} rekursiv als solche Listen, 
-deren Elemente natürliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
+deren Elemente nat\"urliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
 geschachtelten Listen sollen durch Kommata getrennt werden und die Listen selber sollen
 durch die eckigen Klammern ``\texttt{[}'' und ``\texttt{]}'' begrenzt sein.
-Beispiele für geschachtelte Listen sind also:
+Beispiele f\"ur geschachtelte Listen sind also:
 \begin{enumerate}
 \item \texttt{[ 1, [ 1, [], [ 2, 3]], 7]}
 \item \texttt{[ [], [ [], [], [ 4], 5], []]}
 \end{enumerate}
-Lösen Sie die folgenden Teilaufgaben:
+L\"osen Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Geben Sie eine Grammatik für geschachtelte Listen an.
+\item Geben Sie eine Grammatik f\"ur geschachtelte Listen an.
 \item Definieren Sie geeignete Klassen, mit deren Hilfe Sie geschachtelte Listen 
-      repräsentieren können.
+      repr\"asentieren k\"onnen.
 \item Geben Sie einen \textsl{JavaCup}-Parser an, der eine geschachtelte Liste einliest
       und einen abstrakten Syntax-Baum der Liste berechnet.
 \end{enumerate}
 
 
 \exercise
-Nehmen Sie an, dass die im Skript eingeführte Sprache \textsl{Integer}-\texttt{C} um eine 
+Nehmen Sie an, dass die im Skript eingef\"uhrte Sprache \textsl{Integer}-\texttt{C} um eine 
 \texttt{do-while}-Schleife erweitert werden soll, deren Syntax durch die folgende Grammatik-Regel gegeben ist:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -113,13 +113,13 @@ $\textsl{statement} \rightarrow \quoted{do}\; \textsl{statement}\; \quoted{while
  \quoted{(} \;\textsl{boolExpr} \;\quoted{)}$.
 \\[0.2cm]
 Die Semantik dieses Konstruktes soll mit der Semantik des entsprechenden Konstruktes in
-der Sprache \texttt{C} übereinstimmen.
+der Sprache \texttt{C} \"ubereinstimmen.
 \begin{enumerate}
 \item Geben Sie eine Gleichung an, die beschreibt, wie eine \texttt{do-while}-Schleife in
-      \textsl{Java-Byte-Code} übersetzt werden kann.
+      \textsl{Java-Byte-Code} \"ubersetzt werden kann.
 \item Geben Sie die Methode $\textsl{compile}()$ an, die das entsprechende
-      Konstrukt übersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
-      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse für \textsc{Ep}
+      Konstrukt \"ubersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
+      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse f\"ur \textsc{Ep}
       wie folgt spezifiziert ist:
       \\[0.2cm]
       \hspace*{1.3cm}

--- a/Probe-Klausur/Sommer/aufgabe-sommer-2008.tex
+++ b/Probe-Klausur/Sommer/aufgabe-sommer-2008.tex
@@ -24,18 +24,18 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 
 \begin{document}
 
 
 \noindent
-{\large  Aufgaben zur Klausurvorbereitung für die Vorlesung ``{\sl Compilerbau}''}
+{\large  Aufgaben zur Klausurvorbereitung f\"ur die Vorlesung ``{\sl Compilerbau}''}
 \vspace{0.5cm}
 
 \noindent
-\textbf{Hinweis}: Bei der Klausur müssen alle Aufgabenbläter mit abgegeben werden, sonst
-ist die Klausur ungültig!
+\textbf{Hinweis}: Bei der Klausur m\"ussen alle Aufgabenbl\"ater mit abgegeben werden, sonst
+ist die Klausur ung\"ultig!
 \vspace{0.5cm}
 
 \exercise
@@ -43,19 +43,19 @@ Die Grammatik $G = \langle \{ S \}, \{ \mathtt{+}, \mathtt{*}, \mathtt{a} \}, R,
 habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \mathtt{+} \mid S\, S\, \mathtt{*} \mid \mathtt{a}. \]
 \begin{enumerate}
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
 \end{enumerate}
 
 \exercise
 Geben Sie ein \textsl{JFlex}-Datei an, mit deren Hilfe Sie alle Hexadezimal-Zahlen, die in
-einer Datei vorkommen, aufaddieren können.  Die Hexadezimal-Zahlen sollen dabei in der Form
+einer Datei vorkommen, aufaddieren k\"onnen.  Die Hexadezimal-Zahlen sollen dabei in der Form
 \[ \mathtt{0xAB123} \]
 dargestellt werden.
 
 \exercise
-Geben Sie die \textsc{Cup}-Spezifikation eines Parsers an, der Boole'sche Ausdrücke
-auswertet.  Die Boole'schen Ausdrücke sollen mit Hilfe der Operatoren ``\texttt{\&}''
+Geben Sie die \textsc{Cup}-Spezifikation eines Parsers an, der Boole'sche Ausdr\"ucke
+auswertet.  Die Boole'schen Ausdr\"ucke sollen mit Hilfe der Operatoren ``\texttt{\&}''
 (logisches und), ``\texttt{|}'' (logisches oder) und ``\texttt{!}'' (logisches nicht) aus
 den Terminalen ``\texttt{true}'' und ``\texttt{false}'' aufgebaut sein. 
 
@@ -76,7 +76,7 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{typeEqs}\bigl(\texttt{addLast(cons(x, nil), z): list(int)}\bigr)$.
-\item Lösen Sie die in Teil (a) berechneten Typ-Gleichungen.
+\item L\"osen Sie die in Teil (a) berechneten Typ-Gleichungen.
 \end{enumerate}
 
 
@@ -84,9 +84,9 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
 \framebox{\epsfig{file=beichel.eps,scale=0.1}}
 Das Alphabet $\Sigma$ werde durch
 \[ \Sigma = \{ \texttt{a}, \texttt{b}, \texttt{c} \} \]
-definiert und auf $\Sigma^*$ werden nachfolgend verschiedene Sprachen definiert, für die Sie jeweils 
+definiert und auf $\Sigma^*$ werden nachfolgend verschiedene Sprachen definiert, f\"ur die Sie jeweils 
 angeben sollen, ob es sich um eine kontextfreie Sprache handelt oder nicht.  Falls es sich
-um eine kontextfreie Sprache handelt, müssen Sie eine Grammatik angeben, die diese Sprache
+um eine kontextfreie Sprache handelt, m\"ussen Sie eine Grammatik angeben, die diese Sprache
 erzeugt, andernfalls sollen Sie mit Hilfe des Pumping-Lemmas nachweisen, dass
 die Sprache nicht kontextfrei ist.
 \begin{enumerate}

--- a/Probe-Klausur/Sommer/loesung-2011.tex
+++ b/Probe-Klausur/Sommer/loesung-2011.tex
@@ -28,7 +28,7 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 \newcommand{\quoted}[1]{\mbox{``\texttt{#1}''}}
 \def\pair(#1,#2){\langle #1, #2 \rangle}
 
@@ -37,7 +37,7 @@
 
 
 \noindent
-{\large  Lösungen zu den Aufgaben zur Klausurvorbereitung}
+{\large  L\"osungen zu den Aufgaben zur Klausurvorbereitung}
 \vspace{0.5cm}
 
 \exercise
@@ -128,7 +128,7 @@ Der Earley-Algorithmus berechnet die folgenden Mengen:
       $
 
       Da dieser Zustand das Earley-Item $\pair(\widehat{S} \rightarrow  E\;\bullet, 0)$
-      enthält, liegt der String $s$ in der von der Grammatik $G$ erzeugten Sprache.
+      enth\"alt, liegt der String $s$ in der von der Grammatik $G$ erzeugten Sprache.
       
 \end{enumerate}
 
@@ -138,9 +138,9 @@ habe  die folgenden Regeln:
 \[ E \rightarrow E\, E\, \quoted{+} \mid E\, E\, \quoted{-} \mid \quoted{a}. \]
 \begin{enumerate}
 \item Berechnen Sie die Mengen $\textsl{First}(E)$ und $\textsl{Follow}(E)$.
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
-\item Berechnen Sie die Menge der LR-Zustände für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
+\item Berechnen Sie die Menge der LR-Zust\"ande f\"ur diese Grammatik.
 \item Untersuchen Sie, ob diese Grammatik mehrdeutig ist.
 \end{enumerate}
 
@@ -154,7 +154,7 @@ habe  die folgenden Regeln:
 
       Bemerkung: Das Zeichen ``$\symbol{36}$'' liegt in der Menge $\textsl{Follow}(E)$, weil 
       $E$ das Start-Symbol der Grammatik ist.
-\item Wir erhalten die folgenden Zustände:
+\item Wir erhalten die folgenden Zust\"ande:
       \begin{enumerate}
       \item Wir definieren $s_0 = \textsl{closure}\bigl(\{\widehat{S} \rightarrow \star E\}\bigr)$ und 
             finden
@@ -207,7 +207,7 @@ habe  die folgenden Regeln:
             \\[0.2cm]
             \hspace*{1.3cm}
             $s_5 = \{ E \rightarrow E \, E \quoted{-} \bullet \}$.
-      \item Als nächstes berechnen wir: 
+      \item Als n\"achstes berechnen wir: 
         \begin{enumerate}
         \item $\textsl{goto}(s_0, \quoted{a}) = s_3$.
         \item $\textsl{goto}(s_1, \quoted{a}) = s_3$.
@@ -216,10 +216,10 @@ habe  die folgenden Regeln:
             
 
             Damit haben wir nun alle interessanten Werte der Funktion $\textsl{goto}()$ berechnet,
-            denn für alle bisher nicht explizit angegebenen Werte liefert diese Funktion die leere Menge.
+            denn f\"ur alle bisher nicht explizit angegebenen Werte liefert diese Funktion die leere Menge.
       \end{enumerate}
 
-\item Damit erhalten wir für die Funktion $\textsl{action}()$ die folgende Tabelle:
+\item Damit erhalten wir f\"ur die Funktion $\textsl{action}()$ die folgende Tabelle:
       \begin{enumerate}
       \item $\textsl{action}(s_0, \quoted{a}) = \pair(\texttt{shift}, s_3)$
       \item $\textsl{action}(s_1, \quoted{\symbol{36}}) = \mathtt{accept}$
@@ -240,14 +240,14 @@ habe  die folgenden Regeln:
       \item $\textsl{action}(s_5, \quoted{-}) = \pair(\texttt{reduce}, E \rightarrow E\, E \quoted{-})$
       \item $\textsl{action}(s_5, \quoted{a}) = \pair(\texttt{reduce}, E \rightarrow E\, E \quoted{-})$
       \end{enumerate}
-      Für die Funktion $\textsl{goto}()$ finden wir:
+      F\"ur die Funktion $\textsl{goto}()$ finden wir:
       \begin{enumerate}
       \item $\textsl{goto}(s_0, E) = s_1$
       \item $\textsl{goto}(s_1, E) = s_2$
       \item $\textsl{goto}(s_2, E) = s_2$
       \end{enumerate}
 
-\item Wir erhalten die folgenden Zustände:
+\item Wir erhalten die folgenden Zust\"ande:
       \begin{enumerate}
       \item Wir setzen wieder 
             $s_0 = \textsl{closure}\Bigl(\bigl\{\widehat{S} \rightarrow \bullet E: \symbol{36}\bigr\}\Bigr)$ 
@@ -308,7 +308,7 @@ habe  die folgenden Regeln:
              \end{array}
              $
 
-             Beachten Sie, dass $s_2 \not= s_3$ ist, denn die Menge der Folge-Token sind für die markierten
+             Beachten Sie, dass $s_2 \not= s_3$ ist, denn die Menge der Folge-Token sind f\"ur die markierten
              Regeln $ E \rightarrow E\; E \bullet \quoted{+}$ und $ E \rightarrow E\; E \bullet \quoted{-}$ 
              in den Mengen $s_2$ und $s_3$ unterschiedlich.
        \item Wir definieren $s_4 = \textsl{goto}(s_0, \quoted{a})$ und erhalten
@@ -357,11 +357,11 @@ $
 \\[0.2cm]
 Bearbeiten Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Überprüfen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
 \end{enumerate}
 
@@ -384,8 +384,8 @@ Bearbeiten Sie die folgenden Teilaufgaben:
       \hspace*{1.3cm}
       $\textsl{First}(\quoted{y} B \quoted{z}) \cap \textsl{First}(\quoted{y} \quoted{u} \quoted{z}) = 
       \{ \quoted{y} \} \not= \{\}$.
-\item Um zu überprüfen, ob die Grammatik eine LL($*$)-Grammatik ist, ersetzen wir zunächst die Variable $B$ 
-      durch ihre Definition.  Für $A$ erhalten wir dann die folgenden Grammatik-Regeln:
+\item Um zu \"uberpr\"ufen, ob die Grammatik eine LL($*$)-Grammatik ist, ersetzen wir zun\"achst die Variable $B$ 
+      durch ihre Definition.  F\"ur $A$ erhalten wir dann die folgenden Grammatik-Regeln:
       \\[0.2cm]
       \hspace*{1.3cm}
       $\begin{array}[t]{lcl}
@@ -397,7 +397,7 @@ Bearbeiten Sie die folgenden Teilaufgaben:
        $
       \\[0.2cm]
       Basteln wir daraus nun, wie im Skript beschrieben, einen endlichen Automaten, so ist leicht zu
-      sehen, dass die akzeptierenden Zustände homogen sind.  Damit handelt es sich bei der
+      sehen, dass die akzeptierenden Zust\"ande homogen sind.  Damit handelt es sich bei der
       angegebenen Grammatik um eine $LL(*)$-Grammatik.
 \item Die angegebene Grammatik ist keine SLR-Grammatik.  Um das zu sehen, erweitern wir die Grammatik
       um die Regel $\widehat{S} \rightarrow A$ und berechnen den Zustand
@@ -436,7 +436,7 @@ Bearbeiten Sie die folgenden Teilaufgaben:
 
       \noindent
       \textbf{Bemerkung}:  Die in der Aufgabe angegebene Grammatik ist sowohl eine LR-Grammatik als
-      auch eine LALR-Grammatik.  Letzteres lässt sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
+      auch eine LALR-Grammatik.  Letzteres l\"asst sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
       und Ersteres folgt aus der Tatsache, dass jede LALR-Grammatik auch eine LR-Grammatik ist.
 \end{enumerate}
 
@@ -458,12 +458,12 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{typeEqs}\bigl(\texttt{addLast(cons(x, nil), z): list(int)}\bigr)$.
-\item Lösen Sie die in Teil (a) berechneten Typ-Gleichungen.
+\item L\"osen Sie die in Teil (a) berechneten Typ-Gleichungen.
 \end{enumerate}
 
 \solution
 \begin{enumerate}
-\item Wir berechnen zunächst die Typ-Gleichungen nach der im Skript angegebenen Definition.
+\item Wir berechnen zun\"achst die Typ-Gleichungen nach der im Skript angegebenen Definition.
       \[
       \begin{array}[t]{cl}
            & \textsl{typeEqs}(\texttt{addLast(cons(x, nil), z): list(int)}) \\[0.2cm]
@@ -482,7 +482,7 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
 
       \end{array}
       \]
-\item Wir lösen die oben berechneten Typ-Gleichungen nach dem im Skript angegebenen Verfahren.
+\item Wir l\"osen die oben berechneten Typ-Gleichungen nach dem im Skript angegebenen Verfahren.
       \\[0.2cm]
       \hspace*{-0.3cm}  
       $\begin{array}[t]{cl}
@@ -527,13 +527,13 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       Damit ist die Substitution 
       $[ T \mapsto \mathtt{int},\; S \mapsto \mathtt{int},\; R \mapsto \mathtt{int}]$ eine 
-      Lösung der Typ-Gleichungen und wir können folgern, dass der Term tatsächlich den angegebenen Typ
+      L\"osung der Typ-Gleichungen und wir k\"onnen folgern, dass der Term tats\"achlich den angegebenen Typ
       hat.
 \end{enumerate}
 \pagebreak
 
 \exercise
-Nehmen Sie an, dass die im Skript eingeführte Sprache \textsl{Integer}-\texttt{C} um eine 
+Nehmen Sie an, dass die im Skript eingef\"uhrte Sprache \textsl{Integer}-\texttt{C} um eine 
 \texttt{do-while}-Schleife erweitert werden soll, deren Syntax durch die folgende Grammatik-Regel gegeben ist:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -541,13 +541,13 @@ $\textsl{statement} \rightarrow \quoted{do}\; \textsl{statement}\; \quoted{while
  \quoted{(} \;\textsl{boolExpr} \;\quoted{)}$.
 \\[0.2cm]
 Die Semantik dieses Konstruktes soll mit der Semantik des entsprechenden Konstruktes in
-der Sprache \texttt{C} übereinstimmen.
+der Sprache \texttt{C} \"ubereinstimmen.
 \begin{enumerate}
 \item Geben Sie eine Gleichung an, die beschreibt, wie eine \texttt{do-while}-Schleife in
-      \textsl{Java-Byte-Code} übersetzt werden kann.
+      \textsl{Java-Byte-Code} \"ubersetzt werden kann.
 \item Geben Sie die Methode $\textsl{compile}()$ an, die das entsprechende
-      Konstrukt übersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
-      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse für \textsc{Ep}
+      Konstrukt \"ubersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
+      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse f\"ur \textsc{Ep}
       wie folgt spezifiziert ist:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -557,7 +557,7 @@ der Sprache \texttt{C} übereinstimmen.
 
 \solution
 \begin{enumerate}
-\item Die Übersetzung einer \texttt{do-while}-Schleife der Form
+\item Die \"Ubersetzung einer \texttt{do-while}-Schleife der Form
       \[ \textsl{do}\; \textsl{statement}\; \texttt{while}\;(\textsl{cond})\; \quoted{;} \]
       orientiert sich an der folgenden Spezifikation:
       \[

--- a/Probe-Klausur/Sommer/loesung-sommer-2008.tex
+++ b/Probe-Klausur/Sommer/loesung-sommer-2008.tex
@@ -24,18 +24,18 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 
 \begin{document}
 
 
 \noindent
-{\large  Lösungen zu den Aufgaben zur Klausurvorbereitung ``{\sl Compilerbau}''}
+{\large  L\"osungen zu den Aufgaben zur Klausurvorbereitung ``{\sl Compilerbau}''}
 \vspace{0.5cm}
 
 \noindent
-\textbf{Hinweis}: Bei der Klausur müssen alle Aufgabenbläter mit abgegeben werden, sonst
-ist die Klausur ungültig!
+\textbf{Hinweis}: Bei der Klausur m\"ussen alle Aufgabenbl\"ater mit abgegeben werden, sonst
+ist die Klausur ung\"ultig!
 \vspace{0.5cm}
 
 \exercise
@@ -43,19 +43,19 @@ Die Grammatik $G = \langle \{ S \}, \{ \mathtt{+}, \mathtt{*}, \mathtt{a} \}, R,
 habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \mathtt{+} \mid S\, S\, \mathtt{*} \mid \mathtt{a}. \]
 \begin{enumerate}
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
 \end{enumerate}
 
 \exercise
 Geben Sie ein \textsl{JFlex}-Datei an, mit deren Hilfe Sie alle Hexadezimal-Zahlen, die in
-einer Datei vorkommen, aufaddieren können.  Die Hexadezimal-Zahlen sollen dabei in der Form
+einer Datei vorkommen, aufaddieren k\"onnen.  Die Hexadezimal-Zahlen sollen dabei in der Form
 \[ \mathtt{0xAB123} \]
 dargestellt werden.
 
 \exercise
-Geben Sie die \textsc{Cup}-Spezifikation eines Parsers an, der Boole'sche Ausdrücke
-auswertet.  Die Boole'schen Ausdrücke sollen mit Hilfe der Operatoren ``\texttt{\&}''
+Geben Sie die \textsc{Cup}-Spezifikation eines Parsers an, der Boole'sche Ausdr\"ucke
+auswertet.  Die Boole'schen Ausdr\"ucke sollen mit Hilfe der Operatoren ``\texttt{\&}''
 (logisches und), ``\texttt{|}'' (logisches oder) und ``\texttt{!}'' (logisches nicht) aus
 den Terminalen ``\texttt{true}'' und ``\texttt{false}'' aufgebaut sein. 
 \pagebreak
@@ -77,12 +77,12 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{typeEqs}\bigl(\texttt{addLast(cons(x, nil), z): list(int)}\bigr)$.
-\item Lösen Sie die in Teil (a) berechneten Typ-Gleichungen.
+\item L\"osen Sie die in Teil (a) berechneten Typ-Gleichungen.
 \end{enumerate}
 
 \solution
 \begin{enumerate}
-\item Wir berechnen zunächst die Typ-Gleichungen nach der im Skript angegebenen Definition.
+\item Wir berechnen zun\"achst die Typ-Gleichungen nach der im Skript angegebenen Definition.
       \[
       \begin{array}[t]{cl}
            & \textsl{typeEqs}(\texttt{addLast(cons(x, nil), z): list(int)}) \\[0.2cm]
@@ -101,7 +101,7 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
 
       \end{array}
       \]
-\item Wir lösen die oben berechneten Typ-Gleichungen nach dem im Skript angegebenen Verfahren.
+\item Wir l\"osen die oben berechneten Typ-Gleichungen nach dem im Skript angegebenen Verfahren.
       \\[0.2cm]
       \hspace*{-0.3cm}  
       $\begin{array}[t]{cl}
@@ -146,7 +146,7 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       Damit ist die Substitution 
       $[ T \mapsto \mathtt{int},\; S \mapsto \mathtt{int},\; R \mapsto \mathtt{int}]$ eine 
-      Lösung der Typ-Gleichungen und wir können folgern, dass der Term tatsächlich den angegebenen Typ
+      L\"osung der Typ-Gleichungen und wir k\"onnen folgern, dass der Term tats\"achlich den angegebenen Typ
       hat.
       \qed
 \end{enumerate}
@@ -155,9 +155,9 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
 \exercise
 Das Alphabet $\Sigma$ werde durch
 \[ \Sigma = \{ \texttt{a}, \texttt{b}, \texttt{c} \} \]
-definiert und auf $\Sigma^*$ werden nachfolgend verschiedene Sprachen definiert, für die Sie jeweils 
+definiert und auf $\Sigma^*$ werden nachfolgend verschiedene Sprachen definiert, f\"ur die Sie jeweils 
 angeben sollen, ob es sich um eine kontextfreie Sprache handelt oder nicht.  Falls es sich
-um eine kontextfreie Sprache handelt, müssen Sie eine Grammatik angeben, die diese Sprache
+um eine kontextfreie Sprache handelt, m\"ussen Sie eine Grammatik angeben, die diese Sprache
 erzeugt und diese Behauptung beweisen.
 Andernfalls sollen Sie mit Hilfe des Pumping-Lemmas nachweisen, dass
 die Sprache nicht kontextfrei ist.
@@ -176,7 +176,7 @@ die Sprache nicht kontextfrei ist.
         B & \rightarrow & \texttt{b} B \texttt{c} \\
           & \mid        & \varepsilon 
       \end{eqnarray*}
-      Wir zeigen zunächst durch Induktion über $n$, dass aus
+      Wir zeigen zun\"achst durch Induktion \"uber $n$, dass aus
       \[ B \Rightarrow^n w \]
       folgt, dass $w$ die Form $w = \texttt{b}^{n-1} \texttt{c}^{n-1}$ haben muss.
       \begin{enumerate}
@@ -202,7 +202,7 @@ die Sprache nicht kontextfrei ist.
                    \[ L(B) \subseteq \{ \texttt{b}^{n} \texttt{c}^{n} \mid n \in \mathbb{N} \} \]
                    gilt.
       \end{enumerate}
-      Wir zeigen nun durch Induktion nach der Länge der Herleitung, dass aus
+      Wir zeigen nun durch Induktion nach der L\"ange der Herleitung, dass aus
       \[ S \Rightarrow^* w \]
       folgt, dass $w \in L_1$ ist.
       \begin{enumerate}
@@ -223,12 +223,12 @@ die Sprache nicht kontextfrei ist.
             \[ w =  \texttt{a}^{m+1} \texttt{b}^{n} \texttt{c}^{m+n+1} \] 
             und folglich gilt auch in diesem Fall $w \in L_1$.
       \end{enumerate}
-      Zum Schluss muss noch gezeigt werden, dass alle Wörter aus 
-      $L_1$ tatsächlich von der oben angegebenen Grammatik erzeugt werden.  Das ist aber offensichtlich,
-      denn das Wort $\texttt{a}^{m} \texttt{b}^{n} \texttt{c}^{m+n}$ lässt sich dadurch erzeugen,
-      dass zunächst $m$ mal die Regel $S \rightarrow \texttt{a} S \texttt{c}$ verwendet wird.
+      Zum Schluss muss noch gezeigt werden, dass alle W\"orter aus 
+      $L_1$ tats\"achlich von der oben angegebenen Grammatik erzeugt werden.  Das ist aber offensichtlich,
+      denn das Wort $\texttt{a}^{m} \texttt{b}^{n} \texttt{c}^{m+n}$ l\"asst sich dadurch erzeugen,
+      dass zun\"achst $m$ mal die Regel $S \rightarrow \texttt{a} S \texttt{c}$ verwendet wird.
       Darauf folgt eine Anwendung der Regel $S \rightarrow B$ und
-      anschließend folgen $n$ Anwendungen der Regel $B \rightarrow \texttt{b} B \texttt{c}$ 
+      anschlie{\ss}end folgen $n$ Anwendungen der Regel $B \rightarrow \texttt{b} B \texttt{c}$ 
       und ganz zum Schluss wird noch die Regel $B \rightarrow \varepsilon$ angewendet. 
       \[
       \begin{array}[t]{lcl}
@@ -242,32 +242,32 @@ die Sprache nicht kontextfrei ist.
       \end{array}
       \]
       \qed
-\item Die Sprache $L_2$ ist nicht kontextfrei.  Wir führen den Beweis indirekt und nehmen an, dass
-      $L_2$ kontextfrei wäre.  Nach dem Pumping-Lemma existiert dann eine natürliche Zahl $n$, so dass
-      für alle $s \in L$, für die $|s| \geq n$ ist, eine Zerlegung $s = uvwxyz$ existiert, für die
-      außerdem folgendes gilt:
+\item Die Sprache $L_2$ ist nicht kontextfrei.  Wir f\"uhren den Beweis indirekt und nehmen an, dass
+      $L_2$ kontextfrei w\"are.  Nach dem Pumping-Lemma existiert dann eine nat\"urliche Zahl $n$, so dass
+      f\"ur alle $s \in L$, f\"ur die $|s| \geq n$ ist, eine Zerlegung $s = uvwxyz$ existiert, f\"ur die
+      au{\ss}erdem folgendes gilt:
       \begin{enumerate}
       \item $|vwx| \leq n$,
       \item $vx \not= \varepsilon$,
-      \item $uv^kwx^ky \in L$ für alle $k \in \mathbb{N}$.
+      \item $uv^kwx^ky \in L$ f\"ur alle $k \in \mathbb{N}$.
       \end{enumerate}
-      Wir können o.B.d.A. fordern, dass $n \geq 1$ gilt.
+      Wir k\"onnen o.B.d.A. fordern, dass $n \geq 1$ gilt.
       Wir betrachten nun den String
       \[ s = \texttt{a}^{2\cdot n} \texttt{b}^{2\cdot n} \texttt{c}^{4\cdot n^2}. \]
-      Offenbar gilt $s \in L_2$ und wegen $|s| = 2 \cdot n + 2 \cdot n + 4 \cdot n^2 > n$ erfüllt $s$ die
+      Offenbar gilt $s \in L_2$ und wegen $|s| = 2 \cdot n + 2 \cdot n + 4 \cdot n^2 > n$ erf\"ullt $s$ die
       Voraussetzung des Pumping-Lemmas.  Wir finden also eine Zerlegung
       \[ s = u v w x y \]
       mit den oben angegebenen Eigenschaften.  Wegen $|vwx| \leq n$ und 
       $| \texttt{b}^{2\cdot n} | = 2\cdot n > n$ kann der Teilstring $vwx$ den String $\texttt{b}^{2\cdot n}$ 
-      nicht vollständig überdecken.  Daher muss einer der beiden folgenden Fälle vorliegen:
+      nicht vollst\"andig \"uberdecken.  Daher muss einer der beiden folgenden F\"alle vorliegen:
       \[ vwx \leq \texttt{a}^{2\cdot n}\texttt{b}^{2\cdot n} \quad \mbox{oder} \quad
          vwx \leq \texttt{b}^{2\cdot n}\texttt{c}^{4\cdot n^2}.
       \]
-      Wir betrachten die beiden Fälle getrennt.
+      Wir betrachten die beiden F\"alle getrennt.
       \begin{enumerate}
       \item $vwx \leq \texttt{a}^{2\cdot n}\texttt{b}^{2\cdot n}$
 
-            In diesem Fall enthält der String $vwx$ den Buchstaben $\texttt{c}$ nicht.
+            In diesem Fall enth\"alt der String $vwx$ den Buchstaben $\texttt{c}$ nicht.
             Nach dem Pumping-Lemma gilt $uwy \in L$. Daher haben wir einerseits
             \[ \textsl{count}(uwy, \texttt{c}) =  \textsl{count}(uvwxy, \texttt{c}) = 4 \cdot n^2, \]
             Andererseits folgt aus $vx \not= \varepsilon$, dass 
@@ -282,23 +282,23 @@ die Sprache nicht kontextfrei ist.
             \[ \textsl{count}(uwy, \texttt{a}) \cdot \textsl{count}(uwy, \texttt{b}) < 
                (2 \cdot n) \cdot (2 \cdot n) = 4\cdot n^2 = \textsl{count}(uwy, \texttt{c})
             \]
-            und daraus würde im Widerspruch zum Pumping-Lemma $uwy \not\in L_2$ folgen.
+            und daraus w\"urde im Widerspruch zum Pumping-Lemma $uwy \not\in L_2$ folgen.
       \item $vwx \leq \texttt{b}^{2\cdot n}\texttt{c}^{4\cdot n^2}$.
           
-            In diesem Fall enthält der String $vwx$ den Buchstaben $\mathtt{a}$ nicht.
-            Wir können annehmen, dass der String $vwx$ den Buchstaben $\mathtt{c}$ enthält, denn
-            andernfalls würde $vwx \leq \texttt{a}^{2\cdot n}\texttt{b}^{2\cdot n}$ gelten und den Fall
+            In diesem Fall enth\"alt der String $vwx$ den Buchstaben $\mathtt{a}$ nicht.
+            Wir k\"onnen annehmen, dass der String $vwx$ den Buchstaben $\mathtt{c}$ enth\"alt, denn
+            andernfalls w\"urde $vwx \leq \texttt{a}^{2\cdot n}\texttt{b}^{2\cdot n}$ gelten und den Fall
             haben wir oben schon behandelt.  Da einerseits $|vy| \leq n$ und andererseits $|vx| > 0$ gilt,
             haben wir insgesamt die Ungleichungs-Kette
             \[ 4\cdot n^2 - n \leq \textsl{count}(uwy,\texttt{c}) < 4\cdot n^2. \]
-            Außerdem gilt $\textsl{count}(uwy,\texttt{a}) = \textsl{count}(s,\texttt{a}) = 2\cdot n$,
+            Au{\ss}erdem gilt $\textsl{count}(uwy,\texttt{a}) = \textsl{count}(s,\texttt{a}) = 2\cdot n$,
             denn $vx$ besteht ja nur aus den Buchstaben \texttt{b} und \texttt{c}.
             Wegen $\textsl{count}(uwy,\texttt{c}) < 4\cdot n^2$ muss dann
             \[ \textsl{count}(uwy,\texttt{b}) < 2\cdot n \]
-            gelten, denn sonst hätte das Produkt 
+            gelten, denn sonst h\"atte das Produkt 
             \[ \textsl{count}(uwy, \texttt{a}) \cdot \textsl{count}(uwy, \texttt{b}) \]
             ja den Wert $4\cdot n^2$
-            und  $uwy$ würde nicht in der Sprache $L_2$ liegen.  Also haben wir
+            und  $uwy$ w\"urde nicht in der Sprache $L_2$ liegen.  Also haben wir
             folgende Ungleichungs-Kette:
             \[ 
             \begin{array}[t]{lcl}

--- a/Probe-Klausur/Sommer/loesung-sommer-2009.tex
+++ b/Probe-Klausur/Sommer/loesung-sommer-2009.tex
@@ -27,7 +27,7 @@
 \vspace*{0.3cm}
 
 \noindent
-\textbf{Lösung}: }
+\textbf{L\"osung}: }
 \newcommand{\quoted}[1]{\;\mbox{``\texttt{#1}''}\;}
 
 
@@ -35,7 +35,7 @@
 
 
 \noindent
-{\large  Lösungen zu den Aufgaben zur Klausurvorbereitung}
+{\large  L\"osungen zu den Aufgaben zur Klausurvorbereitung}
 \vspace{0.5cm}
 
 \exercise
@@ -44,9 +44,9 @@ habe  die folgenden Regeln:
 \[ S \rightarrow S\, S\, \quoted{+} \mid S\, S\, \quoted{-} \mid \quoted{a}. \]
 \begin{enumerate}
 \item Berechnen Sie die Mengen $\textsl{First}(S)$ und $\textsl{Follow}(S)$.
-\item Berechnen Sie die Menge der SLR-Zustände für diese Grammatik.
-\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ für diese Grammatik.
-\item Berechnen Sie die Menge der LR-Zustände für diese Grammatik.
+\item Berechnen Sie die Menge der SLR-Zust\"ande f\"ur diese Grammatik.
+\item Berechnen Sie die Funktionen $\textsl{action}()$ und $\textsl{goto}()$ f\"ur diese Grammatik.
+\item Berechnen Sie die Menge der LR-Zust\"ande f\"ur diese Grammatik.
 \end{enumerate}
 
 \solution
@@ -56,7 +56,7 @@ habe  die folgenden Regeln:
       \hspace*{1.3cm}
       $\textsl{First}(S) = \{ a \}$ \quad und \quad
       $\textsl{Follow}(S) = \{ \quoted{+}, \quoted{-}, \quoted{a}, \symbol{36} \}$.
-\item Wir erhalten die folgenden Zustände:
+\item Wir erhalten die folgenden Zust\"ande:
       \begin{enumerate}
       \item Wir definieren $s_0 = \textsl{closure}\bigl(\{\widehat{S} \rightarrow \star S\}\bigr)$ und 
             finden
@@ -112,7 +112,7 @@ habe  die folgenden Regeln:
       \end{enumerate}
       \pagebreak
 
-\item Damit erhalten wir für die Funktion $\textsl{action}()$ die folgende Tabelle:
+\item Damit erhalten wir f\"ur die Funktion $\textsl{action}()$ die folgende Tabelle:
       \begin{enumerate}
       \item $\textsl{action}(s_0, \quoted{a}) = \pair(\texttt{shift}, s_3)$
       \item $\textsl{action}(s_1, \quoted{\symbol{36}}) = \mathtt{accept}$
@@ -133,13 +133,13 @@ habe  die folgenden Regeln:
       \item $\textsl{action}(s_5, \quoted{-}) = \pair(\texttt{reduce}, S \rightarrow S\, S \quoted{-})$
       \item $\textsl{action}(s_5, \quoted{a}) = \pair(\texttt{reduce}, S \rightarrow S\, S \quoted{-})$
       \end{enumerate}
-      Für die Funktion $\textsl{goto}()$ finden wir:
+      F\"ur die Funktion $\textsl{goto}()$ finden wir:
       \begin{enumerate}
       \item $\textsl{goto}(s_0, S) = s_1$
       \item $\textsl{goto}(s_1, S) = s_2$
       \item $\textsl{goto}(s_2, S) = s_2$
       \end{enumerate}
-\item Wir erhalten die folgenden Zustände:
+\item Wir erhalten die folgenden Zust\"ande:
       \begin{enumerate}
       \item Wir setzen wieder 
             $s_0 = \textsl{closure}\Bigl(\bigl\{\widehat{S} \rightarrow \star S: \symbol{36}\bigr\}\Bigr)$ 
@@ -243,11 +243,11 @@ $
 \\[0.2cm]
 Bearbeiten Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Überprüfen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL(1)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine LL($*$)-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
-\item Überprüfen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begründen Sie
+\item \"Uberpr\"ufen Sie, ob die  diese Grammatik eine SLR-Grammatik ist und begr\"unden Sie
       Ihre Antwort.
 \end{enumerate}
 
@@ -270,8 +270,8 @@ Bearbeiten Sie die folgenden Teilaufgaben:
       \hspace*{1.3cm}
       $\textsl{First}(\quoted{y} B \quoted{z}) \cap \textsl{First}(\quoted{y} \quoted{u} \quoted{z}) = 
       \{ \quoted{y} \} \not= \{\}$.
-\item Um zu überprüfen, ob die Grammatik eine LL($*$)-Grammatik ist, annotieren wir die Regeln
-      wie im Skript beschrieben mit Zuständen und erhalten die folgenden annotierten Regeln:
+\item Um zu \"uberpr\"ufen, ob die Grammatik eine LL($*$)-Grammatik ist, annotieren wir die Regeln
+      wie im Skript beschrieben mit Zust\"anden und erhalten die folgenden annotierten Regeln:
       \begin{enumerate}
       \item $A \rightarrow _{\pair(0,1)} B _{\pair(1,1)} \quoted{x} _{\pair(2,1)}$
       \item $A \rightarrow _{\pair(0,2)} \quoted{y} _{\pair(1,2)} B _{\pair(2,2)} \quoted{z} _{\pair(3,2)}$
@@ -280,11 +280,11 @@ Bearbeiten Sie die folgenden Teilaufgaben:
       \item $B \rightarrow _{\pair(5,0)} \quoted{u} _{\pair(6,0)}$ 
       \end{enumerate}
       Als Start-Zustand definieren wir den Zustand $\pair(0,0)$ und setzen
-      $\textsl{start}(B) = \pair(4,0)$ sowie $\textsl{end}(B) = \pair(7,0)$.  Die Zustands-Übergangs-Funktion des für
+      $\textsl{start}(B) = \pair(4,0)$ sowie $\textsl{end}(B) = \pair(7,0)$.  Die Zustands-\"Ubergangs-Funktion des f\"ur
       einen LL($*)$-Parser zu konstruierenden nicht-deterministischen Automaten ist dann
       wie folgt gegeben:
       \begin{enumerate}
-      \item Der Start-Zustand ist mit den Anfangs-Zuständen der einzelnen Regeln für $A$ verbunden,
+      \item Der Start-Zustand ist mit den Anfangs-Zust\"anden der einzelnen Regeln f\"ur $A$ verbunden,
             wir haben also
             \\[0.2cm]
             \hspace*{1.3cm} $\delta(\pair(0,0), \varepsilon) = \pair(0,1)$, \quad
@@ -292,13 +292,13 @@ Bearbeiten Sie die folgenden Teilaufgaben:
             \\[0.2cm]
             \hspace*{1.3cm} $\delta(\pair(0,0), \varepsilon) = \pair(0,3)$, \quad
                             $\delta(\pair(0,0), \varepsilon) = \pair(0,4)$.
-      \item Aus der Regel $A \rightarrow B \quoted{x}$ erhalten wir die Übergänge
+      \item Aus der Regel $A \rightarrow B \quoted{x}$ erhalten wir die \"Uberg\"ange
             \\[0.2cm]
             \hspace*{1.3cm}
             $\delta(\pair(0,1), \varepsilon) = \pair(4,0)$, \quad
             $\delta(\pair(7,0), \varepsilon) = \pair(1,1)$, \quad
             $\delta(\pair(1,1), \quoted{x}) = \pair(2,1)$.
-      \item Aus der Regel $A \rightarrow \quoted{y} B \quoted{z}$ erhalten wir die Übergänge
+      \item Aus der Regel $A \rightarrow \quoted{y} B \quoted{z}$ erhalten wir die \"Uberg\"ange
             \\[0.2cm]
             \hspace*{1.3cm}
             $\delta(\pair(0,2), \quoted{y}) = \pair(1,2)$, \quad
@@ -307,31 +307,31 @@ Bearbeiten Sie die folgenden Teilaufgaben:
             \hspace*{1.3cm}
             $\delta(\pair(7,0), \varepsilon) = \pair(2,2)$, \quad
             $\delta(\pair(2,2), \quoted{z}) = \pair(3,2)$.
-      \item Aus der Regel $A \rightarrow \quoted{u} \quoted{z}$ erhalten wir die Übergänge
+      \item Aus der Regel $A \rightarrow \quoted{u} \quoted{z}$ erhalten wir die \"Uberg\"ange
             \\[0.2cm]
             \hspace*{1.3cm}
             $\delta(\pair(0,3), \quoted{u}) = \pair(1,3)$, \quad
             $\delta(\pair(1,3), \quoted{z}) = \pair(2,3)$.
-      \item Aus der Regel $A \rightarrow \quoted{y} \quoted{u} \quoted{x}$ erhalten wir die Übergänge
+      \item Aus der Regel $A \rightarrow \quoted{y} \quoted{u} \quoted{x}$ erhalten wir die \"Uberg\"ange
             \\[0.2cm]
             \hspace*{1.3cm}
             $\delta(\pair(0,4), \quoted{y}) = \pair(1,4)$, \quad
             $\delta(\pair(1,4), \quoted{u}) = \pair(2,4)$, \quad
             $\delta(\pair(2,4), \quoted{x}) = \pair(3,4)$.
-      \item Aus der Regel $B \rightarrow \quoted{u}$ erhalten wir die Übergänge
+      \item Aus der Regel $B \rightarrow \quoted{u}$ erhalten wir die \"Uberg\"ange
             \\[0.2cm]
             \hspace*{1.3cm}
             $\delta(\pair(4,0), \varepsilon) = \pair(5,0)$, \quad
             $\delta(\pair(5,0), \quoted{u})  = \pair(6,0)$, \quad
             $\delta(\pair(6,0), \varepsilon) = \pair(7,0)$.
-      \item Die Menge der akzeptierenden Zustände ist durch die Endzustände der Regeln für
+      \item Die Menge der akzeptierenden Zust\"ande ist durch die Endzust\"ande der Regeln f\"ur
             die Variable $A$ gegeben:
             \\[0.2cm]
             \hspace*{1.3cm}
             $\bigl\{ \pair(2,1), \pair(3,2), \pair(2,3), \pair(3,4) \bigr\}$
       \end{enumerate}
       Wir beginnen nun damit, diesen nicht-deterministischen Automaten in einen deterministischen 
-      Automaten zu überführen.  Der Start-Zustand des deterministischen  Automaten ist dann
+      Automaten zu \"uberf\"uhren.  Der Start-Zustand des deterministischen  Automaten ist dann
       \\[0.2cm]
       \hspace*{1.3cm}
       $S_0 := 
@@ -348,8 +348,8 @@ Bearbeiten Sie die folgenden Teilaufgaben:
       \hspace*{1.3cm}
       $S_2 := \Delta(S_1, \quoted{z}) = \bigl\{ \pair(3,2), \pair(2,3) \bigr\}$.
       \\[0.2cm]
-      Diese Menge enthält zwei akzeptierende Zustände, ist aber nicht homogen, da diese
-      Zustände einen unterschiedlichen Index haben.  Folglich handelt es sich bei der obigen Grammatik
+      Diese Menge enth\"alt zwei akzeptierende Zust\"ande, ist aber nicht homogen, da diese
+      Zust\"ande einen unterschiedlichen Index haben.  Folglich handelt es sich bei der obigen Grammatik
       nicht um eine LL($*$)-Grammatik.
 
       \textbf{Bemerkung}:
@@ -403,32 +403,32 @@ Bearbeiten Sie die folgenden Teilaufgaben:
 
       \noindent
       \textbf{Bemerkung}:  Die in der Aufgabe angegebene Grammatik ist sowohl eine LR-Grammatik als
-      auch eine LALR-Grammatik.  Letzteres lässt sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
+      auch eine LALR-Grammatik.  Letzteres l\"asst sich mit \textsl{Bison} oder \textsl{JavaCup} nachweisen 
       und Ersteres folgt aus der Tatsache, dass jede LALR-Grammatik auch eine LR-Grammatik ist.
 \end{enumerate}
 \pagebreak
 
 \exercise
 Wir definieren \emph{geschachtelte Listen} rekursiv als solche Listen, 
-deren Elemente natürliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
+deren Elemente nat\"urliche Zahlen oder geschachtelte Listen sind.  Die Elemente in
 geschachtelten Listen sollen durch Kommata getrennt werden und die Listen selber sollen
 durch die eckigen Klammern ``\texttt{[}'' und ``\texttt{]}'' begrenzt sein.
-Beispiele für geschachtelte Listen sind also:
+Beispiele f\"ur geschachtelte Listen sind also:
 \begin{enumerate}
 \item \texttt{[ 1, [ 1, [], [ 2, 3]], 7]}
 \item \texttt{[ [], [ [], [], [ 4], 5], []]}
 \end{enumerate}
-Lösen Sie die folgenden Teilaufgaben:
+L\"osen Sie die folgenden Teilaufgaben:
 \begin{enumerate}
-\item Geben Sie eine Grammatik für geschachtelte Listen an.
+\item Geben Sie eine Grammatik f\"ur geschachtelte Listen an.
 \item Geben Sie die EP-Spezifikation von Klassen an, mit deren Hilfe sich
-      geschachtelte Listen repräsentieren lassen.
+      geschachtelte Listen repr\"asentieren lassen.
 \item Geben Sie einen \textsl{JavaCup}-Parser an, der eine geschachtelte Liste einliest
       und einen abstrakten Syntax-Baum der Liste berechnet.
 
-      \textbf{Hinweis:} In der Klausur können Sie später davon ausgehen, dass ein geeigneter
+      \textbf{Hinweis:} In der Klausur k\"onnen Sie sp\"ater davon ausgehen, dass ein geeigneter
       \textsl{JFlex}-Scanner bereits gegeben ist, aber bei dieser Aufgabe sollen Sie den
-      Scanner ebenfalls erstellen, damit Sie Ihre Lösung auch testen können.
+      Scanner ebenfalls erstellen, damit Sie Ihre L\"osung auch testen k\"onnen.
 \end{enumerate}
 
 \solution
@@ -450,10 +450,10 @@ Lösen Sie die folgenden Teilaufgaben:
       \end{array}
       $
       \\[0.2cm]
-      gegeben sind, leistet das Gewünschte.  Hier steht $L$ für eine ungeklammerte Liste, 
+      gegeben sind, leistet das Gew\"unschte.  Hier steht $L$ f\"ur eine ungeklammerte Liste, 
       deren Elemente durch Kommata
-      getrennt sind,  $N$ steht für eine ungeklammerte nicht-leere Liste, deren Elemente durch Kommata getrennt
-      sind und $E$ steht für ein Listen-Element, ist also entweder eine in eckigen Klammern
+      getrennt sind,  $N$ steht f\"ur eine ungeklammerte nicht-leere Liste, deren Elemente durch Kommata getrennt
+      sind und $E$ steht f\"ur ein Listen-Element, ist also entweder eine in eckigen Klammern
       eingefasste Liste oder eine Zahl.
 \item Wir definieren eine abstrakte Klasse \texttt{Element}, die sowohl Listen als auch Zahlen
       umfasst:
@@ -513,7 +513,7 @@ Lösen Sie die folgenden Teilaufgaben:
       \end{Verbatim}
       \pagebreak
 
-      Der dazugehörige Scanner ist wie folgt definiert:
+      Der dazugeh\"orige Scanner ist wie folgt definiert:
       \begin{Verbatim}[ frame         = lines, 
                         framesep      = 0.3cm, 
                         labelposition = bottomline,
@@ -575,12 +575,12 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       \hspace*{1.3cm}
       $\textsl{typeEqs}\bigl(\texttt{addLast(cons(x, nil), z): list(int)}\bigr)$.
-\item Lösen Sie die in Teil (a) berechneten Typ-Gleichungen.
+\item L\"osen Sie die in Teil (a) berechneten Typ-Gleichungen.
 \end{enumerate}
 
 \solution
 \begin{enumerate}
-\item Wir berechnen zunächst die Typ-Gleichungen nach der im Skript angegebenen Definition.
+\item Wir berechnen zun\"achst die Typ-Gleichungen nach der im Skript angegebenen Definition.
       \[
       \begin{array}[t]{cl}
            & \textsl{typeEqs}(\texttt{addLast(cons(x, nil), z): list(int)}) \\[0.2cm]
@@ -599,7 +599,7 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
 
       \end{array}
       \]
-\item Wir lösen die oben berechneten Typ-Gleichungen nach dem im Skript angegebenen Verfahren.
+\item Wir l\"osen die oben berechneten Typ-Gleichungen nach dem im Skript angegebenen Verfahren.
       \\[0.2cm]
       \hspace*{-0.3cm}  
       $\begin{array}[t]{cl}
@@ -644,13 +644,13 @@ und die Variablen \texttt{x} und \texttt{z} haben den Typ \texttt{int}.
       \\[0.2cm]
       Damit ist die Substitution 
       $[ T \mapsto \mathtt{int},\; S \mapsto \mathtt{int},\; R \mapsto \mathtt{int}]$ eine 
-      Lösung der Typ-Gleichungen und wir können folgern, dass der Term tatsächlich den angegebenen Typ
+      L\"osung der Typ-Gleichungen und wir k\"onnen folgern, dass der Term tats\"achlich den angegebenen Typ
       hat.
 \end{enumerate}
 \pagebreak
 
 \exercise
-Nehmen Sie an, dass die im Skript eingeführte Sprache \textsl{Integer}-\texttt{C} um eine 
+Nehmen Sie an, dass die im Skript eingef\"uhrte Sprache \textsl{Integer}-\texttt{C} um eine 
 \texttt{do-while}-Schleife erweitert werden soll, deren Syntax durch die folgende Grammatik-Regel gegeben ist:
 \\[0.2cm]
 \hspace*{1.3cm}
@@ -658,13 +658,13 @@ $\textsl{statement} \rightarrow \quoted{do} \textsl{statement} \quoted{while}
  \quoted{(} \textsl{boolExpr} \quoted{)}$.
 \\[0.2cm]
 Die Semantik dieses Konstruktes soll mit der Semantik des entsprechenden Konstruktes in
-der Sprache \texttt{C} übereinstimmen.
+der Sprache \texttt{C} \"ubereinstimmen.
 \begin{enumerate}
 \item Geben Sie eine Gleichung an, die beschreibt, wie eine \texttt{do-while}-Schleife in
-      \textsl{Java-Byte-Code} übersetzt werden kann.
+      \textsl{Java-Byte-Code} \"ubersetzt werden kann.
 \item Geben Sie die Methode $\textsl{compile}()$ an, die das entsprechende
-      Konstrukt übersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
-      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse für \textsc{Ep}
+      Konstrukt \"ubersetzt.  Gehen Sie dabei davon aus, dass Sie diese Methode innerhalb
+      einer Klasse \texttt{DoWhile} implementieren, wobei diese Klasse f\"ur \textsc{Ep}
       wie folgt spezifiziert ist:
       \\[0.2cm]
       \hspace*{1.3cm}
@@ -674,7 +674,7 @@ der Sprache \texttt{C} übereinstimmen.
 
 \solution
 \begin{enumerate}
-\item Die Übersetzung einer \texttt{do-while}-Schleife der Form
+\item Die \"Ubersetzung einer \texttt{do-while}-Schleife der Form
       \[ \texttt{while}\;(\textsl{cond})\;\textsl{statement} \]
       orientiert sich an der folgenden Spezifikation:
       \[
@@ -725,7 +725,7 @@ Zeigen Sie, dass die wie folgt definierte Menge $M$
 \hspace*{1.3cm}
 $M := \{ x \in \mathbb{R} \mid 0 \leq x \leq 1 \}$
 \\[0.2cm] 
-nicht abzählbar ist.
+nicht abz\"ahlbar ist.
 
 \noindent
 \textbf{Hinweis}: Nehmen Sie an, dass Sie eine Funktion
@@ -733,12 +733,12 @@ nicht abzählbar ist.
 \hspace*{1.3cm}
 $f: \mathbb{N} \rightarrow M$
 \\[0.2cm]
-gibt, so dass es für jedes $x \in M$ eine Zahl $n \in \mathbb{N}$ gibt, für die
-$x = f(n)$ ist.  Führen Sie diese Annahme zum Widerspruch, indem Sie eine Zahl 
-$\gamma \in M$ konstruieren, für die 
+gibt, so dass es f\"ur jedes $x \in M$ eine Zahl $n \in \mathbb{N}$ gibt, f\"ur die
+$x = f(n)$ ist.  F\"uhren Sie diese Annahme zum Widerspruch, indem Sie eine Zahl 
+$\gamma \in M$ konstruieren, f\"ur die 
 \\[0.2cm]
 \hspace*{1.3cm}
-$f(n) \not= \gamma$ \quad für alle $n \in \mathbb{N}$
+$f(n) \not= \gamma$ \quad f\"ur alle $n \in \mathbb{N}$
 \\[0.2cm]
 gilt.  Zur Konstruktion von $\gamma$ ist es sinnvoll die Hilfsfunktion
 \\[0.2cm]
@@ -755,7 +755,7 @@ $\textsl{digit}(0.125, 2) = 2$, \quad
 $\textsl{digit}(0.125, 3) = 5$, \quad und 
 \\[0.2cm]
 \hspace*{1.3cm}
-$\textsl{digit}(0.125, k) = 0$, \quad für alle $k > 3$.
+$\textsl{digit}(0.125, k) = 0$, \quad f\"ur alle $k > 3$.
 
 \solution
 Wir definieren die Zahl $\gamma$ indem wir die einzelnen Ziffern von $\gamma$ durch
@@ -764,7 +764,7 @@ Wir definieren die Zahl $\gamma$ indem wir die einzelnen Ziffern von $\gamma$ du
 $\textsl{digit}(\gamma,n) = \bigl(\textsl{digit}\bigl(f(n),n\bigr) + 1\bigr) \;\mathtt{mod}\; 10$
 \\[0.2cm]
 definieren.  Den Widerspruch erhalten wir nun aus der Tasache, dass es eine Zahl $n_0 \in \mathbb{N}$ geben 
-muss, für die
+muss, f\"ur die
 \\[0.2cm]
 \hspace*{1.3cm}
 $f(n_0) = \gamma$
@@ -779,14 +779,14 @@ $
 \end{array}
 $
 \\[0.2cm]
-Da für jede Ziffer $x \not= (x + 1) \;\mathtt{mod}\; 10$ gilt, ist dies ein Widerspruch, der uns zeigt,
-dass die Menge $M$ nicht abzählbar ist.
+Da f\"ur jede Ziffer $x \not= (x + 1) \;\mathtt{mod}\; 10$ gilt, ist dies ein Widerspruch, der uns zeigt,
+dass die Menge $M$ nicht abz\"ahlbar ist.
 \vspace{0.3cm}
 
 \noindent
 \framebox{\epsfig{file=danger.eps,scale=0.05}}
 \exercise
-Aus wieviel Zeichen muss der kleinste Ausdruck $e$ mindestens bestehen, für den
+Aus wieviel Zeichen muss der kleinste Ausdruck $e$ mindestens bestehen, f\"ur den
 \\[0.2cm]
 \hspace*{1.3cm}
 $\textsl{ershov}(e) = 30$
@@ -800,14 +800,14 @@ mit $a_n$.  Dann haben wir $a_1 = 1$ und
 \hspace*{1.3cm}
 $a_{n+1} = 2 * a_n + 1$
 \\[0.2cm]
-Diese Rekurrenz-Gleichung hat die Lösung $a_{n} = 2^n - 1$, was wir leicht durch Induktion nachweisen könnten.
-Setzen wir für $n$ den Wert $30$ ein, so sehen wir, dass der kleinste Ausdruck aus
+Diese Rekurrenz-Gleichung hat die L\"osung $a_{n} = 2^n - 1$, was wir leicht durch Induktion nachweisen k\"onnten.
+Setzen wir f\"ur $n$ den Wert $30$ ein, so sehen wir, dass der kleinste Ausdruck aus
 \\[0.2cm]
 \hspace*{1.3cm}
 $2^{30} - 1 = 1\,073\,741\,823$
 \\[0.2cm]
-Zeichen besteht.  Dieser Ausdruck hätte daher eine Größe von knapp einem Gigabyte und wir können
-schließen, dass in der Praxis 30 Register für die Auswertung von Ausdrücken ausreichen.
+Zeichen besteht.  Dieser Ausdruck h\"atte daher eine Gr\"o{\ss}e von knapp einem Gigabyte und wir k\"onnen
+schlie{\ss}en, dass in der Praxis 30 Register f\"ur die Auswertung von Ausdr\"ucken ausreichen.
 
 \end{document}
 

--- a/Slides/slides.tex
+++ b/Slides/slides.tex
@@ -29,19 +29,19 @@
 \begin{slide}{}
 \normalsize
 \begin{center}
-Überblick über die Vorlesung
+\"Uberblick \"uber die Vorlesung
 \end{center}
 \vspace{0.5cm}
 
 \footnotesize
 \begin{enumerate}
 \item Definition: Formale Sprachen
-\item Reguläre Ausdrücke: Spezifikation von Strings
+\item Regul\"are Ausdr\"ucke: Spezifikation von Strings
 
       wichtig in Skriptsprachen
  
       \textsl{Tcl}, \textsl{Perl}, \textsl{Python}, \textsl{Ruby}, $\cdots$
-\item Anwendungen regulärer Ausdrücke
+\item Anwendungen regul\"arer Ausdr\"ucke
 
       \texttt{flex}: \emph{\underline{f}ast \underline{lex}ical analyser generator}.
 
@@ -62,7 +62,7 @@
 \vspace*{\fill}
 \tiny \addtocounter{mypage}{1}
 \rule{17cm}{1mm}
-Überblick  \hspace*{\fill} Seite \arabic{mypage}
+\"Uberblick  \hspace*{\fill} Seite \arabic{mypage}
 \end{slide}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -70,7 +70,7 @@
 \begin{slide}{}
 \normalsize
 \begin{center}
-Überblick, Teil \texttt{II}
+\"Uberblick, Teil \texttt{II}
 \end{center}
 \vspace{0.5cm}
 
@@ -87,8 +87,8 @@
       Grundlage von \textsl{Bison}
 \item Der Parser-Generator \textsl{JavaCup}
 
-      \textsl{JavaCup} ist ein LALR-Parser-Generator für \textsl{Java}.
-\item Typ-Überprüfung
+      \textsl{JavaCup} ist ein LALR-Parser-Generator f\"ur \textsl{Java}.
+\item Typ-\"Uberpr\"ufung
   
 \item Entwicklung eines einfacher Compiler
 \item Register-Zuordnung  
@@ -97,7 +97,7 @@
 \vspace*{\fill}
 \tiny \addtocounter{mypage}{1}
 \rule{17cm}{1mm}
-Überblick  \hspace*{\fill} Seite \arabic{mypage}
+\"Uberblick  \hspace*{\fill} Seite \arabic{mypage}
 \end{slide}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -140,7 +140,7 @@ Literatur  \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Algebra regulärer Ausdrücke
+Algebra regul\"arer Ausdr\"ucke
 \end{center}
 \vspace{0.5cm}
 
@@ -360,7 +360,7 @@ algebraische Vereinfachungen  \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Eine Grammatik für arithmetische Ausdrücke
+Eine Grammatik f\"ur arithmetische Ausdr\"ucke
 \end{center}
 \vspace{1.5cm}
 
@@ -390,7 +390,7 @@ Eine Grammatik für arithmetische Ausdrücke
 \vspace*{\fill}
 \tiny \addtocounter{mypage}{1}
 \rule{17cm}{1mm}
-Grammatik für arithmetische Ausdrücke  \hspace*{\fill} Seite \arabic{mypage}
+Grammatik f\"ur arithmetische Ausdr\"ucke  \hspace*{\fill} Seite \arabic{mypage}
 \end{slide}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -404,7 +404,7 @@ Entfernen von Links-Rekursion
 
 \footnotesize
 
-Gegeben: links-rekursive Grammatik für Variable $A$
+Gegeben: links-rekursive Grammatik f\"ur Variable $A$
 \begin{center}
   \framebox{
   \framebox{
@@ -448,7 +448,7 @@ Grammatik  ohne Links-Rekursion \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Eine Grammatik für arithmetische Ausdrücke ohne Links-Rekursion
+Eine Grammatik f\"ur arithmetische Ausdr\"ucke ohne Links-Rekursion
 \end{center}
 \vspace{1.5cm}
 
@@ -486,7 +486,7 @@ Grammatik  ohne Links-Rekursion \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Eine Grammatik für reguläre Ausdrücke
+Eine Grammatik f\"ur regul\"are Ausdr\"ucke
 \end{center}
 \vspace{1.5cm}
 
@@ -520,7 +520,7 @@ Terminale: \squoted{|}, \squoted{*}, \squoted{.}, \squoted{(}, \squoted{)}, \tex
 \vspace*{\fill}
 \tiny \addtocounter{mypage}{1}
 \rule{17cm}{1mm}
-Grammatik für reguläre Ausdrücke \hspace*{\fill} Seite \arabic{mypage}
+Grammatik f\"ur regul\"are Ausdr\"ucke \hspace*{\fill} Seite \arabic{mypage}
 \end{slide}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -528,7 +528,7 @@ Grammatik für reguläre Ausdrücke \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Eine eindeutige Grammatik für reguläre Ausdrücke
+Eine eindeutige Grammatik f\"ur regul\"are Ausdr\"ucke
 \end{center}
 \vspace{1.5cm}
 
@@ -559,7 +559,7 @@ Eine eindeutige Grammatik für reguläre Ausdrücke
 \vspace*{\fill}
 \tiny \addtocounter{mypage}{1}
 \rule{17cm}{1mm}
-Grammatik für reguläre Ausdrücke \hspace*{\fill} Seite \arabic{mypage}
+Grammatik f\"ur regul\"are Ausdr\"ucke \hspace*{\fill} Seite \arabic{mypage}
 \end{slide}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -567,7 +567,7 @@ Grammatik für reguläre Ausdrücke \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Eine nicht-links-rekursive Grammatik für reguläre Ausdrücke
+Eine nicht-links-rekursive Grammatik f\"ur regul\"are Ausdr\"ucke
 \end{center}
 \vspace{1.5cm}
 
@@ -598,7 +598,7 @@ Eine nicht-links-rekursive Grammatik für reguläre Ausdrücke
 \vspace*{\fill}
 \tiny \addtocounter{mypage}{1}
 \rule{17cm}{1mm}
-Grammatik für reguläre Ausdrücke \hspace*{\fill} Seite \arabic{mypage}
+Grammatik f\"ur regul\"are Ausdr\"ucke \hspace*{\fill} Seite \arabic{mypage}
 \end{slide}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -664,7 +664,7 @@ Shift-Reduce-Parser  \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Grammatik für arithmetische Ausdrücke
+Grammatik f\"ur arithmetische Ausdr\"ucke
 \end{center}
 \vspace{0.5cm}
 
@@ -683,7 +683,7 @@ Grammatik für arithmetische Ausdrücke
 
 \normalsize
 \begin{center}
-Grammatik für konjunktive Normalform
+Grammatik f\"ur konjunktive Normalform
 \end{center}
 
 \footnotesize
@@ -708,7 +708,7 @@ Zwei Grammatiken  \hspace*{\fill} Seite \arabic{mypage}
 \begin{slide}{}
 \normalsize
 \begin{center}
-Zustände des SLR-Parsers für arithmetische Ausdrücke
+Zust\"ande des SLR-Parsers f\"ur arithmetische Ausdr\"ucke
 \end{center}
 \vspace{0.5cm}
 
@@ -754,7 +754,7 @@ s_6 & := & \{ & F \rightarrow \quoted{(} E \star \quoted{)},\;
 \vspace*{\fill}
 \tiny \addtocounter{mypage}{1}
 \rule{17cm}{1mm}
-Zustände  \hspace*{\fill} Seite \arabic{mypage}
+Zust\"ande  \hspace*{\fill} Seite \arabic{mypage}
 \end{slide}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
While I'm at it... ;)

*fixed: `ä` `Ä` `ö` `Ö` `ü` `Ü` `ß`*