### PR TITLE
Fixed typo

### DIFF
--- a/Lecture-Notes/lr-parser.tex
+++ b/Lecture-Notes/lr-parser.tex
@@ -1192,7 +1192,7 @@ denn $a \rightarrow \bullet\, \varepsilon$ ist dasselbe wie $a \rightarrow \vare
 In diesem Zustand gibt es einen Reduce-Reduce-Konflikt zwischen den beiden markierten Regeln
 \\[0.2cm]
 \hspace*{1.3cm}
-$a \rightarrow \bullet\, \varepsilon \quad \mbox{und} \quad b \rightarrow \varepsilon \bullet$.
+$a \rightarrow \varepsilon \bullet \quad \mbox{und} \quad b \rightarrow \varepsilon \bullet$.
 \\[0.2cm]
 Dieser Konflikt tritt bei der Berechnung von 
 \\[0.2cm]

--- a/Lecture-Notes/lr-parser.tex
+++ b/Lecture-Notes/lr-parser.tex
@@ -1305,7 +1305,7 @@ Dazu erweitern wir zunächst die Definition einer markierten Regel.
   \item $(a \rightarrow \beta \gamma) \in R$.
   \item $L \subseteq T$.
   \end{enumerate}
-  Wir schreiben die erweiterte markierte Regel $\langle A, \beta, \gamma, L \rangle$ als
+  Wir schreiben die erweiterte markierte Regel $\langle a, \beta, \gamma, L \rangle$ als
   \\[0.2cm]
   \hspace*{1.3cm}
   $a \rightarrow \beta \bullet \gamma: L$.
@@ -1331,7 +1331,7 @@ in dem folgendes gilt:
       Die Menge $L$ bezeichnen wir daher als die Menge der \blue{Folge-Token}.
 \end{enumerate}
 
-Mit erweiterten markierten Regeln arbeitet sich ganz ähnlich wie mit markierten Regeln, allerdings
+Mit erweiterten markierten Regeln arbeitet es sich ganz ähnlich wie mit markierten Regeln, allerdings
 müssen wir die Definitionen der Funktionen $\textsl{closure}$, $\textsl{goto}$ und $\textsl{action}$
 etwas modifizieren.  Wir beginnen mit der Funktion $\textsl{closure}$.
 


### PR DESCRIPTION
Guten Abend Herr Professor Stroetmann,

uns ist bewusst, dass die Anpassung nicht unbedingt notwendig gewesen wäre. Trotzdem hat es unserer Meinung nach in Bezug auf die Definition eines `Reduce-Reduce-Konflikts` sowie der Funktion `action` und der damit verbundenen Reduzierung einer Regel der Form `α → β •` Sinn gemacht, das `ε` vor den Punkt zur Markierung der Regel zu setzen.

Sollte diese Form von Ihnen bewusst gewählt worden sein, so können Sie diesen Pull Request einfach schließen.

Viele liebe Grüße
Philipp und Pius