### PR TITLE
Fixed link to 'Earley-Parser.ipynb' in script

### DIFF
--- a/Lecture-Notes/earley-parser.tex
+++ b/Lecture-Notes/earley-parser.tex
@@ -391,7 +391,7 @@ angegebenen Algorithmus.
 The \textsl{Jupyter} notebook
 \\[0.2cm]
 \hspace*{1.3cm}
-\href{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python/Earley-Parser.ipynb}{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python/Earley-Parser.ipynb}
+\href{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python//Earley-Parser/Earley-Parser.ipynb}{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python//Earley-Parser/Earley-Parser.ipynb}
 \\[0.2cm]
 contains an implementation of Earley's algorithm.
 

--- a/Lecture-Notes/earley-parser.tex
+++ b/Lecture-Notes/earley-parser.tex
@@ -391,7 +391,7 @@ angegebenen Algorithmus.
 The \textsl{Jupyter} notebook
 \\[0.2cm]
 \hspace*{1.3cm}
-\href{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python//Earley-Parser/Earley-Parser.ipynb}{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python//Earley-Parser/Earley-Parser.ipynb}
+\href{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python/Earley-Parser/Earley-Parser.ipynb}{https://github.com/karlstroetmann/Formal-Languages/blob/master/ANTLR4-Python/Earley-Parser/Earley-Parser.ipynb}
 \\[0.2cm]
 contains an implementation of Earley's algorithm.
 


### PR DESCRIPTION
Fixed broken link to 'Earley-Parser.ipynb' in script.