### PR TITLE
Fixed cutted off graphs

### DIFF
--- a/ANTLR4-Python/AST-2-Dot.ipynb
+++ b/ANTLR4-Python/AST-2-Dot.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "def tuple2dot(t):\n",
     "    dot = gv.Digraph('Abstract Syntax Tree')\n",
-    "    dot.graph_attr['size'] = '10,12'\n",
+    "    #dot.graph_attr['size'] = '10,12'       # Only set this if fixed size is nessesary (sometimes graph is bigger than the output element and will not be shown totally)\n",
     "    Nodes_2_Names = {}\n",
     "    assign_numbers((), t, Nodes_2_Names)\n",
     "    create_nodes(dot, (), t, Nodes_2_Names)\n",
@@ -128,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.8.5"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
Graphs truncated in Jupyter Notebooks are now no longer cutted off and scaled to match the output size.