### PR TITLE
removed arb function

### DIFF
--- a/Python/Regexp-2-NFA.ipynb
+++ b/Python/Regexp-2-NFA.ipynb
@@ -200,7 +200,7 @@
     "def catenate(self, f1, f2):\n",
     "    M1, Sigma, delta1, q1, A1 = f1\n",
     "    M2, Sigma, delta2, q3, A2 = f2\n",
-    "    q2 = arb(A1)\n",
+    "    q2, = A1\n",
     "    delta = delta1 | delta2\n",
     "    delta[q2, ''] = {q3}\n",
     "    return M1 | M2, Sigma, delta, q1, A2\n",
@@ -241,8 +241,8 @@
     "def disjunction(self, f1, f2):\n",
     "        M1, Sigma, delta1, q1, A1 = f1\n",
     "        M2, Sigma, delta2, q2, A2 = f2\n",
-    "        q3 = arb(A1)\n",
-    "        q4 = arb(A2)\n",
+    "        q3, = A1\n",
+    "        q4, = A2\n",
     "        q0 = self.getNewState()\n",
     "        q5 = self.getNewState() \n",
     "        delta = delta1 | delta2\n",
@@ -283,7 +283,7 @@
    "source": [
     "def kleene(self, f):\n",
     "    M, Sigma, delta0, q1, A = f\n",
-    "    q2 = arb(A)\n",
+    "    q2, = A\n",
     "    q0 = self.getNewState()\n",
     "    q3 = self.getNewState()\n",
     "    delta = delta0\n",
@@ -314,24 +314,6 @@
     "\n",
     "RegExp2NFA.getNewState = getNewState\n",
     "del getNewState"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The function `arb(S)` returns an arbitrary member from the set `S`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def arb(S):\n",
-    "    for x in S:\n",
-    "        return x"
    ]
   },
   {


### PR DESCRIPTION
Vorschlag: Die Funktion `arb()` entfernen und alle Aufrufe `q2 = arb(A1)`durch `q2, = A1` ersetzen.
Da die Invariante 2) definiert, dass es nur einen akzeptierenden Zustand geben darf sollte dieser Ausdruck stets funktionieren. Im Gegensatz zur `arb()`-Funktion würde auch eine Exception ausgelöst werden, falls die Invariante verletzt ist.