### PR TITLE
removed line breaks causing errors

### DIFF
--- a/fl.sh
+++ b/fl.sh
@@ -6,6 +6,4 @@ conda install -y -c conda-forge graphviz
 conda install -y -c conda-forge python-graphviz
 pip install mypy
 pip install nb-mypy
-pip install ipynb
-
-
+pip install ipynb./fl.sh: 


### PR DESCRIPTION
When executing the script, the following errors are encountered in fl.sh:

line 10: $‘\r’: command not found
line 11: $‘\r’: command not found

These are line breaks that have no further function, which is why they can be removed.