### PR TITLE
Fixed typo

### DIFF
--- a/ANTLR4-Python/LR-Parser-Generator/LR-Table-Generator.ipynb
+++ b/ANTLR4-Python/LR-Parser-Generator/LR-Table-Generator.ipynb
@@ -1103,7 +1103,7 @@
    },
    "outputs": [],
    "source": [
-    "cat parse-table.py"
+    "!cat parse-table.py"
    ]
   },
   {
@@ -1156,7 +1156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.9.1"
   },
   "varInspector": {
    "cols": {

--- a/ANTLR4-Python/SLR-Parser-Generator/SLR-Table-Generator.ipynb
+++ b/ANTLR4-Python/SLR-Parser-Generator/SLR-Table-Generator.ipynb
@@ -988,7 +988,7 @@
    },
    "outputs": [],
    "source": [
-    "cat parse-table.py"
+    "!cat parse-table.py"
    ]
   },
   {
@@ -1034,7 +1034,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.9.1"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
Guten Morgen Herr Professor Stroetmann,

die Anpassung wäre nicht unbedingt notwendig gewesen, da der Befehl `cat` auch ohne das `!` verarbeitet wird, da aber jedes andere Kommando so ausgeführt wird, habe ich es entsprechend angepasst.

Als kurze Erläuterung, wieso `cat` auch ohne `!` geht:
Das Jupyter Notebook stellt die Möglichkeit bereit über `!` Befehle in der Shell auszuführen. Dabei wird eine neue Shell (und somit ein neuer Prozess) gestartet, die das Kommando dann ausführt.
Zusätzlich bietet der **IPython-Kernel**, auf dem Jupyter Notebook läuft, die Möglichkeit über `%` Kommandos auszuführen. Dabei ist zu beachten, dass durch die Funktion **automagic** die mit dem Befehl `%automagic` an- und ausgeschalten werden kann, das führende `%` (bei aktivierter Funktion) optional wird. Standardmäßig ist diese Funktion eingeschalten. Durch `%autocall` kann der Status von **automagic** überprüft werden. Im Gegensatz zu den `!`-Kommandos werden `%`-Kommandos in der gleichen Shell ausgeführt. Das bedeutet, dass beispielsweise der Verzeichniswechsel mit `!cd ..` in Jupyter Notebook keinen Erfolg bringen wird, da das Verzeichnis nur in einem neuen Prozess gewechselt wird, der dann wieder beendet wird. Mit `%cd ..` kann das Verzeichnis dann auch mit Wirkung auf Jupyter Notebook gewechselt werden.
Eine kleine zusätzliche Funktionalität ist, dass der Aufruf `%ls` Order farbig hevorhebt. Gleiches gilt natürlich auch für `ls` (bei aktivierter **automatic**-Funktion).