### PR TITLE
Binder files to run notebooks in container

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,0 +1,4 @@
+poppler-utils
+graphviz
+wget
+default-jdk

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,9 @@
+name: formal-languages-environment
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - ply
+  - pip:
+    - graphviz
+    - antlr4-python3-runtime

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,7 +2,7 @@ name: formal-languages-environment
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python=3.9
   - ply
   - pip:
     - graphviz

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - ply
   - pip:
     - graphviz
-    - antlr4-python3-runtime
+    - antlr4-python3-runtime>=4.8,<4.9

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Create local bin folder 
+mkdir -p /home/$NB_USER/.local/bin
+
+# create antlr4 command
+cat > /home/$NB_USER/.local/bin/antlr4 <<EOF
+#!/bin/bash
+java -jar /home/$NB_USER/.local/antlr-4.8-complete.jar \$@
+EOF
+
+chmod +x /home/$NB_USER/.local/bin/antlr4
+
+# install antlr
+wget -O /home/$NB_USER/.local/antlr-4.8-complete.jar  https://www.antlr.org/download/antlr-4.8-complete.jar 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,20 @@
+name: Container Factory
+on: 
+  push:
+    paths:
+      - "Python/**"
+      - "ANTLR4-Python/**"
+      - "Ply/**"
+      - "Exercises/**"
+      - ".binder/**"
+jobs:
+  create-and-publish-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout files in repo
+        uses: actions/checkout@master
+      - name: run repo2docker an publish image
+        uses: jupyterhub/repo2docker-action@master
+        with:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Formal-Languages
 ================
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/karlstroetmann/Algorithms/HEAD)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/karlstroetmann/Formal-Languages/HEAD)
 
 Lecture notes and examples for my class on formal languages and compilers.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
 Formal-Languages
 ================
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/karlstroetmann/Algorithms/HEAD)
 
 Lecture notes and examples for my class on formal languages and compilers.
+
+# Docker (Experimental Feature)
+
+The notebooks available in this repository can be run via [Docker](https://www.docker.com).
+In order to be able to store changes made to these notebooks it is beneficial to create a local directory `Solutions` that will be linked to the directory `Python/Personal-Solutions`.  The permissions of the directory `Solutions` need to be set to `777`.  For example, with `linux` creating this directory and setting the permissions is achieved with the following commands:
+```
+    cd
+    mkdir Solutions
+    chmod 777 Solutions
+```
+Then, in order to change a file in the docker container and have the changes persist, inside the docker
+container the file has to be copied to `Python/Personal-Solutions`.
+
+The docker image can be downloaded via the following command:
+```
+    docker pull karlstroetmann/formal-languages
+```
+After that, the *container* can be started as follows:
+```
+docker run -p 8888:8888 -v /Users/yourname/Solutions/:/home/jovyan/Python/Personal-Solutions karlstroetmann/formal-languages
+```
+Note that you have to replace the directory `/Users/yourname` with your home directory.
+Unfortunately, you cannot specify your home directory as `~`, since `Docker` does not
+understand this notation.
+
+To connect to the container, enter the adress `localhost:8888` into your browser.
+You will then be asked for a *token*.  You find this token in the message that is
+displayed by the `docker run ...` command executed previously.
+
+### Important notes:
+* **FileNotFoundError: [Errno 2] No such file or directory: 'xdg-open'**: Set `.render(view=False)`, because files can not be opened automatically
+* `antlr4` command is available
+* The path to antlr4.jar is `/home/jovyan/.local/antlr-4.8-complete.jar`


### PR DESCRIPTION
Hallo Herr Stroetmann,
Wie schon im Algorithmen-Repository, habe ich alle Dateien hinzugefügt um die Notebooks mit Hilfe eines Containers anzuschauen und zu bearbeiten. Die CI ist dabei gleich geblieben, nur entsprechende "Aktivierungs"-Pfade wurden aktualisiert. Bitte fügen Sie vor dem Merge noch die entsprechenden Secrets *DOCKER_USERNAME* und *DOCKER_PASSWORD* zu ihrem Repo hinzu, damit die neuste Version direkt verfügbar ist :) !

Bei einer schnellen Überprüfung haben alle Notebooks weitestgehend funktioniert, eventuelle Fehler habe ich in der README nochmal angesprochen. 

  